### PR TITLE
Destroying listeners in proper React's life cycle method

### DIFF
--- a/IapExample/App.js
+++ b/IapExample/App.js
@@ -80,7 +80,7 @@ class Page extends Component {
     });
   }
 
-  componentWillMount() {
+  componentWillUnmount() {
     if (purchaseUpdateSubscription) {
       purchaseUpdateSubscription.remove();
       purchaseUpdateSubscription = null;


### PR DESCRIPTION
I believe that listener's `remove()` should be called in `componentWillUnmount()` instead of `componentWillMount()`.