### PR TITLE
Add missing return in getSubscribeItems() on iOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ export const getItems = (skus) => {
 export const getSubscribeItems = (skus) => {
   if (Platform.OS === 'ios') {
     // ios will just use existing function
-    getItems(skus);
+    return getItems(skus);
   }
   else if (Platform.OS === 'android') {
     return new Promise(function (resolve, reject) {

--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ export const buyItem = (item) => {
  */
 export const buySubscribeItem = (item) => {
   if (Platform.OS === 'ios') {
-    buyItem(item);
+    return buyItem(item);
   } else if (Platform.OS === 'android') {
     return new Promise(function (resolve, reject) {
       RNIapModule.buySubscribeItem(item, (err, purchase) => {

--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -74,22 +74,6 @@ RCT_EXPORT_METHOD(purchaseItem:(NSString *)productID callback:(RCTResponseSender
   }
 }
 
-// hyochan add
-RCT_EXPORT_METHOD(purchaseSubscribeItem:(NSString *)productID callback:(RCTResponseSenderBlock)callback) {
-    RCTLogInfo(@"\n\n\n\n Obj c >> InAppPurchase  :: purchaseItem :: %@    Valid Product : %ld  \n\n\n\n .", productID, (unsigned long)validProducts.count);
-    purchaseCallback = callback;
-
-    for (int k = 0; k < validProducts.count; k++) {
-        SKProduct *theProd = [validProducts objectAtIndex:k];
-        if ([productID isEqualToString:theProd.productIdentifier]) {
-            NSLog(@"\n\n\n Obj c >> InAppPurchase  :: purchaseItem :: Product Found  \n\n\n.");
-            SKPayment *payment = [SKPayment paymentWithProduct:theProd];
-            [[SKPaymentQueue defaultQueue] addPayment:payment];
-            return;
-        }
-    }
-}
-
 #pragma mark ===== StoreKit Delegate
 
 -(void)productsRequest:(SKProductsRequest *)request didReceiveResponse:(SKProductsResponse *)response {


### PR DESCRIPTION
getSubscribeItems() and buySubscribeItem() are currently broken on iOS : they always return undefined. This commit fixes it. It also removes an unused method in the iOS native code.