### PR TITLE
Android subscription upgrade/downgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Lastly, this module also supports types for typescript users from `0.2.5`.
 | getSubscriptions | `string[]` Subscription IDs/skus | `Promise<Subscription[]>` | Get a list of subscriptions. Note: On iOS  this method has the same output as `getProducts`. Because iOS does not differentiate between IAP products and subscriptions.  |
 | getPurchaseHistory | | `Promise<Purchase[]>` | Gets an invetory of purchases made by the user regardless of consumption status (where possible) |
 | getAvailablePurchases | | `Promise<Purchase[]>` | Get all purchases made by the user (either non-consumable, or haven't been consumed yet)
-| buySubscription | `string` Subscription ID/sku | `Promise<Purchase>` | Create (buy) a subscription to a sku |
+| buySubscription | `string` Subscription ID/sku, `string` Old Subscription ID/sku (on Android) | `Promise<Purchase>` | Create (buy) a subscription to a sku. For upgrading/downgrading subscription on Android pass second parameter with current subscription ID, on iOS this is handled automatically by store. |
 | buyProduct | `string` Product ID/sku | `Promise<Purchase>` | Buy a product |
 | buyProductWithoutFinishTransaction | `string` Product ID/sku | `Promise<Purchase>` | Buy a product without finish transaction call (iOS only) |
 | finishTransaction | `void` | `void` | Send finishTransaction call to Apple IAP server. Call this function after receipt validation process |

--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -316,7 +316,7 @@ public class RNIapModule extends ReactContextBaseJavaModule {
       addPromiseForKey(PROMISE_BUY_ITEM, promise);
       BillingFlowParams.Builder builder = BillingFlowParams.newBuilder();
 
-      if (type == BillingClient.SkuType.SUBS && oldSku != null && !oldSku.isEmpty()) {
+      if (type.equals(BillingClient.SkuType.SUBS) && oldSku != null && !oldSku.isEmpty()) {
         // Subscription upgrade/downgrade
         builder.addOldSku(oldSku);
       }

--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -308,19 +308,25 @@ public class RNIapModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void buyItemByType(String type, String sku, Promise promise) {
+  public void buyItemByType(String type, String sku, String oldSku, Promise promise) {
     final Activity activity = getCurrentActivity();
     if (activity == null) {
       promise.reject(E_UNKNOWN, "getCurrentActivity returned null");
     } else {
       addPromiseForKey(PROMISE_BUY_ITEM, promise);
-      BillingFlowParams flowParams = BillingFlowParams.newBuilder()
-          .setSku(sku)
+      BillingFlowParams.Builder builder = BillingFlowParams.newBuilder();
+
+      if (type == BillingClient.SkuType.SUBS && oldSku != null && !oldSku.isEmpty()) {
+        // Subscription upgrade/downgrade
+        builder.addOldSku(oldSku);
+      }
+
+      BillingFlowParams flowParams = builder.setSku(sku)
           .setType(type)
           .build();
 
       int responseCode = mBillingClient.launchBillingFlow(activity,flowParams);
-      Log.d(TAG, "buyItemByType (type: " + type + ", sku: " + sku + ") responseCode: " + responseCode + "(" + getBillingResponseCodeName(responseCode) + ")");
+      Log.d(TAG, "buyItemByType (type: " + type + ", sku: " + sku + ", oldSku: " + oldSku + ") responseCode: " + responseCode + "(" + getBillingResponseCodeName(responseCode) + ")");
       if (responseCode != BillingClient.BillingResponse.OK) {
         rejectPromisesWithBillingError(PROMISE_BUY_ITEM,responseCode);
       }

--- a/index.d.ts
+++ b/index.d.ts
@@ -84,9 +84,10 @@ export function getAvailablePurchases() : Promise<Purchase[]>;
 /**
  * Create a subscription to a sku
  * @param {string} sku The product's sku/ID
+ * @param {string} oldSku Optional old product's ID for upgrade/downgrade (Android only)
  * @returns {Promise<Purchase>}
  */
-export function buySubscription(sku: string) : Promise<SubscriptionPurchase>;
+export function buySubscription(sku: string, oldSku: string) : Promise<SubscriptionPurchase>;
 
 /**
  * Buy a product

--- a/index.d.ts
+++ b/index.d.ts
@@ -87,7 +87,7 @@ export function getAvailablePurchases() : Promise<Purchase[]>;
  * @param {string} oldSku Optional old product's ID for upgrade/downgrade (Android only)
  * @returns {Promise<Purchase>}
  */
-export function buySubscription(sku: string, oldSku: string) : Promise<SubscriptionPurchase>;
+export function buySubscription(sku: string, oldSku?: string) : Promise<SubscriptionPurchase>;
 
 /**
  * Buy a product

--- a/index.d.ts
+++ b/index.d.ts
@@ -84,7 +84,7 @@ export function getAvailablePurchases() : Promise<Purchase[]>;
 /**
  * Create a subscription to a sku
  * @param {string} sku The product's sku/ID
- * @param {string} oldSku Optional old product's ID for upgrade/downgrade (Android only)
+ * @param {string} [oldSku] Optional old product's ID for upgrade/downgrade (Android only)
  * @returns {Promise<Purchase>}
  */
 export function buySubscription(sku: string, oldSku?: string) : Promise<SubscriptionPurchase>;

--- a/index.js
+++ b/index.js
@@ -86,11 +86,12 @@ export const getAvailablePurchases = () => Platform.select({
 /**
  * Create a subscription to a sku
  * @param {string} sku The product's sku/ID
+ * @param {string} oldSku Optional old product's ID for upgrade/downgrade (Android only)
  * @returns {Promise<SubscriptionPurchase>}
  */
-export const buySubscription = (sku) => Platform.select({
+export const buySubscription = (sku, oldSku) => Platform.select({
   ios: () => RNIapIos.buyProduct(sku),
-  android: () => RNIapModule.buyItemByType(ANDROID_ITEM_TYPE_SUBSCRIPTION, sku)
+  android: () => RNIapModule.buyItemByType(ANDROID_ITEM_TYPE_SUBSCRIPTION, sku, oldSku)
 })();
 
 /**

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ export const getAvailablePurchases = () => Platform.select({
 /**
  * Create a subscription to a sku
  * @param {string} sku The product's sku/ID
- * @param {string} oldSku Optional old product's ID for upgrade/downgrade (Android only)
+ * @param {string} [oldSku] Optional old product's ID for upgrade/downgrade (Android only)
  * @returns {Promise<SubscriptionPurchase>}
  */
 export const buySubscription = (sku, oldSku) => Platform.select({


### PR DESCRIPTION
Hello!

Add optional `oldSku` parameter for `buySubscription` on **Android** to support subscription upgrade/downgrade.

Fix #185