### PR TITLE
Update Gradle 3.2.1 - build tools version 28.0.3

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,14 +9,14 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:3.0.0'
+    classpath 'com.android.tools.build:gradle:3.2.1'
   }
 }
 
 apply plugin: 'com.android.library'
 
 def DEFAULT_COMPILE_SDK_VERSION = 28
-def DEFAULT_BUILD_TOOLS_VERSION = "28.0.2"
+def DEFAULT_BUILD_TOOLS_VERSION = "28.0.3"
 def DEFAULT_MIN_SDK_VERSION = 16
 def DEFAULT_TARGET_SDK_VERSION = 27
 


### PR DESCRIPTION
This PR updates _Gradle_ version to `3.2.1` and default build tools version to `28.0.3` to avoid warnings in most versions.

![Captura de pantalla 2019-05-14 a las 15 40 21](https://user-images.githubusercontent.com/4986411/57704395-186a4100-7662-11e9-8e56-408358bed6b6.png)

⚠️ Needed to be tested.