### PR TITLE
resolve(null) => resolve(true)

### DIFF
--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -151,7 +151,7 @@ public class RNIapModule extends ReactContextBaseJavaModule {
     ensureConnection(promise, new Runnable() {
       @Override
       public void run() {
-        promise.resolve(null);
+        promise.resolve(true);
       }
     });
   }
@@ -168,7 +168,7 @@ public class RNIapModule extends ReactContextBaseJavaModule {
     }
 
     mBillingClient = null;
-    promise.resolve(null);
+    promise.resolve(true);
   }
 
   @ReactMethod
@@ -405,7 +405,7 @@ public class RNIapModule extends ReactContextBaseJavaModule {
               return;
             }
 
-            promise.resolve(null);
+            promise.resolve(true);
           }
         });
       }


### PR DESCRIPTION
In this project, if a promise is not rejected it is successful so returning null was a bit confusing on the Android side. Now it is more consistent with ios.

`const result = await RNIap.initConnection();`
Now the result is `true`