### PR TITLE
Fix ‘EXC_BAD_ACCESS’ on iOS

### DIFF
--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -26,6 +26,10 @@
   return self;
 }
 
+-(void) dealloc {
+    [[SKPaymentQueue defaultQueue] removeTransactionObserver:self];
+}
+
 
 ////////////////////////////////////////////////////     _//////////_//      EXPORT_MODULE
 RCT_EXPORT_MODULE();


### PR DESCRIPTION
Fix ‘EXC_BAD_ACCESS’ on iOS.