### PR TITLE
Builds again, gotta be careful with these settings

### DIFF
--- a/RNIap.podspec
+++ b/RNIap.podspec
@@ -1,5 +1,4 @@
 require 'json'
-
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
@@ -12,10 +11,8 @@ Pod::Spec.new do |s|
   s.author       = package['author']
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/author/RNIap.git", :tag => "master" }
-  s.source_files  = "ios/*.{h,m}"
+  s.source_files  = "RNIap/**/*.{h,m}"
   s.requires_arc = true
 
   s.dependency 'React'
 end
-
-  


### PR DESCRIPTION
Took me way too long to get builds to work again. The change of Podspec didn't break by app before I re-installed all node_modules and, cleared all `build` dirs and redid `pod install`.

This project could use a CI that attempts to do a clean build from scratch to catch these early on.