### PR TITLE
Do not null mBillingClient (#315)

### DIFF
--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -1,3 +1,4 @@
+
 package com.dooboolab.RNIap;
 
 import android.app.Activity;
@@ -66,8 +67,6 @@ public class RNIapModule extends ReactContextBaseJavaModule {
   private IInAppBillingService mService;
   private BillingClient mBillingClient;
 
-  private boolean clientReady = false;
-
   private ServiceConnection mServiceConn = new ServiceConnection() {
     @Override public void onServiceDisconnected(ComponentName name) {
       mService = null;
@@ -109,7 +108,7 @@ public class RNIapModule extends ReactContextBaseJavaModule {
   }
 
   private void ensureConnection (final Promise promise, final Runnable callback) {
-    if (clientReady) {
+    if (mBillingClient != null && mBillingClient.isReady()) {
       callback.run();
       return;
     }
@@ -124,7 +123,6 @@ public class RNIapModule extends ReactContextBaseJavaModule {
         if (responseCode == BillingClient.BillingResponse.OK ) {
           Log.d(TAG, "billing client ready");
           callback.run();
-          clientReady = true;
         } else {
           rejectPromiseWithBillingError(promise, responseCode);
         }
@@ -133,7 +131,6 @@ public class RNIapModule extends ReactContextBaseJavaModule {
       @Override
       public void onBillingServiceDisconnected() {
         Log.d(TAG, "billing client disconnected");
-        clientReady = false;
       }
     };
 
@@ -141,7 +138,6 @@ public class RNIapModule extends ReactContextBaseJavaModule {
       reactContext.bindService(intent, mServiceConn, Context.BIND_AUTO_CREATE);
       mBillingClient = BillingClient.newBuilder(reactContext).setListener(purchasesUpdatedListener).build();
       mBillingClient.startConnection(billingClientStateListener);
-      clientReady = true;
     } catch (Exception e) {
       promise.reject(E_NOT_PREPARED, e.getMessage(), e);
     }
@@ -172,8 +168,6 @@ public class RNIapModule extends ReactContextBaseJavaModule {
         return;
       }
     }
-
-    mBillingClient = null;
     promise.resolve(true);
   }
 


### PR DESCRIPTION
This PR tries to solve issues brought up in #315 , specifically that methods are invoked on `mBillingClient` when it is `null`. See my comment there for a discussion of the problem. Copy-pasted here, the variable `clientReady` is being used to track if the billing client setup has been completed, by setting it to `false` in the onBillingServiceDisconnected() callback. But `mBillingClient` itself is set to `null` immediately when `endConnection()` is called. This is a mismatch. It's possible for `clientReady` to remain set to `true`, even if `mBillingClient` is `null`. In that case, methods will be invoked by the on the null object instance. It seems that something is preventing `onBillingServiceDisconnected()` from being called.

Solution:

- avoid setting `mBillingClient` to `null`. It is still not initialized in the class constructor, so will be `null` before `ensureConnection()` is called for the first time. Thus the null checks are still necessary.

- Remove the `clientReady` property in favor of relying on `mBillingClient.isReady()` (again checking for null before calling).

The root cause of this issue is that when `endConnection()` is called as a React Native component is unmounting, it seems that the `onBillingServiceDisconnected()` callback is never invoked. I don't know whether this is intended by the API or not, so I did not attempt to change this. I suggest someone with more experience in Android In App Billing review this PR before it is merged.