### PR TITLE
Implement requiresMainQueueSetup to prevent warning in RN 0.49+

### DIFF
--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -26,6 +26,10 @@
   [[SKPaymentQueue defaultQueue] removeTransactionObserver:self];
 }
 
++(BOOL)requiresMainQueueSetup {
+  return YES;
+}
+
 -(void)addPromiseForKey:(NSString*)key
                resolve:(RCTPromiseResolveBlock)resolve
                 reject:(RCTPromiseRejectBlock)reject {


### PR DESCRIPTION
See https://github.com/invertase/react-native-firebase/issues/491