### PR TITLE
update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ Once you have called `getProducts()`, and you have a valid response, you can cal
 
 ```javascript
   try {
+    if(this.subscription) {
+      this.subscription.remove();
+    }
     // Will return a purchase object with a receipt which can be used to validate on your server.
     const purchase = await RNIap.buyProduct('com.example.coins100');
     this.setState({
@@ -198,9 +201,9 @@ Once you have called `getProducts()`, and you have a valid response, you can cal
   } catch(err) {
     // standardized err.code and err.message available
     console.warn(err.code, err.message);
-    const subscription = RNIap.addAdditionalSuccessPurchaseListenerIOS(async (purchase) => {
+    this.subscription = RNIap.addAdditionalSuccessPurchaseListenerIOS(async (purchase) => {
       this.setState({ receipt: purchase.transactionReceipt }, () => this.goToNext());
-      subscription.remove();
+      this.subscription.remove();
     });
   }
 ```


### PR DESCRIPTION
The original way to add listener without removing it before another purchase begin cause problem.
For example, cancel IAP twice and then success, this third success event will trigger the previous two listener.
This won't affect 'store kit flow' since you won't call buyProduct() when your customer is solving a problem with his or her account.