### PR TITLE
Add missing field in ProductPurchase interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,7 @@ export interface ProductPurchase {
   transactionReceipt: string;
   signatureAndroid?: string;
   dataAndroid?: string;
+  purchaseToken?: string;
 }
 
 export interface SubscriptionPurchase extends ProductPurchase {


### PR DESCRIPTION
`RNIap.buyProduct` also returns `purchaseToken` on Android devices, but it is missing in `ProductPurchase` interface