### PR TITLE
method to retrieve pending transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ _*deprecated_<br>~~`buySubscription(sku: string)`~~<ul><li>sku: subscription ID/
 `clearTransactionIOS()` | `void`            | **iOS only**<br>Clear up the unfinished transanction which sometimes causes problem.<br>Read more in below README.
 `clearProductsIOS()`    | `void`            | **iOS only**<br>Clear all products and subscriptions.<br>Read more in below README.
 `requestReceiptIOS()`   | `Promise<string>` | **iOS only**<br>Get the current receipt.
+`requestPendingPurchasesIOS()` | `Promise<ProductPurchase[]>` | **IOS only**<br>Gets all the transactions which are pending to be finished.
 `validateReceiptIos(body: Object, devMode: boolean)`<ul><li>body: receiptBody</li><li>devMode: isTest</li></ul> | `Object\|boolean` | **iOS only**<br>Validate receipt.
 `endConnectionAndroid()`   | `Promise<void>` | **Android only**<br>End billing connection.
 `consumeAllItemsAndroid()` | `Promise<void>` | **Android only**<br>Consume all items so they are able to buy again.
@@ -125,6 +126,7 @@ _*deprecated_<br>~~`buySubscription(sku: string)`~~<ul><li>sku: subscription ID/
 _*deprecated_<br>~~`buySubscription(sku: string, prevSku?: string, mode?: number)`~~<ul><li>sku: subscription ID/sku</li><li>prevSku: old subscription ID/sku (optional)</li><li>mode: proration mode (optional)</li></ul> | `Promise<Purchase>` | **Android only**<br>Create (buy) a subscription to a sku.<br>For upgrading/downgrading subscription on Android pass the second parameter with current subscription ID, on iOS this is handled automatically by store.<br>You can also optionally pass in a proration mode integer for upgrading/downgrading subscriptions on Android
 `requestSubscription(sku: string, prevSku?: string, mode?: number)`<ul><li>sku: subscription ID/sku</li><li>prevSku: old subscription ID/sku (optional)</li><li>mode: proration mode (optional)</li></ul>                  | `Promise<string>`   | **Android only**<br>Create (buy) a subscription to a sku.<br>For upgrading/downgrading subscription on Android pass the second parameter with current subscription ID, on iOS this is handled automatically by store.<br>You can also optionally pass in a proration mode integer for upgrading/downgrading subscriptions on Android
 `validateReceiptAndroid(bundleId: string, productId: string, productToken: string, accessToken: string)`<br><ul><li>bundleId: the packageName</li><li>productId: productId</li><li>productToken: productToken</li><li>accessToken: accessToken</li><li>isSubscription: isSubscription</li></ul> | `Object\|boolean` | **Android only**<br>Validate receipt.
+
 
 </details>
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -269,3 +269,10 @@ export function purchaseErrorListener(fn: Function) : EmitterSubscription;
  * @returns {Promise<string>}
  */
 export function requestReceiptIOS(): Promise<string>;
+
+/**
+ * Request all the pending transactions (IOS only)
+ * @returns {Promise<ProductPurchase[]>}
+ */
+export function requestPendingPurchasesIOS(): Promise<ProductPurchase[]>;
+

--- a/index.d.ts
+++ b/index.d.ts
@@ -274,5 +274,5 @@ export function requestReceiptIOS(): Promise<string>;
  * Request all the pending transactions (IOS only)
  * @returns {Promise<ProductPurchase[]>}
  */
-export function requestPendingPurchasesIOS(): Promise<ProductPurchase[]>;
+export function getPendingPurchasesIOS(): Promise<ProductPurchase[]>;
 

--- a/index.js
+++ b/index.js
@@ -484,7 +484,7 @@ export const requestReceiptIOS = () => {
  * Get the pending purchases in IOS.
  * @returns {Promise<ProductPurchase[]>}
  */
-export const requestPendingPurchasesIOS = () => {
+export const getPendingPurchasesIOS = () => {
   if (Platform.OS === 'ios') {
     checkNativeiOSAvailable();
     return RNIapIos.getPendingTransactions();
@@ -532,6 +532,7 @@ export default {
   getSubscriptions,
   getPurchaseHistory,
   getAvailablePurchases,
+  getPendingPurchasesIOS,
   consumeAllItemsAndroid,
   buySubscription,
   buyProduct,

--- a/index.js
+++ b/index.js
@@ -481,6 +481,17 @@ export const requestReceiptIOS = () => {
 };
 
 /**
+ * Get the pending purchases in IOS.
+ * @returns {Promise<ProductPurchase[]>}
+ */
+export const requestPendingPurchasesIOS = () => {
+  if (Platform.OS === 'ios') {
+    checkNativeiOSAvailable();
+    return RNIapIos.getPendingTransactions();
+  }
+};
+
+/**
  * deprecated codes
  */
 /*

--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -318,6 +318,32 @@ RCT_EXPORT_METHOD(finishTransaction:(NSString*)transactionIdentifier) {
     [self finishTransactionWithIdentifier:transactionIdentifier];
 }
 
+RCT_EXPORT_METHOD(getPendingTransactions:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    [self requestReceiptDataWithBlock:^(NSData *receiptData, NSError *error) {
+        if (receiptData == nil) {
+            resolve(nil);
+        }
+        else {
+            NSArray<SKPaymentTransaction *> *transactions = [[SKPaymentQueue defaultQueue] transactions];
+            NSMutableArray *output = [NSMutableArray array];
+            
+            for (SKPaymentTransaction *item in transactions) {
+                NSMutableDictionary *purchase = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                                 @(item.transactionDate.timeIntervalSince1970 * 1000), @"transactionDate",
+                                                 item.transactionIdentifier, @"transactionId",
+                                                 item.payment.productIdentifier, @"productId",
+                                                 [receiptData base64EncodedStringWithOptions:0], @"transactionReceipt",
+                                                 nil
+                                                 ];
+                [output addObject:purchase];
+            }
+            
+            resolve(output);
+        }
+    }];
+}
+
 #pragma mark ===== StoreKit Delegate
 
 -(void)productsRequest:(SKProductsRequest *)request didReceiveResponse:(SKProductsResponse *)response {


### PR DESCRIPTION
We are having several customers complaining about their purchases not to be confirmed even though they are payed. We identify this might happen when something wrong happens between finishing the payment in the appstore and confirming the purchase. That's why we came with this method: it retrieves the pending transactions (those who are payed but not yet finished), so they can be processed and finished once the user receives his products. This can be very useful as a complement to a 'Restore Purchases' button, which can be pressed when the user has issues with his purchases.