### PR TITLE
onHostDestroy fix

### DIFF
--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -90,7 +90,7 @@ public class RNIapModule extends ReactContextBaseJavaModule {
     @Override
     public void onHostDestroy() {
       try {
-        if (mServiceConn != null) {
+        if (mService != null) {
           reactContext.unbindService(mServiceConn);
         }
       } catch (IllegalArgumentException ie) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iap",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "React Native In App Purchase Module.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Checking if `mService` is null instead of `mServiceConn` before trying to unbind service. `mServiceConn` will always be an object.