### PR TITLE
Add support for iOS In-App Purchase promotions

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,6 @@ If you need to clear all products, subscriptions in that array, just call `clear
 
 We've like to update this solution as version changes in `react-native-iap`.
 
-
 ## Q & A
 
 #### Can I buy product right away skipping fetching products if I already know productId?
@@ -364,6 +363,29 @@ We've like to update this solution as version changes in `react-native-iap`.
 #### How do I use react-native-iap in expo?
 - You should detach from `expo` and get `expokit` out of it.
 - Releated issue in #174.
+
+#### How do I handle promoted products in ios?
+
+- Offical doc is [here](https://developer.apple.com/app-store/promoting-in-app-purchases/)
+- Add an event listener for the `iap-promoted-product` event somewhere early in your app's lifecycle:
+
+  ```javascript
+  // Import the `NativeModules` and `NativeEventEmitter` components from 'react-native'
+  const { RNIapIos } = NativeModules;
+  const IAPEmitter = new NativeEventEmitter(RNIapIos);
+
+  IAPEmitter.addListener('iap-promoted-product', async () => {
+    // Check if there's a persisted promoted product
+    const productID = await RNIap.getPromotedProduct();
+    if (productID !== null) { // You may want to validate the product ID against your own SKUs
+      try {
+        await RNIap.buyPromotedProduct(); // This will trigger the App Store purchase process
+      } catch(e) {
+        console.warn(e);
+      }
+    }
+  });
+  ```
 
 #### Invalid productId in ios.
 - Please try below and make sure you've done belows.

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const ANDROID_ITEM_TYPE_IAP = 'inapp';
 const IOS_ITEM_TYPE_SUBSCRIPTION = 'sub';
 const IOS_ITEM_TYPE_IAP = 'iap';
 
-export const onPromotedProduct = 'iap-promoted-product';
+export const PROMOTED_PRODUCT = 'iap-promoted-product';
 
 /**
  * @deprecated Deprecated since 2.0.0. Use initConnection instead.
@@ -194,8 +194,8 @@ export const consumePurchase = (token) => Platform.select({
  */
 export const getPromotedProduct = () => Platform.select({
   ios: async() => RNIapIos.promotedProduct(),
-  android: async() => Promise.resolve()
-})()
+  android: async() => Promise.resolve(),
+})();
 
 /**
  * Buy the currently selected promoted product (iOS only)
@@ -204,8 +204,8 @@ export const getPromotedProduct = () => Platform.select({
  */
 export const buyPromotedProduct = () => Platform.select({
   ios: async() => RNIapIos.buyPromotedProduct(),
-  android: async() => Promise.resolve()
-})()
+  android: async() => Promise.resolve(),
+})();
 
 /**
  * Validate receipt for iOS.

--- a/index.js
+++ b/index.js
@@ -8,6 +8,8 @@ const ANDROID_ITEM_TYPE_IAP = 'inapp';
 const IOS_ITEM_TYPE_SUBSCRIPTION = 'sub';
 const IOS_ITEM_TYPE_IAP = 'iap';
 
+export const onPromotedProduct = 'iap-promoted-product';
+
 /**
  * @deprecated Deprecated since 2.0.0. Use initConnection instead.
  * @returns {Promise<void>}
@@ -184,6 +186,26 @@ export const consumePurchase = (token) => Platform.select({
   ios: async() => Promise.resolve(), // Consuming is a no-op on iOS, as soon as the product is purchased it is considered consumed.
   android: async() => RNIapModule.consumeProduct(token),
 })();
+
+/**
+ * Should Add Store Payment (iOS only)
+ *   Indicates the the App Store purchase should continue from the app instead of the App Store. 
+ * @returns {null}
+ */
+export const getPromotedProduct = () => Platform.select({
+  ios: async() => RNIapIos.promotedProduct(),
+  android: async() => Promise.resolve()
+})()
+
+/**
+ * Buy the currently selected promoted product (iOS only)
+ *   Initiates the payment process for a promoted product. Should only be called in response to the `iap-promoted-product` event.  
+ * @returns {null}
+ */
+export const buyPromotedProduct = () => Platform.select({
+  ios: async() => RNIapIos.buyPromotedProduct(),
+  android: async() => Promise.resolve()
+})()
 
 /**
  * Validate receipt for iOS.

--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -46,6 +46,14 @@
   hasListeners = NO;
 }
 
+- (void)addListener:(NSString *)eventName {
+  [super addListener:eventName];
+
+  if ([eventName isEqualToString:@"iap-promoted-product"] && promotedPayment != nil) {
+    [self sendEventWithName:@"iap-promoted-product" body:promotedPayment.productIdentifier];
+  }
+}
+
 -(void)addPromiseForKey:(NSString*)key resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
   NSMutableArray* promises = [promisesByKey valueForKey:key];
 


### PR DESCRIPTION
This pull request adds support for the additional `SKProductTransactionObserver` delegates that support promoting In-App Purchase products in the App Store. 

This pull request closes #199. 