### PR TITLE
Fix promo code purchase not being restored.

### DIFF
--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -343,7 +343,8 @@ RCT_EXPORT_METHOD(buyPromotedProduct:(RCTPromiseResolveBlock)resolve
   NSMutableArray* items = [NSMutableArray arrayWithCapacity:queue.transactions.count];
 
   for(SKPaymentTransaction *transaction in queue.transactions) {
-    if(transaction.transactionState == SKPaymentTransactionStateRestored) {
+    if(transaction.transactionState == SKPaymentTransactionStateRestored
+        || transaction.transactionState == SKPaymentTransactionStatePurchased) {
       NSDictionary *restored = [self getPurchaseData:transaction];
       [items addObject:restored];
       [[SKPaymentQueue defaultQueue] finishTransaction:transaction];


### PR DESCRIPTION
Fixes promo code purchase not being restored.
Checks for transaction state being SKPaymentTransactionStatePurchased and finishes the transaction.
https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/StoreKitGuide/Chapters/DeliverProduct.html#//apple_ref/doc/uid/TP40008267-CH5-SW4