### PR TITLE
[Do not merge yet] Return an error when it fails to parse JSON

### DIFF
--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -245,7 +245,7 @@ public class RNIapModule extends ReactContextBaseJavaModule {
 
           WritableMap item = Arguments.createMap();
           item.putString("productId", json.getString("productId"));
-          item.putString("transactionId", json.getString("orderId"));
+          item.putString("transactionId", json.optString("orderId"));
           item.putString("transactionDate", String.valueOf(json.getLong("purchaseTime")));
           item.putString("transactionReceipt", json.getString("purchaseToken"));
           item.putString("data", data);

--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -55,6 +55,7 @@ public class RNIapModule extends ReactContextBaseJavaModule {
   private static final String E_REMOTE_ERROR = "E_REMOTE_ERROR";
   private static final String E_USER_ERROR = "E_USER_ERROR";
   private static final String E_DEVELOPER_ERROR = "E_DEVELOPER_ERROR";
+  private static final String E_BILLING_RESPONSE_JSON_PARSE_ERROR = "E_BILLING_RESPONSE_JSON_PARSE_ERROR";
 
   private static final String PROMISE_PREPARE = "PROMISE_PREPARE";
   private static final String PROMISE_BUY_ITEM = "PROMISE_BUY_ITEM";
@@ -257,7 +258,8 @@ public class RNIapModule extends ReactContextBaseJavaModule {
 
           items.pushMap(item);
         } catch (JSONException e) {
-          e.printStackTrace();
+          promise.reject(E_BILLING_RESPONSE_JSON_PARSE_ERROR, e.getMessage());
+          return;
         }
       }
 


### PR DESCRIPTION
What do you think? 
The downside of this is that it fails the entire retrieval of items in case there is any "bad" transaction exists... 

I also use optString for "orderId" as it is known to be empty for test order before 2018... But perhaps I should just fail that case as well?

https://github.com/dooboolab/react-native-iap/issues/195