### PR TITLE
Add stable branch for podspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Changelogs
-- **[2.4.0]**
+- **[2.4.+]**
   + Add support for iOS In-App Purchase promotions [#388](https://github.com/dooboolab/react-native-iap/pull/388).
   + Implemented `addAdditionalSuccessPurchaseListenerIOS` to handle extra successed purchase event. Related to [#307](https://github.com/dooboolab/react-native-iap/issues/307).
   + Attempt to fix crashing in `ensureConnection` for android. Related [#315](https://github.com/dooboolab/react-native-iap/issues/315).
@@ -8,6 +8,7 @@
   + Update `build.gradle` to match version in react-native `0.58`.
   + Fix issue with promoted product event not firing on older devices [#390](https://github.com/dooboolab/react-native-iap/pull/390).
   + Add support for iOS In-App Purchase promotions.
+  + Add stable channel for pod [#404](https://github.com/dooboolab/react-native-iap/issues/404).
 - **[2.3.23]**
   + Resolve [#288](https://github.com/dooboolab/react-native-iap/issues/288).
 - **[2.3.21]**

--- a/RNIap.podspec
+++ b/RNIap.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = "MIT"
   s.author       = package['author']
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "https://github.com/dooboolab/react-native-iap.git", :tag => "master" }
+  s.source       = { :git => "https://github.com/dooboolab/react-native-iap.git", :tag => "stable" }
   s.source_files  = "ios/**/*.{h,m}"
   s.requires_arc = true
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iap",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "React Native In App Purchase Module.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Fixes #404 
- The new version will be released from `stable` channel from now.