### PR TITLE
Remove deprecated React pod dependency

### DIFF
--- a/RNIap.podspec
+++ b/RNIap.podspec
@@ -14,8 +14,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/author/RNIap.git", :tag => "master" }
   s.source_files  = "ios/*.{h,m}"
   s.requires_arc = true
-
-  s.dependency 'React'
 end
 
   


### PR DESCRIPTION
error: bundling failed: ambiguous resolution: module `/x/y/z/index.js` tries to require `react-native`, but there are several files providing this module. You can delete or fix them:

  * `/x/y/z/ios/Pods/React/package.json`
  * `/x/y/z/node_modules/react-native/package.json`