### PR TITLE
Fix for BillingClientImpl Crashes - Promise consumed twice

### DIFF
--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -124,10 +124,10 @@ public class RNIapModule extends ReactContextBaseJavaModule {
       public void onBillingSetupFinished(@BillingClient.BillingResponse int responseCode) {
         if (responseCode == BillingClient.BillingResponse.OK ) {
           Log.d(TAG, "billing client ready");
-		  if (!bSetupCallbackConsumed) {
-			bSetupCallbackConsumed = true;
+          if (!bSetupCallbackConsumed) {
+            bSetupCallbackConsumed = true;
             callback.run();
-		  }
+          }
         } else {
           rejectPromiseWithBillingError(promise, responseCode);
         }

--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -118,11 +118,16 @@ public class RNIapModule extends ReactContextBaseJavaModule {
     intent.setPackage("com.android.vending");
 
     final BillingClientStateListener billingClientStateListener = new BillingClientStateListener() {
+      private boolean bSetupCallbackConsumed = false;
+
       @Override
       public void onBillingSetupFinished(@BillingClient.BillingResponse int responseCode) {
         if (responseCode == BillingClient.BillingResponse.OK ) {
           Log.d(TAG, "billing client ready");
-          callback.run();
+		  if (!bSetupCallbackConsumed) {
+			bSetupCallbackConsumed = true;
+            callback.run();
+		  }
         } else {
           rejectPromiseWithBillingError(promise, responseCode);
         }


### PR DESCRIPTION
It's quick and dirty but it seems to work for #315. I can't think of a scenario where you would ever want the same listener to hit it's onSetupFinished callback twice. If the app shutdown and restarted, and needed to get a new connection, it would have created a new listener. I also didn't see a way to unsubscribe a listener from the BillingClient.