### PR TITLE
Add handling previous transaction in iOS

### DIFF
--- a/RNIapExample/src/components/pages/First.js
+++ b/RNIapExample/src/components/pages/First.js
@@ -126,6 +126,7 @@ class Page extends Component {
   render() {
     const { productList, receipt, availableItemsMessage } = this.state;
     const receipt100 = receipt.substring(0, 100);
+    const { OS } = Platform;
 
     return (
       <View style={ styles.container }>
@@ -143,6 +144,26 @@ class Page extends Component {
               style={styles.btn}
               textStyle={styles.txt}
             >Get available purchases</NativeButton>
+
+            {OS === 'ios' ? 
+              <NativeButton
+                onPress={() => RNIap.iosHandlePrevTransaction((err, purchase) => {
+                  this.setState({ receipt: purchase.transactionReceipt }, () => this.goToNext());
+                })}
+                activeOpacity={0.5}
+                style={styles.btn}
+                textStyle={styles.txt}
+              >Fetch Preveous Transaction </NativeButton>
+            : null}
+
+            {OS === 'ios' ? 
+              <NativeButton
+                onPress={() => RNIap.finishTransaction()}
+                activeOpacity={0.5}
+                style={styles.btn}
+                textStyle={styles.txt}
+              >Finish Transaction </NativeButton>
+            : null}
 
             <Text style={{ margin: 5, fontSize: 15, alignSelf: 'center' }} >{availableItemsMessage}</Text>
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -69,6 +69,15 @@ export function endConnection() : Promise<void>;
 export function consumeAllItems() : Promise<void>;
 
 /**
+ * Consume all items in android. No-op in iOS.
+ * @param {object} successCB the call back method
+ * @returns void {
+
+ } Promise<void>}
+ */
+export function iosHandlePrevTransaction(successCB: any): void;
+
+/**
  * Get a list of products (consumable and non-consumable items, but not subscriptions)
  * @param skus The item skus
  */

--- a/index.js
+++ b/index.js
@@ -49,6 +49,20 @@ export const consumeAllItems = () => Platform.select({
 
 /**
  * Get a list of products (consumable and non-consumable items, but not subscriptions)
+ * @param {any} successCB the call back method
+ * @returns void {
+
+ */
+export const iosHandlePrevTransaction = (successCB) => Platform.select({
+  ios: () => {
+    console.log('  success cb in index.ts', successCB, typeof successCB);
+    RNIapIos.handleMissingTransaction(successCB)
+  },
+  android: () => console.log(' No method for android '),
+})();
+
+/**
+ * Get a list of products (consumable and non-consumable items, but not subscriptions)
  * @param {string[]} skus The item skus
  * @returns {Promise<Product[]>}
  */
@@ -287,4 +301,5 @@ export default {
   consumePurchase,
   validateReceiptIos,
   validateReceiptAndroid,
+  iosHandlePrevTransaction,
 };


### PR DESCRIPTION
Implement method fetching previous missing successful transaction.

Test scenario.

> Purchase without finish transaction. (you may quit the app when the purchasing popup shows)
> Finish the App
> Run the App again. (As soon as you start up, the receipt will come to the `updated transaction` method in RNIapIos.m.
> The successful but not processed (by the App) transaction is stored in `prevPurchase`.
> Call `iosHandlePrevTransaction` explicitly and the method will fetch the purchase object exactly same manner as the normal buy product. 
> You can see the app is navigating to the next page and confirm the result.
> You can send `finish transaction` whenever you like. 