### PR TITLE
Expose BCP47 language tag for iOS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ async componentDidMount() {
 |`productId`| ✓ | ✓ | Returns a string needed to purchase the item later |
 |`currency`| ✓ | ✓ | Returns the currency code |
 |`localizedPrice`| ✓ | ✓ | Use localizedPrice if you want to display the price to the user so you don't need to worry about currency symbols. |
+|`localeIOS`| ✓ |   | Returns the BCP 47 language tag. (eg. `en-US`) (iOS). |
 |`title`| ✓ | ✓ | Returns the title Android and localizedTitle on iOS |
 |`description`| ✓ | ✓ | Returns the localized description on Android and iOS |
 |`introductoryPrice`| ✓ | ✓ | Formatted introductory price of a subscription, including its currency sign, such as €3.99. The price doesn't include tax. |

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ interface Common {
   price: string
   currency: string
   localizedPrice: string
+  localeIOS: string
 }
 
 export interface Product<ID extends string> extends Common {

--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -315,6 +315,7 @@ RCT_EXPORT_METHOD(clearProducts) {
 	
   NSString* localizedPrice = [formatter stringFromNumber:product.price];
   NSString* introductoryPrice = localizedPrice;
+  NSString* locale = localeIdentifierToBCP47(product.priceLocale.localeIdentifier);
 	
   NSString* introductoryPricePaymentMode = @"";
   NSString* introductoryPriceNumberOfPeriods = @"";
@@ -400,6 +401,7 @@ RCT_EXPORT_METHOD(clearProducts) {
      product.localizedTitle ? product.localizedTitle : @"", @"title",
      product.localizedDescription ? product.localizedDescription : @"", @"description",
      localizedPrice, @"localizedPrice",
+     locale, @"localeIOS",
      periodNumberIOS, @"subscriptionPeriodNumberIOS",
      periodUnitIOS, @"subscriptionPeriodUnitIOS",
      introductoryPrice, @"introductoryPrice",
@@ -450,6 +452,13 @@ RCT_EXPORT_METHOD(clearProducts) {
 static NSString *RCTKeyForInstance(id instance)
 {
     return [NSString stringWithFormat:@"%p", instance];
+}
+
+static NSString *localeIdentifierToBCP47(NSString* localeIdentifier) 
+{
+  // e.g. `en_US@currency=USD` -> `en-US`.
+  NSString *identifier = [[product.priceLocale.localeIdentifier componentsSeparatedByString:@"@"] objectAtIndex:0];
+  return [identifier stringByReplacingOccurrencesOfString:@"_" withString:@"-"];
 }
 
 @end


### PR DESCRIPTION
Expose BCP47 language tag for iOS. This value can then be used in conjunction with ECMAScript I18n API `Intl.NumberFormat` to format currency correctly. #342 

See:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat
https://developer.apple.com/documentation/foundation/nslocale/1416263-localeidentifier
https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/LanguageandLocaleIDs/LanguageandLocaleIDs.html