### PR TITLE
fix(getSubscriptions) : iOS return subs properly

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ export const getSubscriptions = (skus) => Platform.select({
   ios: async() => {
     checkNativeiOSAvailable();
     return RNIapIos.getItems(skus)
-      .then((items) => items.filter((item) => item.productId));
+      .then((items) => items.filter((item) => skus.includes(item.productId)));
   },
   android: async() => {
     checkNativeAndroidAvailable();


### PR DESCRIPTION
## Description

iOS getSubscriptions return subscriptions that only received ids

- - - -
## Problem

### Code
```js
const A = await RNIap.getSubscriptions(['01.month.subscription']);
console.log('A',A);
const B = await RNIap.getSubscriptions(['01.month.subscription','03.month.subscription']);
console.log('B',B);
const C = await RNIap.getSubscriptions(['01.month.subscription','03.month.subscription','12.month.subscription']);
console.log('C',C);
const D = await RNIap.getSubscriptions(['01.month.subscription','03.month.subscription']);
console.log('D',D);
const E = await RNIap.getSubscriptions(['01.month.subscription']);
console.log('E',E);
```

### Expected behavior
```
A [{..}]
B [{..},{..}]
C [{..},{..},{..}]
D [{..},{..},]
E [{..}]
```

### Actual behavior
```
A [{..}]
B [{..},{..}]
C [{..},{..},{..}]
D [{..},{..},{..}]
E [{..},{..},{..}]
```

- - - - -
## Result
### Before(Android)
![image](https://user-images.githubusercontent.com/26326015/63318741-7178fd80-c352-11e9-98dc-72160e888c5b.png)

### Before(iOS)
![image](https://user-images.githubusercontent.com/26326015/63317842-4b9e2980-c34f-11e9-9164-f0b970a460e2.png)

### After(iOS)
![image](https://user-images.githubusercontent.com/26326015/63317768-0b3eab80-c34f-11e9-9aef-12fbf647c6f9.png)
