### PR TITLE
Updated method name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,10 @@ async componentDidMount() {
 |`freeTrialPeriodAndroid`|  | ✓ | Trial period configured in Google Play Console, specified in ISO 8601 format. For example, P7D equates to seven days. |
 
 ## End Billing Connection
-When you are done with the billing, you should release it for android([READ](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.html#endConnection())). It is not needed in ios. No need to check platform either since nothing will happen in ios. This can be used in `componentWillUnMount`.
+When you are done with the billing, you should release it for android([READ](https://developer.android.com/reference/com/android/billingclient/api/BillingClient.html#endConnectionAndroid())). It is not needed in ios. No need to check platform either since nothing will happen in ios. This can be used in `componentWillUnMount`.
 ```javascript
 componentWillUnmount() {
-  RNIap.endConnection();
+  RNIap.endConnectionAndroid();
 }
 ```
 


### PR DESCRIPTION
`endConnection()` no longer exists on this package, the function is now called `endConnectionAndroid()`. This change updates the name of the method in the docs.