### PR TITLE
fix: android: move google repo above jcenter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,11 +1,11 @@
 
 buildscript {
   repositories {
-    jcenter()
     maven {
       url 'https://maven.google.com/'
       name 'Google'
     }
+    jcenter()
   }
 
   dependencies {


### PR DESCRIPTION
Fixes build errors related to jcenter missing android-specific
dependencies.

