### PR TITLE
Force finish transaction

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,6 +149,17 @@ export const finishTransaction = () => Platform.select({
 })();
 
 /**
+ * Clear Transaction (iOS only)
+ *   Finish remaining transactions. Related to issue #257
+ *     link : https://github.com/dooboolab/react-native-iap/issues/257
+ * @returns {null}
+ */
+export const clearTransaction = () => Platform.select({
+  ios: () => RNIapIos.clearTransaction(),
+  android: () => console.log(' No effect on Android!'),
+})();
+
+/**
  * Consume a product (on Android.) No-op on iOS.
  * @param {string} token The product's token (on Android)
  * @returns {Promise}
@@ -256,6 +267,7 @@ export default {
   buyProductWithQuantityIOS,
   buyProductWithoutFinishTransaction,
   finishTransaction,
+  clearTransaction,
   consumePurchase,
   validateReceiptIos,
   validateReceiptAndroid,

--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -169,6 +169,14 @@ RCT_EXPORT_METHOD(finishTransaction) {
   currentTransaction = nil;
 }
 
+RCT_EXPORT_METHOD(clearTransaction) {
+  NSArray *pendingTrans = [[SKPaymentQueue defaultQueue] transactions];
+  NSLog(@"\n\n\n  ***  clear remaining Transactions. Call this before make a new transaction   \n\n.");
+  for (int k = 0; k < pendingTrans.count; k++) {
+    [[SKPaymentQueue defaultQueue] finishTransaction:pendingTrans[k]];
+  }
+}
+
 #pragma mark ===== StoreKit Delegate
 
 -(void)productsRequest:(SKProductsRequest *)request didReceiveResponse:(SKProductsResponse *)response {


### PR DESCRIPTION
Calling finishTransaction, which I mentioned, would be no effect when restarting the App or device itself. So, I looked up the document on iOS I found `transactions` property in skpaymentqueue class, and I used it for this implementation.

https://developer.apple.com/documentation/storekit/skpaymentqueue

I named the new method to `clear transaction` which looks fit better.
Check and test the method. Especially the jsDoc return values etc.
