### PR TITLE
Make ensureConnection always provide a valid BillingClient

### DIFF
--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -114,7 +114,7 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
     };
 
     try {
-      billingClient = BillingClient.newBuilder(reactContext).setListener(this).build();
+      billingClient = BillingClient.newBuilder(reactContext).enablePendingPurchases().setListener(this).build();
       billingClient.startConnection(billingClientStateListener);
     } catch (Exception e) {
       promise.reject(DoobooUtils.E_NOT_PREPARED, e.getMessage(), e);


### PR DESCRIPTION
If enablePendingPurchases() is not called, trying to buy a Product on the connection will fail.