### PR TITLE
Add additional success callback

### DIFF
--- a/RNIapExample/src/components/pages/First.js
+++ b/RNIapExample/src/components/pages/First.js
@@ -106,6 +106,28 @@ class Page extends Component {
     }
   }
 
+  /**
+   * This method will be sent as additional purchase success callback.
+   * And can be called after the purchase promise is rejected (not resolved).
+   */
+  additionalAction = async (err, purchase) => {
+    this.setState({ receipt: purchase.transactionReceipt }, () => this.goToNext()); 
+  }
+
+  buyItemWithAdditionalCallback = async(sku) => {
+    try {
+      console.info('buy Item with additinal callback: ' + sku);
+      // purchase is the return promise.
+      const purchase = await RNIap.buyProduct(sku, this.additionalAction);
+      // Resolved Case
+      this.setState({ receipt: purchase.transactionReceipt }, () => this.goToNext());
+    } catch (err) {
+      // Reject case
+      console.warn(err.code, err.message);
+      Alert.alert(err.message);
+    }
+  }
+
   getAvailablePurchases = async() => {
     try {
       console.info('Get available purchases (non-consumable or unconsumed consumable)');

--- a/index.js
+++ b/index.js
@@ -117,8 +117,8 @@ export const buySubscription = (sku, oldSku, prorationMode) => {
  * @param {string} sku The product's sku/ID
  * @returns {Promise<ProductPurchase>}
  */
-export const buyProduct = (sku) => Platform.select({
-  ios: () => RNIapIos.buyProduct(sku),
+export const buyProduct = (sku, iosSuccess) => Platform.select({
+  ios: () => RNIapIos.buyProduct(sku, iosSuccess),
   android: () => RNIapModule.buyItemByType(ANDROID_ITEM_TYPE_IAP, sku, null, 0),
 })();
 


### PR DESCRIPTION
일단 작업했는데 한번 검토해보세요.
iOS 네이티브에는 콜백 저장 변수와 상태 관리 변수를 뒀구요. 상태 관리 변수의 변화를 보시면 이해가 되실 듯.
Promise가 reject 난 후 성공이 올 때만 부르게 했습니다.
코드가 얼마 안 되서 이해가 쉬울 듯 하네요..

First.js 예제에서 buyItemWithAdditionalCallback 을 부르도록 수정해서 테스트 하셔요.