### PR TITLE
3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Changelogs
+- **[3.1.2]**
+  + Remove `getOrderId` from PurchaseHistory [#554](https://github.com/dooboolab/react-native-iap/pull/554)
 - **[3.1.1]**
   + Fix transanctionId in `onPurchaseUpdated` in `android` [#552](https://github.com/dooboolab/react-native-iap/pull/552)
 - **[3.1.0]**

--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -319,7 +319,6 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
             for (PurchaseHistoryRecord purchase : purchaseHistoryRecordList) {
               WritableMap item = Arguments.createMap();
               item.putString("productId", purchase.getSku());
-              item.putString("transactionId", purchase.getOrderId());
               item.putString("transactionDate", String.valueOf(purchase.getPurchaseTime()));
               item.putString("transactionReceipt", purchase.getOriginalJson());
               item.putString("purchaseToken", purchase.getPurchaseToken());

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,7 +35,7 @@ export interface Subscription<ID extends string> extends Common {
 
 export interface ProductPurchase {
   productId: string;
-  transactionId: string;
+  transactionId?: string;
   transactionDate: number;
   transactionReceipt: string;
   signatureAndroid?: string;

--- a/index.js.flow
+++ b/index.js.flow
@@ -35,7 +35,7 @@ export type Subscription<ID> = Common & {
 
 export type ProductPurchase = {|
   productId: string,
-  transactionId: string,
+  transactionId?: string,
   transactionDate: number,
   transactionReceipt: string,
   signatureAndroid?: string,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iap",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "React Native In App Purchase Module.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
- Update `ProductPurchase` type to optional.
- Remove getOrderId from PurchaseHistory
- Update package version


Co-Authored by @rborn 