### PR TITLE
Remove deprecated annotation on requestSubscription method in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -141,7 +141,6 @@ export function buySubscription(sku: string, oldSku?: string, prorationMode?: nu
 /**
  * Request a subscription to a sku
  * 
- * @deprecated
  * @param {string} sku The product's sku/ID
  * @param {string} [oldSku] Optional old product's ID for upgrade/downgrade (Android only)
  * @param {number} [prorationMode] Optional proration mode for upgrade/downgrade (Android only)


### PR DESCRIPTION
In README.md, seems to it is not deprecated at `requestSubscription`.
But index.d.ts, `requestSubscription` is marked as @deprecated.

This PR remove deprecated annotation on `requestSubscription` method.

(If this method is deprecated definitedly, please close this PR and tell me alternative method ;-) )