### PR TITLE
fix crash iOS<11.2 when introductoryPrice is nil

### DIFF
--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -275,7 +275,7 @@ RCT_EXPORT_METHOD(finishTransaction) {
   formatter.numberStyle = NSNumberFormatterCurrencyStyle;
   formatter.locale = product.priceLocale;
   NSString* localizedPrice = [formatter stringFromNumber:product.price];
-  NSString* introductoryPrice;
+  NSString* introductoryPrice = localizedPrice;
     
   // NSString* itemType = @"Do not use this. It returned sub only before";
   NSString* currencyCode = @"";


### PR DESCRIPTION
As reported here

https://github.com/dooboolab/react-native-iap/issues/233