### PR TITLE
Check billingClient before invoking callback

### DIFF
--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -99,7 +99,9 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
         if (!bSetupCallbackConsumed) {
           bSetupCallbackConsumed = true;
           if (billingResult.getResponseCode() == BillingClient.BillingResponseCode.OK ) {
-            callback.run();
+            if (billingClient != null && billingClient.isReady()) {
+              callback.run();
+            }
           } else {
             WritableMap error = Arguments.createMap();
             error.putInt("responseCode", billingResult.getResponseCode());


### PR DESCRIPTION
This fixes the case when onHostDetroy is invoked before onBillingSetupFinished, leading to a NPE in the callback (https://github.com/dooboolab/react-native-iap/issues/606)