### PR TITLE
Fix gradle api usage

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,12 +21,12 @@ def DEFAULT_MIN_SDK_VERSION = 16
 def DEFAULT_TARGET_SDK_VERSION = 27
 
 android {
-  compileSdkVersion rootProject.ext.hasProperty('compileSdkVersion') ? rootProject.ext.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
-  buildToolsVersion rootProject.ext.hasProperty('buildToolsVersion') ? rootProject.ext.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
+  compileSdkVersion rootProject.ext.has('compileSdkVersion') ? rootProject.ext.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
+  buildToolsVersion rootProject.ext.has('buildToolsVersion') ? rootProject.ext.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
   defaultConfig {
-    minSdkVersion rootProject.ext.hasProperty('minSdkVersion') ? rootProject.ext.minSdkVersion : DEFAULT_MIN_SDK_VERSION
-    targetSdkVersion rootProject.ext.hasProperty('targetSdkVersion') ? rootProject.ext.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
+    minSdkVersion rootProject.ext.has('minSdkVersion') ? rootProject.ext.minSdkVersion : DEFAULT_MIN_SDK_VERSION
+    targetSdkVersion rootProject.ext.has('targetSdkVersion') ? rootProject.ext.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
     versionCode 1
     versionName "1.0"
   }


### PR DESCRIPTION
Currently, local configuration of versions is ignored by this library.

[`hasProperty()`](https://docs.gradle.org/current/javadoc/org/gradle/api/Project.html#hasProperty-java.lang.String-) exists on the `Project` object itself; `Project.ext` uses [`has()`](https://docs.gradle.org/current/javadoc/org/gradle/api/plugins/ExtraPropertiesExtension.html#has-java.lang.String-).

You can test by modifying the main app's `build.gradle`.
```gradle
buildscript {
    ext {
        buildToolsVersion = "28.0.3"
// [...]
```
With this mr, setting `buildToolsVersion` to something older will result in a warning during build. On current master, changes to `buildToolsVersion` have no effect.