### PR TITLE
Fix for double callback consume crash

### DIFF
--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -122,14 +122,14 @@ public class RNIapModule extends ReactContextBaseJavaModule {
 
       @Override
       public void onBillingSetupFinished(@BillingClient.BillingResponse int responseCode) {
-        if (responseCode == BillingClient.BillingResponse.OK ) {
-          Log.d(TAG, "billing client ready");
-          if (!bSetupCallbackConsumed) {
-            bSetupCallbackConsumed = true;
+        if (!bSetupCallbackConsumed) {
+          bSetupCallbackConsumed = true;
+          if (responseCode == BillingClient.BillingResponse.OK ) {
+            Log.d(TAG, "billing client ready");
             callback.run();
+          } else {
+            rejectPromiseWithBillingError(promise, responseCode);
           }
-        } else {
-          rejectPromiseWithBillingError(promise, responseCode);
         }
       }
 


### PR DESCRIPTION
This commit fixes https://github.com/dooboolab/react-native-iap/issues/315
Previous pull request https://github.com/dooboolab/react-native-iap/pull/379 fixed the issue just partially.
Here is the stack showing the case when the app crashes:
```
java.lang.RuntimeException: 
  at com.facebook.react.bridge.CallbackImpl.invoke (CallbackImpl.java:28)
  at com.facebook.react.bridge.PromiseImpl.reject (PromiseImpl.java:68)
  at com.facebook.react.bridge.PromiseImpl.reject (PromiseImpl.java:36)
  at com.dooboolab.RNIap.RNIapModule.rejectPromiseWithBillingError (RNIapModule.java:458)
  at com.dooboolab.RNIap.RNIapModule.access$300 (RNIapModule.java:46)
  at com.dooboolab.RNIap.RNIapModule$3.onBillingSetupFinished (RNIapModule.java:132)
  at com.android.billingclient.api.BillingClientImpl$BillingServiceConnection.onServiceConnected (BillingClientImpl.java:908)
 
  at android.app.LoadedApk$ServiceDispatcher.doConnected (LoadedApk.java:1839)
  at android.app.LoadedApk$ServiceDispatcher$RunConnection.run (LoadedApk.java:1871)
  at android.os.Handler.handleCallback (Handler.java:873)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loop (Looper.java:214)
  at android.app.ActivityThread.main (ActivityThread.java:6981)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:493)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1445)
```