### PR TITLE
3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   + Update `podspec` to match the version.
   + Improved handling of receipts [#521](https://github.com/dooboolab/react-native-iap/pull/521)
   + Fixes for [#530](https://github.com/dooboolab/react-native-iap/issues/530)
+  + Make ensureConnection always provide a valid BillingClient [#539](https://github.com/dooboolab/react-native-iap/pull/539)
 - **[2.5.+]**
   + Fix flow type [#482](https://github.com/dooboolab/react-native-iap/pull/482)
   + Ugrade gradle to `3.2.1` [#488](https://github.com/dooboolab/react-native-iap/pull/488)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Changelogs
-- **[3.0.+]**
+- **[3.0.0]**
   + Major migration and breaking changes done in [#510](https://github.com/dooboolab/react-native-iap/pull/510)
   + Fixes crashing when `requestPurchase` in android [#512](https://github.com/dooboolab/react-native-iap/issues/512)
   + Fix minor typing [#514](https://github.com/dooboolab/react-native-iap/issues/514)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iap",
-  "version": "3.0.0-rc.16",
+  "version": "3.0.0",
   "description": "React Native In App Purchase Module.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
  + Major migration and breaking changes done in [#510](https://github.com/dooboolab/react-native-iap/pull/510)
  + Fixes crashing when `requestPurchase` in android [#512](https://github.com/dooboolab/react-native-iap/issues/512)
  + Fix minor typing [#514](https://github.com/dooboolab/react-native-iap/issues/514)
  + Add purchaseErrorListner to subscribe purchase error. `ios` warning fixed. Typings added. [#517](https://github.com/dooboolab/react-native-iap/issues/517)
  + Resolve [#315](https://github.com/dooboolab/react-native-iap/issues/315) by safely wrap promises with `ObjectAlreadyConsumedException`.
  + Fixed typo in `purchaseErrorListener`.
  + Fixed missing import for `ObjectAlreadyConsumedException`.
  + Update `podspec` to match the version.
  + Improved handling of receipts [#521](https://github.com/dooboolab/react-native-iap/pull/521)
  + Fixes for [#530](https://github.com/dooboolab/react-native-iap/issues/530)
  + Make ensureConnection always provide a valid BillingClient [#539](https://github.com/dooboolab/react-native-iap/pull/539)