### PR TITLE
Updating Default Android Setup

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,8 +16,8 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-  compileSdkVersion 26
-  buildToolsVersion "26.0.2"
+  compileSdkVersion 23
+  buildToolsVersion "23.0.1"
 
   defaultConfig {
     minSdkVersion 16

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary">
+          package="com.dooboolab.RNIap">
 
 </manifest>
   


### PR DESCRIPTION
- Lowering build tools to those commonly found in other RN github modules (Android 23, and Build Tools 23.0.1)

- Gave the Android packageName an appropriate one instead of the default one (which is com.reactlibrary). This was a problem building for myself due to having another package with this default name.