### PR TITLE
Fixed missing item.putBoolean for autoRenewingAndroid key

### DIFF
--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -290,7 +290,9 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
           item.putString("signatureAndroid", purchase.getSignature());
           item.putInt("purchaseStateAndroid", purchase.getPurchaseState());
 
-          if (type.equals(BillingClient.SkuType.SUBS)) purchase.isAutoRenewing();
+          if (type.equals(BillingClient.SkuType.SUBS)) {
+            item.putBoolean("autoRenewingAndroid", purchase.isAutoRenewing());
+          }
           items.pushMap(item);
         }
         try {


### PR DESCRIPTION
Missing item.putBoolean for purchase Item causes the key autoRenewingAndroid to be undefined. 

Closes #669 