### PR TITLE
fix the bugs about different function name defined in index.js and index.d.ts.

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ export const buyProduct = (sku) => Platform.select({
  * @param {string} token The product's token (on Android)
  * @returns {Promise}
  */
-export const consumeProduct = (token) => Platform.select({
+export const consumePurchase = (token) => Platform.select({
   ios: () => Promise.resolve(), // Consuming is a no-op on iOS, as soon as the product is purchased it is considered consumed.
   android: () => RNIapModule.consumeProduct(token)
 })();


### PR DESCRIPTION
I tried to call `RNIap.consumePurchase(token)` in my React-Native App after calling `RNIap.buyProduct(sku)` and getting product information, but it failed.
After reading the source code, I found the function name is defined as `consumePurchase` in `index.d.ts` but `consumeProduct` in `index.js`, what means `consumePurchase` cannot do anything but throw an exception.
So I just change the function name from `consumeProduct` to `consumePurchase` in `index.js` to satisfy the doc and that's it.