### PR TITLE
Fix Platform Specific Type Definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,16 +21,16 @@ export interface Subscription<ID extends string> extends Common {
 
   introductoryPrice?: string
   introductoryPricePaymentModeIOS?: string
-  introductoryPriceNumberOfPeriods?: number
-  introductoryPriceSubscriptionPeriod: object
+  introductoryPriceNumberOfPeriodsIOS?: string
+  introductoryPriceSubscriptionPeriodIOS?: string
 
-  subscriptionPeriodNumberIOS?: number
+  subscriptionPeriodNumberIOS?: string
   subscriptionPeriodUnitIOS?: string
 
-  introductoryPriceCyclesAndroid?: number
+  introductoryPriceCyclesAndroid?: string
   introductoryPricePeriodAndroid?: string
   subscriptionPeriodAndroid?: string
-  freeTrialPeriodAndroid: string
+  freeTrialPeriodAndroid?: string
 }
 
 export interface ProductPurchase {


### PR DESCRIPTION
The `Subscription` interface in `index.d.ts` does not align with what I am receiving from `getSubscriptions()`.

- All returned values are strings, no numbers or objects.  
- Platform specific values are optional since they are only returned per specific platform
- introductoryPriceSubscriptionPeriodIOS does not currently exist on interface
- introductoryPriceNumberOfPeriodsIOS does not currently exist on interface

```javascript
androidSubscriptionResponse: [
  {
    introductoryPricePeriodAndroid: "",
    introductoryPriceCyclesAndroid: "",
    productId: "xxxx",
    price: "49.99",
    currency: "USD",
    type: "subs",
    localizedPrice: "$49.99",
    freeTrialPeriodAndroid: "P3D",
    title: "xxx",
    description: "xxx",
    introductoryPrice: "",
    subscriptionPeriodAndroid: "P1Y"
  },
];
```

```javascript
iOSSubscriptionResponse: [
  {
    description: "xxx",
    introductoryPriceSubscriptionPeriodIOS: "DAY",
    productId: "xxx",
    currency: "USD",
    introductoryPriceNumberOfPeriodsIOS: "1",
    type: "Do not use this. It returned sub only before",
    title: "xxx",
    price: "49.99",
    localizedPrice: "$49.99",
    introductoryPricePaymentModeIOS: "FREETRIAL",
    introductoryPrice: "$0.00",
    subscriptionPeriodNumberIOS: "1",
    subscriptionPeriodUnitIOS: "YEAR"
  },
];
```