### PR TITLE
Improved handling of receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 | consumeAllItemsAndroid | | `Promise<void>` | Consume all items in android so they are able to buy again (on Android.) No-op on iOS. |
 | validateReceiptIos | `object` receiptBody, `boolean` isTest | `object or boolean` result | validate receipt for ios. |
 | validateReceiptAndroid | `string` packageName, `string` productId, `string` productToken, `string` accessToken, `boolean` isSubscription | `object or boolean` result | validate receipt for android. |
+| requestReceiptIOS |  | `Promise<string>` | Get the current receipt (on iOS.) No-op on Android. |
 
 ## Npm repo
 https://www.npmjs.com/package/react-native-iap
@@ -276,6 +277,8 @@ const result = await RNIap.validateReceiptIos(receiptBody, false);
 console.log(result);
 ```
 For further information, please refer to [guide](https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html).
+
+Sometimes you will need to get the receipt at times other than after purchase. For example, when a user needs to ask for permission to buy a product (`Ask to buy` flow) or unstable internet connections. For these cases we have a convenience method `requestReceiptIOS` which gets the latest receipt for the app at any given time. The response is base64 encoded.
 
 ### iOS Purchasing process right way.
 Issue regarding `valid products`

--- a/index.d.ts
+++ b/index.d.ts
@@ -233,3 +233,9 @@ export function purchaseUpdatedListener(fn: Function) : EmitterSubscription;
  * @returns {callback(e: PurchaseError)}
  */
 export function purchaseErrorListener(fn: Function) : EmitterSubscription;
+
+/**
+ * Request current receipt base64 encoded (IOS only)
+ * @returns {Promise<string>}
+ */
+export function requestReceiptIOS(): Promise<string>;

--- a/index.js
+++ b/index.js
@@ -432,6 +432,17 @@ export const purchaseErrorListener = (e) => {
 };
 
 /**
+ * Get the current receipt base64 encoded in IOS.
+ * @returns {Promise<string>}
+ */
+export const requestReceiptIOS = () => {
+  if (Platform.OS === 'ios') {
+    checkNativeiOSAvailable();
+    return RNIapIos.requestReceipt();
+  }
+};
+
+/**
  * deprecated codes
  */
 /*
@@ -486,4 +497,6 @@ export default {
   requestPurchaseWithQuantityIOS,
   requestSubscription,
   purchaseUpdatedListener,
+  purchaseErrorListener,
+  requestReceiptIOS,
 };


### PR DESCRIPTION
We noticed obtaining the App receipt isn’t as straightforward as we thought. 

NSBundle.mainBundle().appStoreReceiptURL returns an NSURL describing the path behind which the receipt can be found, if there is one!

To quote the documentation: (https://developer.apple.com/documentation/foundation/nsbundle/1407276-appstorereceipturl)

For an application purchased from the App Store, call this method on its application bundle locate the receipt. This method makes no guarantee about whether there is a file at the returned URL — **only that if a receipt is present, that is its location.**

In such a case, you have to start a SKReceiptRefreshRequest. This tries to download a receipt and saves it in the known destination if everything succeeds.

Obviously the process must be asynchronous now.

On top fo this, we fixed a couple of minor issues with v3.0.0 and added a new method to request the receipt in iOS whenever it's needed. 