### PR TITLE
Avoid looping on a null purchases list

### DIFF
--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -284,6 +284,9 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
         final WritableNativeArray items = new WritableNativeArray();
         Purchase.PurchasesResult result = billingClient.queryPurchases(type.equals("subs") ? BillingClient.SkuType.SUBS : BillingClient.SkuType.INAPP);
         final List<Purchase> purchases = result.getPurchasesList();
+        if (purchases == null) {
+          return;
+        }
 
         for (Purchase purchase : purchases) {
           WritableNativeMap item = new WritableNativeMap();


### PR DESCRIPTION
Lately we have been getting a large number of crashes when no purchases are received when calling `getPurchasesList`. This small change ensures looping only happens if a list of purchases is received