### PR TITLE
fix: make it build with older XCode

### DIFF
--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -180,6 +180,7 @@ RCT_EXPORT_METHOD(buyProductWithOffer:(NSString*)sku
     }
     if (product) {
         payment = [SKMutablePayment paymentWithProduct:product];
+        #if __IPHONE_12_2
         if (@available(iOS 12.2, *)) {
             SKPaymentDiscount *discount = [[SKPaymentDiscount alloc]
                                            initWithIdentifier:discountOffer[@"identifier"]
@@ -190,6 +191,7 @@ RCT_EXPORT_METHOD(buyProductWithOffer:(NSString*)sku
                                            ];
             payment.paymentDiscount = discount;
         }
+        #endif
         payment.applicationUsername = usernameHash;
         [[SKPaymentQueue defaultQueue] addPayment:payment];
         [self addPromiseForKey:RCTKeyForInstance(payment.productIdentifier) resolve:resolve reject:reject];
@@ -567,9 +569,11 @@ RCT_EXPORT_METHOD(finishTransaction:(NSString*)transactionIdentifier) {
     }
     
     NSArray *discounts;
+    #if __IPHONE_12_2
     if (@available(iOS 12.2, *)) {
         discounts = [self getDiscountData:[product.discounts copy]];
     }
+    #endif
     
     NSDictionary *obj = [NSDictionary dictionaryWithObjectsAndKeys:
                          product.productIdentifier, @"productId",
@@ -645,6 +649,7 @@ RCT_EXPORT_METHOD(finishTransaction:(NSString*)transactionIdentifier) {
             
             
             NSString* discountIdentifier = @"";
+            #if __IPHONE_12_2
             if (@available(iOS 12.2, *)) {
                 discountIdentifier = discount.identifier;
                 switch (discount.type) {
@@ -660,6 +665,7 @@ RCT_EXPORT_METHOD(finishTransaction:(NSString*)transactionIdentifier) {
                 }
                 
             }
+            #endif
             
             [mappedDiscounts addObject:[NSDictionary dictionaryWithObjectsAndKeys:
                                         discountIdentifier, @"identifier",


### PR DESCRIPTION
This PR makes it possible to use this module while building projects in older XCode versions [issue](https://github.com/dooboolab/react-native-iap/issues/577)

With this change I was able to build project with XCode 10.1 and with XCode 10.3