### PR TITLE
Add discounts array to Subscription type (iOS Only)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,16 @@ interface Common {
   localizedPrice: string;
 }
 
+export interface Discount {
+  identifier: string;
+  type: string;
+  numberOfPeriods: string;
+  price: string;
+  localizedPrice: string;
+  paymendMode: string;
+  subscriptionPeriods: string;
+}
+
 export interface Product<ID> extends Common {
   type: 'inapp' | 'iap';
   productId: ID;
@@ -20,6 +30,8 @@ export interface Product<ID> extends Common {
 export interface Subscription<ID> extends Common {
   type: 'subs' | 'sub';
   productId: ID;
+  
+  discounts?: DiscountIOS[];
 
   introductoryPrice?: string;
   introductoryPricePaymentModeIOS?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,8 +18,8 @@ export interface Discount {
   numberOfPeriods: string;
   price: string;
   localizedPrice: string;
-  paymendMode: string;
-  subscriptionPeriods: string;
+  paymentMode: string;
+  subscriptionPeriod: string;
 }
 
 export interface Product<ID> extends Common {

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,7 +31,7 @@ export interface Subscription<ID> extends Common {
   type: 'subs' | 'sub';
   productId: ID;
   
-  discounts?: DiscountIOS[];
+  discounts?: Discount[];
 
   introductoryPrice?: string;
   introductoryPricePaymentModeIOS?: string;


### PR DESCRIPTION
I noticed this was missing.

I have not validated yet if the types are correct. But I assume they are based on: https://github.com/dooboolab/react-native-iap/blob/ae9e0b5c1bf951bede7d2d0a72e4400a3bd20f32/ios/RNIapIos.m#L633-L707

<img width="577" alt="Screenshot 2019-09-04 at 14 45 10" src="https://user-images.githubusercontent.com/5155373/64257794-47b10080-cf26-11e9-9ccd-30034461b8de.png">
