### PR TITLE
Keep valid SKUs in memory

### DIFF
--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -76,6 +76,7 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
   public RNIapModule(ReactApplicationContext reactContext) {
     super(reactContext);
     this.reactContext = reactContext;
+    this.skus = new ArrayList<SkuDetails>();
     reactContext.addLifecycleEventListener(lifecycleEventListener);
   }
 
@@ -234,7 +235,11 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
               return;
             }
 
-            skus = skuDetailsList;
+            for (SkuDetails sku : skuDetailsList) {
+              if (!skus.contains(sku)) {
+                skus.add(sku);
+              }
+            }
             WritableNativeArray items = new WritableNativeArray();
 
             for (SkuDetails skuDetails : skuDetailsList) {


### PR DESCRIPTION
I get an error when trying to purchase a product after calling `getSubscriptions(subSkus)` and `getProducts(productSkus)`, like so:

```
const subscriptions = await RNIap.getSubscriptions(subscriptionIds);
const products = await RNIap.getProducts(productIds);
```

This seems to be because both call `RNIapModule.getItemsByType()`, which replaces the internal SKUs cache. The only way to get it to work without making this change is to call the `getProducts()` or `getSubscriptions()` before trying to purchase.