### PR TITLE
Fix issue with promoted product event not firing on older devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,13 @@ We've like to update this solution as version changes in `react-native-iap`.
 #### How do I handle promoted products in ios?
 
 - Offical doc is [here](https://developer.apple.com/app-store/promoting-in-app-purchases/)
+- Start the IAPPromotionObserver in `-[application:didFinishLaunchingWithOptions:]` your AppDelegate:
+
+    ```objc
+    // Add '#import "IAPPromotionObserver.h"' to your imports
+    [IAPPromotionObserver startObserving]; 
+    ```
+
 - Add an event listener for the `iap-promoted-product` event somewhere early in your app's lifecycle:
 
   ```javascript

--- a/ios/IAPPromotionObserver.h
+++ b/ios/IAPPromotionObserver.h
@@ -1,0 +1,21 @@
+#import <StoreKit/StoreKit.h>
+
+@protocol IAPPromotionObserverDelegate;
+
+@interface IAPPromotionObserver: NSObject <SKPaymentTransactionObserver>
+
+@property (strong, nonatomic, readonly) SKPayment *payment;
+@property (strong, nonatomic, readonly) SKProduct *product;
+@property (weak, nonatomic) id<IAPPromotionObserverDelegate> delegate;
+
++ (instancetype)sharedObserver;
++ (void)startObserving;
+
+@end
+
+@protocol IAPPromotionObserverDelegate <NSObject>
+
+@required
+- (BOOL)shouldAddStorePayment:(SKPayment *)payment forProduct:(SKProduct *)product;
+
+@end

--- a/ios/IAPPromotionObserver.m
+++ b/ios/IAPPromotionObserver.m
@@ -1,0 +1,61 @@
+#import "IAPPromotionObserver.h"
+
+@interface IAPPromotionObserver () {
+  SKPayment *_promotedPayment;
+  SKProduct *_promotedProduct;
+}
+
+@end
+
+@implementation IAPPromotionObserver
+
++ (instancetype)sharedObserver {
+  static IAPPromotionObserver *sharedInstance = nil;
+  static dispatch_once_t onceToken;
+
+  dispatch_once(&onceToken, ^{
+    sharedInstance = [[IAPPromotionObserver alloc] init];
+  });
+
+  return sharedInstance;
+}
+
++ (void)startObserving {
+  [IAPPromotionObserver sharedObserver];
+}
+
+- (instancetype)init {
+  if ((self = [super init])) {
+    [SKPaymentQueue.defaultQueue addTransactionObserver:self];
+  }
+
+  return self;
+}
+
+-(void) dealloc {
+  [[SKPaymentQueue defaultQueue] removeTransactionObserver:self];
+}
+
+- (SKPayment *)payment {
+  return _promotedPayment;
+}
+
+- (SKProduct *)product {
+  return _promotedProduct;
+}
+
+- (void)paymentQueue:(SKPaymentQueue *)queue updatedTransactions:(NSArray<SKPaymentTransaction *> *)transactions {
+}
+
+- (BOOL)paymentQueue:(SKPaymentQueue *)queue shouldAddStorePayment:(SKPayment *)payment forProduct:(SKProduct *)product {
+  _promotedProduct = product;
+  _promotedPayment = payment;
+
+  if (self.delegate != nil && [self.delegate respondsToSelector:@selector(shouldAddStorePayment:forProduct:)]) {
+    return [self.delegate shouldAddStorePayment:payment forProduct:product];
+  }
+
+  return NO;
+}
+
+@end

--- a/ios/RNIap.xcodeproj/project.pbxproj
+++ b/ios/RNIap.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		28CBF364220349F6005F51AC /* IAPPromotionObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 28CBF363220349F6005F51AC /* IAPPromotionObserver.m */; };
 		B3E7B58A1CC2AC0600A0062D /* RNIapIos.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RNIapIos.m */; };
 /* End PBXBuildFile section */
 
@@ -24,6 +25,8 @@
 
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libRNIap.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNIap.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		28CBF362220349F6005F51AC /* IAPPromotionObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IAPPromotionObserver.h; sourceTree = "<group>"; };
+		28CBF363220349F6005F51AC /* IAPPromotionObserver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IAPPromotionObserver.m; sourceTree = "<group>"; };
 		B3E7B5881CC2AC0600A0062D /* RNIapIos.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNIapIos.h; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* RNIapIos.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNIapIos.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -52,6 +55,8 @@
 			children = (
 				B3E7B5881CC2AC0600A0062D /* RNIapIos.h */,
 				B3E7B5891CC2AC0600A0062D /* RNIapIos.m */,
+				28CBF362220349F6005F51AC /* IAPPromotionObserver.h */,
+				28CBF363220349F6005F51AC /* IAPPromotionObserver.m */,
 				134814211AA4EA7D00B7C361 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -112,6 +117,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				28CBF364220349F6005F51AC /* IAPPromotionObserver.m in Sources */,
 				B3E7B58A1CC2AC0600A0062D /* RNIapIos.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
This pull request fixes #389 by adding a mechanism to listen for `-[paymentQueue:addAddStorePayment:forProduct:]` far earlier in the native app lifecycle than would otherwise be possible in pure React Native. 