### PR TITLE
Fix: remove TS duplicate definition of 'freeTrialPeriodAndroid'

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,6 @@ export interface Subscription<ID extends string> extends Common {
   subscriptionPeriodNumberIOS?: string
   subscriptionPeriodUnitIOS?: number
 
-  freeTrialPeriodAndroid?: string
   introductoryPriceCyclesAndroid?: number
   introductoryPricePeriodAndroid?: string
   subscriptionPeriodAndroid?: string


### PR DESCRIPTION
Removes the duplicate definition of `freeTrialPeriodAndroid` which declared it as an optional string.

fix #375