### PR TITLE
Fix crash when localizedDescription is nil

### DIFF
--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -236,8 +236,8 @@ RCT_EXPORT_METHOD(buyProduct:(NSString*)sku
     @"price" : [product.price stringValue],
     @"currency" : currencyCode,
     @"type": itemType,
-    @"title" : product.localizedTitle,
-    @"description" : product.localizedDescription,
+    @"title" : product.localizedTitle ? product.localizedTitle : @"",
+    @"description" : product.localizedDescription ? product.localizedDescription : @"",
     @"localizedPrice" : localizedPrice
   };
 }


### PR DESCRIPTION
Currently app crashes with error `iOS Fatal Error - [__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[5]'` when localizedDescription is not set in itunesconnect.

The same approach is used in another StoreKit React Native package:
https://github.com/chirag04/react-native-in-app-utils/blob/master/InAppUtils/InAppUtils.m#L220