### PR TITLE
fix example to correctly display available purchases

### DIFF
--- a/RNIapExample/src/components/pages/First.js
+++ b/RNIapExample/src/components/pages/First.js
@@ -141,7 +141,7 @@ class Page extends Component {
           >
             <View style={{ height: 50 }} />
             <NativeButton
-              onPress={this.getItems}
+              onPress={this.getAvailablePurchases}
               activeOpacity={0.5}
               style={styles.btn}
               textStyle={styles.txt}


### PR DESCRIPTION
[GIVEN]
- Location: Iap example app
- Issue: Button labelled `Get available purchases` gets items instead, which is confusing for newbies like myself:(

[THEN]
- Fix button to correctly display available purchases

Not sure what the correct flow for PRs are -- let me know if there are any issues