### PR TITLE
fixed typo in TypeScript definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -229,7 +229,7 @@ export function addAdditionalSuccessPurchaseListenerIOS(fn: Function) : EmitterS
 export function purchaseUpdatedListener(fn: Function) : EmitterSubscription;
 
 /**
- * Subscribe a listener when purchase is updated.
+ * Subscribe a listener when purchase got error.
  * @returns {callback(e: PurchaseError)}
  */
-export function purchaseUpdatedListener(fn: Function) : EmitterSubscription;
+export function purchaseErrorListener(fn: Function) : EmitterSubscription;


### PR DESCRIPTION
There was no  `purchaseErrorListener` defined and `purchaseUpdatedListener` was added twice.