### PR TITLE
add endConnection method to default export

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,6 +219,7 @@ export const validateReceiptAndroid = async (packageName, productId, productToke
 
 export default {
   prepare,
+  endConnection,
   getProducts,
   getSubscriptions,
   getPurchaseHistory,


### PR DESCRIPTION
This method is missing from the default export currently, meaning you have to import it separately via a barrel brace or face exceptions that it is not a function.