### PR TITLE
Added purchased state to the restored items in getAvailableItems for iOS

### DIFF
--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -311,7 +311,7 @@ RCT_EXPORT_METHOD(buyPromotedProduct:(RCTPromiseResolveBlock)resolve
   NSMutableArray* items = [NSMutableArray arrayWithCapacity:queue.transactions.count];
 
   for(SKPaymentTransaction *transaction in queue.transactions) {
-    if(transaction.transactionState == SKPaymentTransactionStateRestored) {
+    if(transaction.transactionState == SKPaymentTransactionStateRestored || transaction.transactionState == SKPaymentTransactionStatePurchased) {
       NSDictionary *restored = [self getPurchaseData:transaction];
       [items addObject:restored];
       [[SKPaymentQueue defaultQueue] finishTransaction:transaction];


### PR DESCRIPTION
Hi there! This should probably address https://github.com/dooboolab/react-native-iap/issues/409. From my experience, apple iaps api sometimes has difficulty distinguishing between `purchased` and `restored` state. Looks like when available items are returned as `restored` once — some of them will be returned as `purchased` the next time.