### PR TITLE
Add `purchase-error` events to handle purchase error

### DIFF
--- a/IapExample/App.js
+++ b/IapExample/App.js
@@ -12,6 +12,8 @@ import RNIap, {
   Product,
   ProductPurchase,
   purchaseUpdatedListener,
+  purchaseErrorListener,
+  PurchaseError,
 } from 'react-native-iap';
 
 // App Bundle > com.dooboolab.test
@@ -36,6 +38,7 @@ const itemSubs = Platform.select({
 });
 
 let purchaseUpdateSubscription;
+let purchaseErrorSubscription;
 
 class Page extends Component {
   constructor(props) {
@@ -61,12 +64,21 @@ class Page extends Component {
       console.log('purchaseUpdatedListener', purchase);
       this.setState({ receipt: purchase.transactionReceipt }, () => this.goNext());
     });
+
+    purchaseErrorSubscription = purchaseErrorListener((error: PurchaseError) => {
+      console.log('purchaseErrorListener', error);
+      Alert.alert('purchase error', JSON.stringify(error));
+    });
   }
 
   componentWillMount() {
     if (purchaseUpdateSubscription) {
       purchaseUpdateSubscription.remove();
       purchaseUpdateSubscription = null;
+    }
+    if (purchaseErrorSubscription) {
+      purchaseErrorSubscription.remove();
+      purchaseErrorSubscription = null;
     }
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,6 +43,11 @@ export interface ProductPurchase {
   purchaseToken?: string;
 }
 
+export interface PurchaseError {
+  responseCode?: number;
+  debugMessage?: string;
+}
+
 export interface SubscriptionPurchase extends ProductPurchase {
   autoRenewingAndroid: boolean;
   originalTransactionDateIOS: string;
@@ -220,6 +225,12 @@ export function addAdditionalSuccessPurchaseListenerIOS(fn: Function) : EmitterS
 
 /**
  * Subscribe a listener when purchase is updated.
- * @returns {callback(e: Event)}
+ * @returns {callback(e: ProductPurchase)}
+ */
+export function purchaseUpdatedListener(fn: Function) : EmitterSubscription;
+
+/**
+ * Subscribe a listener when purchase is updated.
+ * @returns {callback(e: PurchaseError)}
  */
 export function purchaseUpdatedListener(fn: Function) : EmitterSubscription;

--- a/index.js
+++ b/index.js
@@ -405,7 +405,7 @@ export const addAdditionalSuccessPurchaseListenerIOS = (e) => {
 
 /**
  * Add IAP purchase event in ios.
- * @returns {callback(e: Event)}
+ * @returns {callback(e: ProductPurchase)}
  */
 export const purchaseUpdatedListener = (e) => {
   if (Platform.OS === 'ios') {
@@ -414,6 +414,20 @@ export const purchaseUpdatedListener = (e) => {
     return myModuleEvt.addListener('purchase-updated', e);
   } else {
     return DeviceEventEmitter.addListener('purchase-updated', e);
+  }
+};
+
+/**
+ * Add IAP purchase error event in ios.
+ * @returns {callback(e: ProductPurchase)}
+ */
+export const purcaseErrorListener = (e) => {
+  if (Platform.OS === 'ios') {
+    checkNativeiOSAvailable();
+    const myModuleEvt = new NativeEventEmitter(RNIapIos);
+    return myModuleEvt.addListener('purchase-error', e);
+  } else {
+    return DeviceEventEmitter.addListener('purchase-error', e);
   }
 };
 

--- a/index.js.flow
+++ b/index.js.flow
@@ -43,6 +43,11 @@ export type ProductPurchase = {|
   purchaseToken?: string,
 |}
 
+expoert type PurchaseError = {
+  responseCode: number,
+  debugMessage: string,
+}
+
 export type SubscriptionPurchase = ProductPurchase & {
   autoRenewingAndroid: boolean,
   originalTransactionDateIOS: string,
@@ -94,6 +99,9 @@ declare module.exports: {
     fn: (any) => any,
   ): EmitterSubscription,
   purchaseUpdatedListener(
+    fn: (any) => any,
+  ): EmitterSubscription,
+  purchaseErrorListener(
     fn: (any) => any,
   ): EmitterSubscription,
 }

--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -8,9 +8,9 @@
 
 ////////////////////////////////////////////////////     _//////////_  // Private Members
 @interface RNIapIos() <IAPPromotionObserverDelegate> {
-  NSMutableDictionary *promisesByKey;
-  dispatch_queue_t myQueue;
-  BOOL hasListeners;
+    NSMutableDictionary *promisesByKey;
+    dispatch_queue_t myQueue;
+    BOOL hasListeners;
 }
 @end
 
@@ -18,82 +18,82 @@
 @implementation RNIapIos
 
 -(instancetype)init {
-  if ((self = [super init])) {
-    promisesByKey = [NSMutableDictionary dictionary];
-    [[SKPaymentQueue defaultQueue] addTransactionObserver:self];
-    [IAPPromotionObserver sharedObserver].delegate = self;
-  }
-  myQueue = dispatch_queue_create("reject", DISPATCH_QUEUE_SERIAL);
-  validProducts = [NSMutableArray array];
-  return self;
+    if ((self = [super init])) {
+        promisesByKey = [NSMutableDictionary dictionary];
+        [[SKPaymentQueue defaultQueue] addTransactionObserver:self];
+        [IAPPromotionObserver sharedObserver].delegate = self;
+    }
+    myQueue = dispatch_queue_create("reject", DISPATCH_QUEUE_SERIAL);
+    validProducts = [NSMutableArray array];
+    return self;
 }
 
 -(void) dealloc {
-  [[SKPaymentQueue defaultQueue] removeTransactionObserver:self];
+    [[SKPaymentQueue defaultQueue] removeTransactionObserver:self];
 }
 
 +(BOOL)requiresMainQueueSetup {
-  return YES;
+    return YES;
 }
 
 - (void)startObserving {
-  hasListeners = YES;
+    hasListeners = YES;
 }
 
 - (void)stopObserving {
-  hasListeners = NO;
+    hasListeners = NO;
 }
 
 - (void)addListener:(NSString *)eventName {
-  [super addListener:eventName];
-
-  SKPayment *promotedPayment = [IAPPromotionObserver sharedObserver].payment;
-  if ([eventName isEqualToString:@"iap-promoted-product"] && promotedPayment != nil) {
-    [self sendEventWithName:@"iap-promoted-product" body:promotedPayment.productIdentifier];
-  }
+    [super addListener:eventName];
+    
+    SKPayment *promotedPayment = [IAPPromotionObserver sharedObserver].payment;
+    if ([eventName isEqualToString:@"iap-promoted-product"] && promotedPayment != nil) {
+        [self sendEventWithName:@"iap-promoted-product" body:promotedPayment.productIdentifier];
+    }
 }
 
 -(void)addPromiseForKey:(NSString*)key resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
-  NSMutableArray* promises = [promisesByKey valueForKey:key];
-
-  if (promises == nil) {
-    promises = [NSMutableArray array];
-    [promisesByKey setValue:promises forKey:key];
-  }
-
-  [promises addObject:@[resolve, reject]];
+    NSMutableArray* promises = [promisesByKey valueForKey:key];
+    
+    if (promises == nil) {
+        promises = [NSMutableArray array];
+        [promisesByKey setValue:promises forKey:key];
+    }
+    
+    [promises addObject:@[resolve, reject]];
 }
 
 -(void)resolvePromisesForKey:(NSString*)key value:(id)value {
-  NSMutableArray* promises = [promisesByKey valueForKey:key];
-
-  if (promises != nil) {
-    for (NSMutableArray *tuple in promises) {
-      RCTPromiseResolveBlock resolveBlck = tuple[0];
-      resolveBlck(value);
+    NSMutableArray* promises = [promisesByKey valueForKey:key];
+    
+    if (promises != nil) {
+        for (NSMutableArray *tuple in promises) {
+            RCTPromiseResolveBlock resolveBlck = tuple[0];
+            resolveBlck(value);
+        }
+        [promisesByKey removeObjectForKey:key];
     }
-    [promisesByKey removeObjectForKey:key];
-  }
 }
 
 -(void)rejectPromisesForKey:(NSString*)key code:(NSString*)code message:(NSString*)message error:(NSError*) error {
-  NSMutableArray* promises = [promisesByKey valueForKey:key];
-
-  if (promises != nil) {
-    for (NSMutableArray *tuple in promises) {
-      RCTPromiseRejectBlock reject = tuple[1];
-      reject(code, message, error);
+    NSMutableArray* promises = [promisesByKey valueForKey:key];
+    
+    if (promises != nil) {
+        for (NSMutableArray *tuple in promises) {
+            RCTPromiseRejectBlock reject = tuple[1];
+            reject(code, message, error);
+        }
+        [promisesByKey removeObjectForKey:key];
     }
-    [promisesByKey removeObjectForKey:key];
-  }
 }
 
 ////////////////////////////////////////////////////     _//////////_  // IAPPromotionObserverDelegate
 - (BOOL)shouldAddStorePayment:(SKPayment *)payment forProduct:(SKProduct *)product {
-  if (hasListeners) {
-    [self sendEventWithName:@"iap-promoted-product" body:product.productIdentifier];
-  }
-  return NO;
+    if (hasListeners) {
+        [self sendEventWithName:@"iap-promoted-product" body:product.productIdentifier];
+    }
+    return NO;
 }
 
 ////////////////////////////////////////////////////     _//////////_//      EXPORT_MODULE
@@ -101,7 +101,7 @@ RCT_EXPORT_MODULE();
 
 - (NSArray<NSString *> *)supportedEvents
 {
-  return @[@"iap-purchase-event", @"iap-promoted-product", @"purchase-updated"];
+    return @[@"iap-purchase-event", @"iap-promoted-product", @"purchase-updated", @"purchase-error"];
 }
 
 RCT_EXPORT_METHOD(canMakePayments:(RCTPromiseResolveBlock)resolve
@@ -113,18 +113,18 @@ RCT_EXPORT_METHOD(canMakePayments:(RCTPromiseResolveBlock)resolve
 RCT_EXPORT_METHOD(getItems:(NSArray*)skus
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
-  NSSet* productIdentifiers = [NSSet setWithArray:skus];
-  productsRequest = [[SKProductsRequest alloc] initWithProductIdentifiers:productIdentifiers];
-  productsRequest.delegate = self;
-  NSString* key = RCTKeyForInstance(productsRequest);
-  [self addPromiseForKey:key resolve:resolve reject:reject];
-  [productsRequest start];
+    NSSet* productIdentifiers = [NSSet setWithArray:skus];
+    productsRequest = [[SKProductsRequest alloc] initWithProductIdentifiers:productIdentifiers];
+    productsRequest.delegate = self;
+    NSString* key = RCTKeyForInstance(productsRequest);
+    [self addPromiseForKey:key resolve:resolve reject:reject];
+    [productsRequest start];
 }
 
 RCT_EXPORT_METHOD(getAvailableItems:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject) {
-  [self addPromiseForKey:@"availableItems" resolve:resolve reject:reject];
-  [[SKPaymentQueue defaultQueue] restoreCompletedTransactions];
+reject:(RCTPromiseRejectBlock)reject) {
+    [self addPromiseForKey:@"availableItems" resolve:resolve reject:reject];
+    [[SKPaymentQueue defaultQueue] restoreCompletedTransactions];
 }
 
 RCT_EXPORT_METHOD(buyProduct:(NSString*)sku
@@ -142,6 +142,13 @@ RCT_EXPORT_METHOD(buyProduct:(NSString*)sku
         [[SKPaymentQueue defaultQueue] addPayment:payment];
         [self addPromiseForKey:RCTKeyForInstance(payment.productIdentifier) resolve:resolve reject:reject];
     } else {
+        if (hasListeners) {
+            NSDictionary *err = [NSDictionary dictionaryWithObjectsAndKeys:
+                                 @"Invalid product ID.", @"debugMessage",
+                                 nil
+                                 ];
+            [self sendEventWithName:@"purchase-error" body:err];
+        }
         reject(@"E_DEVELOPER_ERROR", @"Invalid product ID.", nil);
     }
 }
@@ -151,459 +158,495 @@ RCT_EXPORT_METHOD(buyProductWithOffer:(NSString*)sku
                   withOffer:(NSDictionary*)discountOffer
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
-  SKProduct *product;
-  for (SKProduct *p in validProducts) {
-    if([sku isEqualToString:p.productIdentifier]) {
-      product = p;
-      break;
+    SKProduct *product;
+    for (SKProduct *p in validProducts) {
+        if([sku isEqualToString:p.productIdentifier]) {
+            product = p;
+            break;
+        }
     }
-  }
-  if (product) {
-    SKPaymentDiscount *discount = [[SKPaymentDiscount alloc]
-      initWithIdentifier:discountOffer[@"identifier"]
-      keyIdentifier:discountOffer[@"keyIdentifier"]
-      nonce:[[NSUUID alloc] initWithUUIDString:discountOffer[@"nonce"]]
-      signature:discountOffer[@"signature"]
-      timestamp:discountOffer[@"timestamp"]
-    ];
-
-    SKMutablePayment *payment = [SKMutablePayment paymentWithProduct:product];
-    payment.applicationUsername = usernameHash;
-    payment.paymentDiscount = discount;
-
-    [[SKPaymentQueue defaultQueue] addPayment:payment];
-    [self addPromiseForKey:RCTKeyForInstance(payment.productIdentifier) resolve:resolve reject:reject];
-  } else {
-    reject(@"E_DEVELOPER_ERROR", @"Invalid product ID.", nil);
-  }
+    if (product) {
+        SKPaymentDiscount *discount = [[SKPaymentDiscount alloc]
+                                       initWithIdentifier:discountOffer[@"identifier"]
+                                       keyIdentifier:discountOffer[@"keyIdentifier"]
+                                       nonce:[[NSUUID alloc] initWithUUIDString:discountOffer[@"nonce"]]
+                                       signature:discountOffer[@"signature"]
+                                       timestamp:discountOffer[@"timestamp"]
+                                       ];
+        
+        SKMutablePayment *payment = [SKMutablePayment paymentWithProduct:product];
+        payment.applicationUsername = usernameHash;
+        payment.paymentDiscount = discount;
+        
+        [[SKPaymentQueue defaultQueue] addPayment:payment];
+        [self addPromiseForKey:RCTKeyForInstance(payment.productIdentifier) resolve:resolve reject:reject];
+    } else {
+        if (hasListeners) {
+            NSDictionary *err = [NSDictionary dictionaryWithObjectsAndKeys:
+                                 @"Invalid product ID.", @"debugMessage",
+                                 nil
+                                 ];
+            [self sendEventWithName:@"purchase-error" body:err];
+        }
+        reject(@"E_DEVELOPER_ERROR", @"Invalid product ID.", nil);
+    }
 }
 
 RCT_EXPORT_METHOD(buyProductWithQuantityIOS:(NSString*)sku
                   quantity:(NSInteger*)quantity
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
-  NSLog(@"\n\n\n  buyProductWithQuantityIOS  \n\n.");
-  SKProduct *product;
-  for (SKProduct *p in validProducts) {
-    if([sku isEqualToString:p.productIdentifier]) {
-      product = p;
-      break;
+    NSLog(@"\n\n\n  buyProductWithQuantityIOS  \n\n.");
+    SKProduct *product;
+    for (SKProduct *p in validProducts) {
+        if([sku isEqualToString:p.productIdentifier]) {
+            product = p;
+            break;
+        }
     }
-  }
-  if (product) {
-    SKMutablePayment *payment = [SKMutablePayment paymentWithProduct:product];
-    payment.quantity = quantity;
-    [[SKPaymentQueue defaultQueue] addPayment:payment];
-    [self addPromiseForKey:RCTKeyForInstance(payment.productIdentifier) resolve:resolve reject:reject];
-  } else {
-    reject(@"E_DEVELOPER_ERROR", @"Invalid product ID.", nil);
-  }
+    if (product) {
+        SKMutablePayment *payment = [SKMutablePayment paymentWithProduct:product];
+        payment.quantity = quantity;
+        [[SKPaymentQueue defaultQueue] addPayment:payment];
+        [self addPromiseForKey:RCTKeyForInstance(payment.productIdentifier) resolve:resolve reject:reject];
+    } else {
+        if (hasListeners) {
+            NSDictionary *err = [NSDictionary dictionaryWithObjectsAndKeys:
+                                 @"Invalid product ID.", @"debugMessage",
+                                 nil
+                                 ];
+            [self sendEventWithName:@"purchase-error" body:err];
+        }
+        reject(@"E_DEVELOPER_ERROR", @"Invalid product ID.", nil);
+    }
 }
 
 RCT_EXPORT_METHOD(buyProductWithoutAutoConfirm:(NSString*)sku
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
-  NSLog(@"\n\n\n  buyProductWithoutAutoConfirm  \n\n.");
-  SKProduct *product;
-  for (SKProduct *p in validProducts) {
-    if([sku isEqualToString:p.productIdentifier]) {
-      product = p;
-      break;
+    NSLog(@"\n\n\n  buyProductWithoutAutoConfirm  \n\n.");
+    SKProduct *product;
+    for (SKProduct *p in validProducts) {
+        if([sku isEqualToString:p.productIdentifier]) {
+            product = p;
+            break;
+        }
     }
-  }
-  if (product) {
-    SKMutablePayment *payment = [SKMutablePayment paymentWithProduct:product];
-    [[SKPaymentQueue defaultQueue] addPayment:payment];
-    [self addPromiseForKey:RCTKeyForInstance(payment.productIdentifier) resolve:resolve reject:reject];
-  } else {
-    reject(@"E_DEVELOPER_ERROR", @"Invalid product ID.", nil);
-  }
+    if (product) {
+        SKMutablePayment *payment = [SKMutablePayment paymentWithProduct:product];
+        [[SKPaymentQueue defaultQueue] addPayment:payment];
+        [self addPromiseForKey:RCTKeyForInstance(payment.productIdentifier) resolve:resolve reject:reject];
+    } else {
+        if (hasListeners) {
+            NSDictionary *err = [NSDictionary dictionaryWithObjectsAndKeys:
+                                 @"Invalid product ID.", @"debugMessage",
+                                 nil
+                                 ];
+            [self sendEventWithName:@"purchase-error" body:err];
+        }
+        reject(@"E_DEVELOPER_ERROR", @"Invalid product ID.", nil);
+    }
 }
 
 RCT_EXPORT_METHOD(clearTransaction) {
-  NSArray *pendingTrans = [[SKPaymentQueue defaultQueue] transactions];
-  NSLog(@"\n\n\n  ***  clear remaining Transactions. Call this before make a new transaction   \n\n.");
-  for (int k = 0; k < pendingTrans.count; k++) {
-    [[SKPaymentQueue defaultQueue] finishTransaction:pendingTrans[k]];
-  }
+    NSArray *pendingTrans = [[SKPaymentQueue defaultQueue] transactions];
+    NSLog(@"\n\n\n  ***  clear remaining Transactions. Call this before make a new transaction   \n\n.");
+    for (int k = 0; k < pendingTrans.count; k++) {
+        [[SKPaymentQueue defaultQueue] finishTransaction:pendingTrans[k]];
+    }
 }
 
 RCT_EXPORT_METHOD(clearProducts) {
-  NSLog(@"\n\n\n  ***  clear valid products. \n\n.");
-  [validProducts removeAllObjects];
+    NSLog(@"\n\n\n  ***  clear valid products. \n\n.");
+    [validProducts removeAllObjects];
 }
 
 RCT_EXPORT_METHOD(promotedProduct:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
-  NSLog(@"\n\n\n  ***  get promoted product. \n\n.");
-  SKProduct *promotedProduct = [IAPPromotionObserver sharedObserver].product;
-  resolve(promotedProduct ? promotedProduct.productIdentifier : [NSNull null]);
+    NSLog(@"\n\n\n  ***  get promoted product. \n\n.");
+    SKProduct *promotedProduct = [IAPPromotionObserver sharedObserver].product;
+    resolve(promotedProduct ? promotedProduct.productIdentifier : [NSNull null]);
 }
 
 RCT_EXPORT_METHOD(buyPromotedProduct:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
-  SKPayment *promotedPayment = [IAPPromotionObserver sharedObserver].payment;
-  if (promotedPayment) {
-    NSLog(@"\n\n\n  ***  buy promoted product. \n\n.");
-    [[SKPaymentQueue defaultQueue] addPayment:promotedPayment];
-    [self addPromiseForKey:RCTKeyForInstance(promotedPayment.productIdentifier) resolve:resolve reject:reject];
-  } else {
-    reject(@"E_DEVELOPER_ERROR", @"Invalid product ID.", nil);
-  }
+    SKPayment *promotedPayment = [IAPPromotionObserver sharedObserver].payment;
+    if (promotedPayment) {
+        NSLog(@"\n\n\n  ***  buy promoted product. \n\n.");
+        [[SKPaymentQueue defaultQueue] addPayment:promotedPayment];
+        [self addPromiseForKey:RCTKeyForInstance(promotedPayment.productIdentifier) resolve:resolve reject:reject];
+    } else {
+        reject(@"E_DEVELOPER_ERROR", @"Invalid product ID.", nil);
+    }
 }
 
 #pragma mark ===== StoreKit Delegate
 
 -(void)productsRequest:(SKProductsRequest *)request didReceiveResponse:(SKProductsResponse *)response {
-  // validProducts = response.products; // do not set directly. use addProduct methods.
-  for (SKProduct* prod in response.products) {
-    [self addProduct:prod];
-  }
-  NSMutableArray* items = [NSMutableArray array];
-
-  for (SKProduct* product in validProducts) {
-    [items addObject:[self getProductObject:product]];
-  }
-
-  [self resolvePromisesForKey:RCTKeyForInstance(request) value:items];
+    // validProducts = response.products; // do not set directly. use addProduct methods.
+    for (SKProduct* prod in response.products) {
+        [self addProduct:prod];
+    }
+    NSMutableArray* items = [NSMutableArray array];
+    
+    for (SKProduct* product in validProducts) {
+        [items addObject:[self getProductObject:product]];
+    }
+    
+    [self resolvePromisesForKey:RCTKeyForInstance(request) value:items];
 }
 
 // Add to valid products from Apple server response. Allowing getProducts, getSubscriptions call several times.
 // Doesn't allow duplication. Replace new product.
 -(void)addProduct:(SKProduct *)aProd {
-  NSLog(@"\n  Add new object : %@", aProd.productIdentifier);
-  int delTar = -1;
-  for (int k = 0; k < validProducts.count; k++) {
-    SKProduct *cur = validProducts[k];
-    if ([cur.productIdentifier isEqualToString:aProd.productIdentifier]) {
-      delTar = k;
+    NSLog(@"\n  Add new object : %@", aProd.productIdentifier);
+    int delTar = -1;
+    for (int k = 0; k < validProducts.count; k++) {
+        SKProduct *cur = validProducts[k];
+        if ([cur.productIdentifier isEqualToString:aProd.productIdentifier]) {
+            delTar = k;
+        }
     }
-  }
-  if (delTar >= 0) {
-    [validProducts removeObjectAtIndex:delTar];
-  }
-  [validProducts addObject:aProd];
+    if (delTar >= 0) {
+        [validProducts removeObjectAtIndex:delTar];
+    }
+    [validProducts addObject:aProd];
 }
 
 - (void)request:(SKRequest *)request didFailWithError:(NSError *)error{
-  NSString* key = RCTKeyForInstance(productsRequest);
-  dispatch_sync(myQueue, ^{
-    [self rejectPromisesForKey:key code:[self standardErrorCode:(int)error.code]
-                       message:error.localizedDescription error:error];
-  });
+    NSString* key = RCTKeyForInstance(productsRequest);
+    dispatch_sync(myQueue, ^{
+        [self rejectPromisesForKey:key code:[self standardErrorCode:(int)error.code]
+                           message:error.localizedDescription error:error];
+    });
 }
 
 -(void)paymentQueue:(SKPaymentQueue *)queue updatedTransactions:(NSArray *)transactions {
-  for (SKPaymentTransaction *transaction in transactions) {
-    switch (transaction.transactionState) {
-      case SKPaymentTransactionStatePurchasing:
-        NSLog(@"\n\n Purchase Started !! \n\n");
-        break;
-      case SKPaymentTransactionStatePurchased:
-        NSLog(@"\n\n\n\n\n Purchase Successful !! \n\n\n\n\n.");
-        [self purchaseProcess:transaction];
-        break;
-      case SKPaymentTransactionStateRestored: // 기존 구매한 아이템 복구..
-        NSLog(@"Restored ");
-        [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
-        break;
-      case SKPaymentTransactionStateDeferred:
-        NSLog(@"Deferred (awaiting approval via parental controls, etc.)");
-        break;
-      case SKPaymentTransactionStateFailed:
-        NSLog(@"\n\n\n\n\n\n Purchase Failed  !! \n\n\n\n\n");
-        [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
-        NSString *key = RCTKeyForInstance(transaction.payment.productIdentifier);
-        dispatch_sync(myQueue, ^{
-          [self rejectPromisesForKey:key code:[self standardErrorCode:(int)transaction.error.code]
-                             message:transaction.error.localizedDescription
-                               error:transaction.error];
-        });
-        break;
+    for (SKPaymentTransaction *transaction in transactions) {
+        switch (transaction.transactionState) {
+            case SKPaymentTransactionStatePurchasing:
+                NSLog(@"\n\n Purchase Started !! \n\n");
+                break;
+            case SKPaymentTransactionStatePurchased:
+                NSLog(@"\n\n\n\n\n Purchase Successful !! \n\n\n\n\n.");
+                [self purchaseProcess:transaction];
+                break;
+            case SKPaymentTransactionStateRestored: // 기존 구매한 아이템 복구..
+                NSLog(@"Restored ");
+                [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
+                break;
+            case SKPaymentTransactionStateDeferred:
+                NSLog(@"Deferred (awaiting approval via parental controls, etc.)");
+                break;
+            case SKPaymentTransactionStateFailed:
+                NSLog(@"\n\n\n\n\n\n Purchase Failed  !! \n\n\n\n\n");
+                [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
+                NSString *key = RCTKeyForInstance(transaction.payment.productIdentifier);
+                dispatch_sync(myQueue, ^{
+                    if (hasListeners) {
+                        NSString *responseCode = [@(transaction.error.code) stringValue];
+                        NSDictionary *err = [NSDictionary dictionaryWithObjectsAndKeys:
+                                             responseCode, @"responseCode",
+                                             transaction.error.localizedDescription, @"debugMessage",
+                                             nil
+                                             ];
+                        [self sendEventWithName:@"purchase-error" body:err];
+                    }
+                    [self rejectPromisesForKey:key code:[self standardErrorCode:(int)transaction.error.code]
+                                       message:transaction.error.localizedDescription
+                                         error:transaction.error];
+                });
+                break;
+        }
     }
-  }
 }
 
 -(void)paymentQueueRestoreCompletedTransactionsFinished:(SKPaymentQueue *)queue {  ////////   RESTORE
-  NSLog(@"\n\n\n  paymentQueueRestoreCompletedTransactionsFinished  \n\n.");
-  NSMutableArray* items = [NSMutableArray arrayWithCapacity:queue.transactions.count];
-
-  for(SKPaymentTransaction *transaction in queue.transactions) {
-    if(transaction.transactionState == SKPaymentTransactionStateRestored
-        || transaction.transactionState == SKPaymentTransactionStatePurchased) {
-      NSDictionary *restored = [self getPurchaseData:transaction];
-      [items addObject:restored];
-      [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
+    NSLog(@"\n\n\n  paymentQueueRestoreCompletedTransactionsFinished  \n\n.");
+    NSMutableArray* items = [NSMutableArray arrayWithCapacity:queue.transactions.count];
+    
+    for(SKPaymentTransaction *transaction in queue.transactions) {
+        if(transaction.transactionState == SKPaymentTransactionStateRestored
+           || transaction.transactionState == SKPaymentTransactionStatePurchased) {
+            NSDictionary *restored = [self getPurchaseData:transaction];
+            [items addObject:restored];
+            [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
+        }
     }
-  }
-
-  [self resolvePromisesForKey:@"availableItems" value:items];
+    
+    [self resolvePromisesForKey:@"availableItems" value:items];
 }
 
 -(void)paymentQueue:(SKPaymentQueue *)queue restoreCompletedTransactionsFailedWithError:(NSError *)error {
-  dispatch_sync(myQueue, ^{
-    [self rejectPromisesForKey:@"availableItems" code:[self standardErrorCode:(int)error.code]
-                       message:error.localizedDescription error:error];
-  });
-  NSLog(@"\n\n\n restoreCompletedTransactionsFailedWithError \n\n.");
+    dispatch_sync(myQueue, ^{
+        [self rejectPromisesForKey:@"availableItems" code:[self standardErrorCode:(int)error.code]
+                           message:error.localizedDescription error:error];
+    });
+    NSLog(@"\n\n\n restoreCompletedTransactionsFailedWithError \n\n.");
 }
 
 -(void)purchaseProcess:(SKPaymentTransaction *)transaction {
-  [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
-  NSURL *receiptUrl = [[NSBundle mainBundle] appStoreReceiptURL];
-  NSDictionary* purchase = [self getPurchaseData:transaction];
-  [self resolvePromisesForKey:RCTKeyForInstance(transaction.payment.productIdentifier) value:purchase];
-
-  // additionally send event
-  if (hasListeners) {
-    [self sendEventWithName:@"iap-purchase-event" body: purchase];
-    [self sendEventWithName:@"purchase-updated" body: purchase];
-  }
+    [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
+    NSURL *receiptUrl = [[NSBundle mainBundle] appStoreReceiptURL];
+    NSDictionary* purchase = [self getPurchaseData:transaction];
+    [self resolvePromisesForKey:RCTKeyForInstance(transaction.payment.productIdentifier) value:purchase];
+    
+    // additionally send event
+    if (hasListeners) {
+        [self sendEventWithName:@"iap-purchase-event" body: purchase];
+        [self sendEventWithName:@"purchase-updated" body: purchase];
+    }
 }
 
 -(NSString *)standardErrorCode:(int)code {
-  NSArray *descriptions = @[
-    @"E_UNKNOWN",
-    @"E_SERVICE_ERROR",
-    @"E_USER_CANCELLED",
-    @"E_USER_ERROR",
-    @"E_USER_ERROR",
-    @"E_ITEM_UNAVAILABLE",
-    @"E_REMOTE_ERROR",
-    @"E_NETWORK_ERROR",
-    @"E_SERVICE_ERROR"
-  ];
-
-  if (code > descriptions.count - 1) {
-    return descriptions[0];
-  }
-  return descriptions[code];
+    NSArray *descriptions = @[
+                              @"E_UNKNOWN",
+                              @"E_SERVICE_ERROR",
+                              @"E_USER_CANCELLED",
+                              @"E_USER_ERROR",
+                              @"E_USER_ERROR",
+                              @"E_ITEM_UNAVAILABLE",
+                              @"E_REMOTE_ERROR",
+                              @"E_NETWORK_ERROR",
+                              @"E_SERVICE_ERROR"
+                              ];
+    
+    if (code > descriptions.count - 1) {
+        return descriptions[0];
+    }
+    return descriptions[code];
 }
 
 -(NSDictionary*)getProductObject:(SKProduct *)product {
-  NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
-  formatter.numberStyle = NSNumberFormatterCurrencyStyle;
-  formatter.locale = product.priceLocale;
-
-  NSString* localizedPrice = [formatter stringFromNumber:product.price];
-  NSString* introductoryPrice = localizedPrice;
-
-  NSString* introductoryPricePaymentMode = @"";
-  NSString* introductoryPriceNumberOfPeriods = @"";
-  NSString* introductoryPriceSubscriptionPeriod = @"";
-
-  NSString* currencyCode = @"";
-  NSString* periodNumberIOS = @"0";
-  NSString* periodUnitIOS = @"";
-
-  NSString* itemType = @"Do not use this. It returned sub only before";
-
-  if (@available(iOS 11.2, *)) {
-    // itemType = product.subscriptionPeriod ? @"sub" : @"iap";
-    unsigned long numOfUnits = (unsigned long) product.subscriptionPeriod.numberOfUnits;
-    SKProductPeriodUnit unit = product.subscriptionPeriod.unit;
-
-    if (unit == SKProductPeriodUnitYear) {
-        periodUnitIOS = @"YEAR";
-    } else if (unit == SKProductPeriodUnitMonth) {
-        periodUnitIOS = @"MONTH";
-    } else if (unit == SKProductPeriodUnitWeek) {
-        periodUnitIOS = @"WEEK";
-    } else if (unit == SKProductPeriodUnitDay) {
-        periodUnitIOS = @"DAY";
+    NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
+    formatter.numberStyle = NSNumberFormatterCurrencyStyle;
+    formatter.locale = product.priceLocale;
+    
+    NSString* localizedPrice = [formatter stringFromNumber:product.price];
+    NSString* introductoryPrice = localizedPrice;
+    
+    NSString* introductoryPricePaymentMode = @"";
+    NSString* introductoryPriceNumberOfPeriods = @"";
+    NSString* introductoryPriceSubscriptionPeriod = @"";
+    
+    NSString* currencyCode = @"";
+    NSString* periodNumberIOS = @"0";
+    NSString* periodUnitIOS = @"";
+    
+    NSString* itemType = @"Do not use this. It returned sub only before";
+    
+    if (@available(iOS 11.2, *)) {
+        // itemType = product.subscriptionPeriod ? @"sub" : @"iap";
+        unsigned long numOfUnits = (unsigned long) product.subscriptionPeriod.numberOfUnits;
+        SKProductPeriodUnit unit = product.subscriptionPeriod.unit;
+        
+        if (unit == SKProductPeriodUnitYear) {
+            periodUnitIOS = @"YEAR";
+        } else if (unit == SKProductPeriodUnitMonth) {
+            periodUnitIOS = @"MONTH";
+        } else if (unit == SKProductPeriodUnitWeek) {
+            periodUnitIOS = @"WEEK";
+        } else if (unit == SKProductPeriodUnitDay) {
+            periodUnitIOS = @"DAY";
+        }
+        
+        periodNumberIOS = [NSString stringWithFormat:@"%lu", numOfUnits];
+        
+        // subscriptionPeriod = product.subscriptionPeriod ? [product.subscriptionPeriod stringValue] : @"";
+        //introductoryPrice = product.introductoryPrice != nil ? [NSString stringWithFormat:@"%@", product.introductoryPrice] : @"";
+        if (product.introductoryPrice != nil) {
+            
+            //SKProductDiscount introductoryPriceObj = product.introductoryPrice;
+            formatter.locale = product.introductoryPrice.priceLocale;
+            introductoryPrice = [formatter stringFromNumber:product.introductoryPrice.price];
+            
+            switch (product.introductoryPrice.paymentMode) {
+                case SKProductDiscountPaymentModeFreeTrial:
+                    introductoryPricePaymentMode = @"FREETRIAL";
+                    introductoryPriceNumberOfPeriods = [@(product.introductoryPrice.subscriptionPeriod.numberOfUnits) stringValue];
+                    break;
+                case SKProductDiscountPaymentModePayAsYouGo:
+                    introductoryPricePaymentMode = @"PAYASYOUGO";
+                    introductoryPriceNumberOfPeriods = [@(product.introductoryPrice.numberOfPeriods) stringValue];
+                    break;
+                case SKProductDiscountPaymentModePayUpFront:
+                    introductoryPricePaymentMode = @"PAYUPFRONT";
+                    introductoryPriceNumberOfPeriods = [@(product.introductoryPrice.subscriptionPeriod.numberOfUnits) stringValue];
+                    break;
+                default:
+                    introductoryPricePaymentMode = @"";
+                    introductoryPriceNumberOfPeriods = @"0";
+                    break;
+            }
+            
+            if (product.introductoryPrice.subscriptionPeriod.unit == SKProductPeriodUnitDay) {
+                introductoryPriceSubscriptionPeriod = @"DAY";
+            } else if (product.introductoryPrice.subscriptionPeriod.unit == SKProductPeriodUnitWeek) {
+                introductoryPriceSubscriptionPeriod = @"WEEK";
+            } else if (product.introductoryPrice.subscriptionPeriod.unit == SKProductPeriodUnitMonth) {
+                introductoryPriceSubscriptionPeriod = @"MONTH";
+            } else if (product.introductoryPrice.subscriptionPeriod.unit == SKProductPeriodUnitYear) {
+                introductoryPriceSubscriptionPeriod = @"YEAR";
+            } else {
+                introductoryPriceSubscriptionPeriod = @"";
+            }
+            
+        } else {
+            introductoryPrice = @"";
+            introductoryPricePaymentMode = @"";
+            introductoryPriceNumberOfPeriods = @"";
+            introductoryPriceSubscriptionPeriod = @"";
+        }
     }
-
-    periodNumberIOS = [NSString stringWithFormat:@"%lu", numOfUnits];
-
-    // subscriptionPeriod = product.subscriptionPeriod ? [product.subscriptionPeriod stringValue] : @"";
-    //introductoryPrice = product.introductoryPrice != nil ? [NSString stringWithFormat:@"%@", product.introductoryPrice] : @"";
-    if (product.introductoryPrice != nil) {
-
-      //SKProductDiscount introductoryPriceObj = product.introductoryPrice;
-      formatter.locale = product.introductoryPrice.priceLocale;
-      introductoryPrice = [formatter stringFromNumber:product.introductoryPrice.price];
-
-      switch (product.introductoryPrice.paymentMode) {
-        case SKProductDiscountPaymentModeFreeTrial:
-          introductoryPricePaymentMode = @"FREETRIAL";
-          introductoryPriceNumberOfPeriods = [@(product.introductoryPrice.subscriptionPeriod.numberOfUnits) stringValue];
-          break;
-        case SKProductDiscountPaymentModePayAsYouGo:
-          introductoryPricePaymentMode = @"PAYASYOUGO";
-          introductoryPriceNumberOfPeriods = [@(product.introductoryPrice.numberOfPeriods) stringValue];
-          break;
-        case SKProductDiscountPaymentModePayUpFront:
-          introductoryPricePaymentMode = @"PAYUPFRONT";
-          introductoryPriceNumberOfPeriods = [@(product.introductoryPrice.subscriptionPeriod.numberOfUnits) stringValue];
-          break;
-        default:
-          introductoryPricePaymentMode = @"";
-          introductoryPriceNumberOfPeriods = @"0";
-          break;
-      }
-
-      if (product.introductoryPrice.subscriptionPeriod.unit == SKProductPeriodUnitDay) {
-        introductoryPriceSubscriptionPeriod = @"DAY";
-      }	else if (product.introductoryPrice.subscriptionPeriod.unit == SKProductPeriodUnitWeek) {
-        introductoryPriceSubscriptionPeriod = @"WEEK";
-      }	else if (product.introductoryPrice.subscriptionPeriod.unit == SKProductPeriodUnitMonth) {
-        introductoryPriceSubscriptionPeriod = @"MONTH";
-      } else if (product.introductoryPrice.subscriptionPeriod.unit == SKProductPeriodUnitYear) {
-        introductoryPriceSubscriptionPeriod = @"YEAR";
-      } else {
-        introductoryPriceSubscriptionPeriod = @"";
-      }
-
-    } else {
-      introductoryPrice = @"";
-      introductoryPricePaymentMode = @"";
-      introductoryPriceNumberOfPeriods = @"";
-      introductoryPriceSubscriptionPeriod = @"";
+    
+    if (@available(iOS 10.0, *)) {
+        currencyCode = product.priceLocale.currencyCode;
     }
-  }
-
-  if (@available(iOS 10.0, *)) {
-    currencyCode = product.priceLocale.currencyCode;
-  }
-
-  NSArray *discounts;
-  if (@available(iOS 12.2, *)) {
-    discounts = [self getDiscountData:[product.discounts copy]];
-  }
-
-  NSDictionary *obj = [NSDictionary dictionaryWithObjectsAndKeys:
-     product.productIdentifier, @"productId",
-     [product.price stringValue], @"price",
-     currencyCode, @"currency",
-     itemType, @"type",
-     product.localizedTitle ? product.localizedTitle : @"", @"title",
-     product.localizedDescription ? product.localizedDescription : @"", @"description",
-     localizedPrice, @"localizedPrice",
-     periodNumberIOS, @"subscriptionPeriodNumberIOS",
-     periodUnitIOS, @"subscriptionPeriodUnitIOS",
-     introductoryPrice, @"introductoryPrice",
-     introductoryPricePaymentMode, @"introductoryPricePaymentModeIOS",
-     introductoryPriceNumberOfPeriods, @"introductoryPriceNumberOfPeriodsIOS",
-     introductoryPriceSubscriptionPeriod, @"introductoryPriceSubscriptionPeriodIOS",
-     discounts, @"discounts",
-     nil
-  ];
-
-  return obj;
+    
+    NSArray *discounts;
+    if (@available(iOS 12.2, *)) {
+        discounts = [self getDiscountData:[product.discounts copy]];
+    }
+    
+    NSDictionary *obj = [NSDictionary dictionaryWithObjectsAndKeys:
+                         product.productIdentifier, @"productId",
+                         [product.price stringValue], @"price",
+                         currencyCode, @"currency",
+                         itemType, @"type",
+                         product.localizedTitle ? product.localizedTitle : @"", @"title",
+                         product.localizedDescription ? product.localizedDescription : @"", @"description",
+                         localizedPrice, @"localizedPrice",
+                         periodNumberIOS, @"subscriptionPeriodNumberIOS",
+                         periodUnitIOS, @"subscriptionPeriodUnitIOS",
+                         introductoryPrice, @"introductoryPrice",
+                         introductoryPricePaymentMode, @"introductoryPricePaymentModeIOS",
+                         introductoryPriceNumberOfPeriods, @"introductoryPriceNumberOfPeriodsIOS",
+                         introductoryPriceSubscriptionPeriod, @"introductoryPriceSubscriptionPeriodIOS",
+                         discounts, @"discounts",
+                         nil
+                         ];
+    
+    return obj;
 }
 
 - (NSMutableArray *)getDiscountData:(NSArray *)discounts {
-  NSMutableArray *mappedDiscounts = [NSMutableArray arrayWithCapacity:[discounts count]];
-  NSString *localizedPrice;
-  NSString *paymendMode;
-  NSString *subscriptionPeriods;
-  NSString *discountType;
+    NSMutableArray *mappedDiscounts = [NSMutableArray arrayWithCapacity:[discounts count]];
+    NSString *localizedPrice;
+    NSString *paymendMode;
+    NSString *subscriptionPeriods;
+    NSString *discountType;
+    
+    if (@available(iOS 11.2, *)) {
+        for(SKProductDiscount *discount in discounts) {
+            NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
+            formatter.numberStyle = NSNumberFormatterCurrencyStyle;
+            formatter.locale = discount.priceLocale;
+            localizedPrice = [formatter stringFromNumber:discount.price];
+            NSString *numberOfPeriods;
+            
+            switch (discount.paymentMode) {
+                case SKProductDiscountPaymentModeFreeTrial:
+                    paymendMode = @"FREETRIAL";
+                    numberOfPeriods = [@(discount.subscriptionPeriod.numberOfUnits) stringValue];
+                    break;
+                case SKProductDiscountPaymentModePayAsYouGo:
+                    paymendMode = @"PAYASYOUGO";
+                    numberOfPeriods = [@(discount.numberOfPeriods) stringValue];
+                    break;
+                case SKProductDiscountPaymentModePayUpFront:
+                    paymendMode = @"PAYUPFRONT";
+                    numberOfPeriods = [@(discount.subscriptionPeriod.numberOfUnits) stringValue];
+                    break;
+                default:
+                    paymendMode = @"";
+                    numberOfPeriods = @"0";
+                    break;
+            }
+            
+            switch (discount.subscriptionPeriod.unit) {
+                case SKProductPeriodUnitDay:
+                    subscriptionPeriods = @"DAY";
+                    break;
+                case SKProductPeriodUnitWeek:
+                    subscriptionPeriods = @"WEEK";
+                    break;
+                case SKProductPeriodUnitMonth:
+                    subscriptionPeriods = @"MONTH";
+                    break;
+                case SKProductPeriodUnitYear:
+                    subscriptionPeriods = @"YEAR";
+                    break;
+                default:
+                    subscriptionPeriods = @"";
+            }
 
-  if (@available(iOS 11.2, *)) {
-    for(SKProductDiscount *discount in discounts) {
-      NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
-      formatter.numberStyle = NSNumberFormatterCurrencyStyle;
-      formatter.locale = discount.priceLocale;
-      localizedPrice = [formatter stringFromNumber:discount.price];
-      NSString *numberOfPeriods;
-      
-      switch (discount.paymentMode) {
-        case SKProductDiscountPaymentModeFreeTrial:
-          paymendMode = @"FREETRIAL";
-          numberOfPeriods = [@(discount.subscriptionPeriod.numberOfUnits) stringValue];
-          break;
-        case SKProductDiscountPaymentModePayAsYouGo:
-          paymendMode = @"PAYASYOUGO";
-          numberOfPeriods = [@(discount.numberOfPeriods) stringValue];
-          break;
-        case SKProductDiscountPaymentModePayUpFront:
-          paymendMode = @"PAYUPFRONT";
-          numberOfPeriods = [@(discount.subscriptionPeriod.numberOfUnits) stringValue];
-          break;
-        default:
-          paymendMode = @"";
-          numberOfPeriods = @"0";
-          break;
-      }
-      
-      switch (discount.subscriptionPeriod.unit) {
-        case SKProductPeriodUnitDay:
-          subscriptionPeriods = @"DAY";
-          break;
-        case SKProductPeriodUnitWeek:
-          subscriptionPeriods = @"WEEK";
-          break;
-        case SKProductPeriodUnitMonth:
-          subscriptionPeriods = @"MONTH";
-          break;
-        case SKProductPeriodUnitYear:
-          subscriptionPeriods = @"YEAR";
-          break;
-        default:
-          subscriptionPeriods = @"";
-      }
+            
+            NSString* discountIdentifier = @"";
+            if (@available(iOS 12.2, *)) {
+                discountIdentifier = discount.identifier;
+                switch (discount.type) {
+                    case SKProductDiscountTypeIntroductory:
+                        discountType = @"INTRODUCTORY";
+                        break;
+                    case SKProductDiscountTypeSubscription:
+                        discountType = @"SUBSCRIPTION";
+                        break;
+                    default:
+                        discountType = @"";
+                        break;
+                }
+                
+            }
 
-      switch (discount.type) {
-        case SKProductDiscountTypeIntroductory:
-          discountType = @"INTRODUCTORY";
-          break;
-        case SKProductDiscountTypeSubscription:
-          discountType = @"SUBSCRIPTION";
-          break;
-        default:
-          discountType = @"";
-          break;
-      }
-
-      [mappedDiscounts addObject:[NSDictionary dictionaryWithObjectsAndKeys:
-        discount.identifier, @"identifier",
-        discountType, @"type",
-        numberOfPeriods, @"numberOfPeriods",
-        discount.price, @"price",
-        localizedPrice, @"localizedPrice",
-        paymendMode, @"paymentMode",
-        subscriptionPeriods, @"subscriptionPeriod",
-        nil
-      ]];
+            [mappedDiscounts addObject:[NSDictionary dictionaryWithObjectsAndKeys:
+                                        discountIdentifier, @"identifier",
+                                        discountType, @"type",
+                                        numberOfPeriods, @"numberOfPeriods",
+                                        discount.price, @"price",
+                                        localizedPrice, @"localizedPrice",
+                                        paymendMode, @"paymentMode",
+                                        subscriptionPeriods, @"subscriptionPeriod",
+                                        nil
+                                        ]];
+        }
     }
-  }
-
-  return mappedDiscounts;
+    
+    return mappedDiscounts;
 }
 
 - (NSDictionary *)getPurchaseData:(SKPaymentTransaction *)transaction {
-  NSData *receiptData;
-  if (NSFoundationVersionNumber >= NSFoundationVersionNumber_iOS_7_0) {
-    receiptData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] appStoreReceiptURL]];
-  } else {
-    receiptData = [transaction transactionReceipt];
-  }
-
-  if (receiptData == nil) return nil;
-
-  NSMutableDictionary *purchase = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-      @(transaction.transactionDate.timeIntervalSince1970 * 1000), @"transactionDate",
-      transaction.transactionIdentifier, @"transactionId",
-      transaction.payment.productIdentifier, @"productId",
-      [receiptData base64EncodedStringWithOptions:0], @"transactionReceipt",
-      nil
-  ];
-
-  // NSMutableDictionary *purchase = [NSMutableDictionary dictionaryWithDictionary: @{
-  //   @"transactionDate": @(transaction.transactionDate.timeIntervalSince1970 * 1000),
-  //   @"transactionId": transaction.transactionIdentifier,
-  //   @"productId": transaction.payment.productIdentifier,
-  //   @"transactionReceipt":[receiptData base64EncodedStringWithOptions:0],
-  // }];
-
-  // originalTransaction is available for restore purchase and purchase of cancelled/expired subscriptions
-  SKPaymentTransaction *originalTransaction = transaction.originalTransaction;
-  if (originalTransaction) {
-    purchase[@"originalTransactionDateIOS"] = @(originalTransaction.transactionDate.timeIntervalSince1970 * 1000);
-    purchase[@"originalTransactionIdentifierIOS"] = originalTransaction.transactionIdentifier;
-  }
-
-  return purchase;
+    NSData *receiptData;
+    if (NSFoundationVersionNumber >= NSFoundationVersionNumber_iOS_7_0) {
+        receiptData = [NSData dataWithContentsOfURL:[[NSBundle mainBundle] appStoreReceiptURL]];
+    } else {
+        receiptData = [transaction transactionReceipt];
+    }
+    
+    if (receiptData == nil) return nil;
+    
+    NSMutableDictionary *purchase = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                     @(transaction.transactionDate.timeIntervalSince1970 * 1000), @"transactionDate",
+                                     transaction.transactionIdentifier, @"transactionId",
+                                     transaction.payment.productIdentifier, @"productId",
+                                     [receiptData base64EncodedStringWithOptions:0], @"transactionReceipt",
+                                     nil
+                                     ];
+    
+    // NSMutableDictionary *purchase = [NSMutableDictionary dictionaryWithDictionary: @{
+    //   @"transactionDate": @(transaction.transactionDate.timeIntervalSince1970 * 1000),
+    //   @"transactionId": transaction.transactionIdentifier,
+    //   @"productId": transaction.payment.productIdentifier,
+    //   @"transactionReceipt":[receiptData base64EncodedStringWithOptions:0],
+    // }];
+    
+    // originalTransaction is available for restore purchase and purchase of cancelled/expired subscriptions
+    SKPaymentTransaction *originalTransaction = transaction.originalTransaction;
+    if (originalTransaction) {
+        purchase[@"originalTransactionDateIOS"] = @(originalTransaction.transactionDate.timeIntervalSince1970 * 1000);
+        purchase[@"originalTransactionIdentifierIOS"] = originalTransaction.transactionIdentifier;
+    }
+    
+    return purchase;
 }
 
 static NSString *RCTKeyForInstance(id instance)


### PR DESCRIPTION
- ios warning fixed.
- typings added.

Fixes #511

```
purchaseUpdateSubscription = purchaseUpdatedListener((purchase: ProductPurchase) => {
  console.log('purchaseUpdatedListener', purchase);
  this.setState({ receipt: purchase.transactionReceipt }, () => this.goNext());
});

purchaseErrorSubscription = purchaseErrorListener((error: PurchaseError) => {
  console.log('purchaseErrorListener', error);
  Alert.alert('purchase error', JSON.stringify(error));
});
```