### PR TITLE
Remove comments about ejected apps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,16 +97,6 @@ https://github.com/dooboolab/react-native-iap
 ### Mostly automatic installation
 `$ react-native link react-native-iap`
 
-**Note for Ejected iOS Apps:**
-
-The above command will add the following to your `Podfile`:
-
-```ruby
-pod 'RNIap', :path => '../node_modules/react-native-iap'
-```
-
-You should remove this before running `pod install` and follow the manual installation instructions below.
-
 ### Manual installation
 
 #### iOS


### PR DESCRIPTION
Removing `pod 'RNIap', :path => '../node_modules/react-native-iap'` from the Podfile makes the module not available in apps using Pods so it's better to let it be in the Podfile.