### PR TITLE
ERROR Pod version 1.3.1

### DIFF
--- a/ios/RNIap.podspec
+++ b/ios/RNIap.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description  = <<-DESC
                   RNIap
                    DESC
-  s.homepage     = ""
+  s.homepage     = "https://github.com/dooboolab/react-native-iap"
   s.license      = "MIT"
   # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
   s.author             = { "author" => "author@domain.cn" }


### PR DESCRIPTION
`homepage` now is a mandatory attribute in cocopods 
```
[!] The `RNIap` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
 ```