### PR TITLE
Make all SubscriptionPurchase property types optional, as they are different per platform

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,9 +59,9 @@ export interface PurchaseError {
 }
 
 export interface SubscriptionPurchase extends ProductPurchase {
-  autoRenewingAndroid: boolean;
-  originalTransactionDateIOS: string;
-  originalTransactionIdentifierIOS: string;
+  autoRenewingAndroid?: boolean;
+  originalTransactionDateIOS?: string;
+  originalTransactionIdentifierIOS?: string;
 }
 
 export type Purchase = ProductPurchase | SubscriptionPurchase;


### PR DESCRIPTION
`autoRenewingAndroid` is not available on `iOS`

`originalTransactionDateIOS` and `originalTransactionIdentifierIOS` are not available on `Android`

So the types should not assume they are there