### PR TITLE
release/3.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@
   - Makes iOS `getSubscriptions` return subscriptions that only received ids [#654](https://github.com/dooboolab/react-native-iap/pull/654)
   - **[3.4.1]**
     - Method to retrive pending transaction [#663](https://github.com/dooboolab/react-native-iap/pull/663)
-    - Fixed missing `autoRenewingAndroid` key [#670](https://github.com/dooboolab/react-native-iap)
+    - Fixed missing `autoRenewingAndroid` key [#670](https://github.com/dooboolab/react-native-iap/pull/670)
   - **[3.4.2]**
     - Enhanced typings.
+  - **[3.4.5]**
+    - Enhanced more typings [#696](https://github.com/dooboolab/react-native-iap/pull/696)
+    - Support installation guide for both `RN >= 0.60` and `RN <0.60`. No need to use different version of `react-native-iap` now.
 - **[3.3.+]**
   - Fix flow tying [#594](https://github.com/dooboolab/react-native-iap/pull/594).
   - Handle null pointer exception [#600](https://github.com/dooboolab/react-native-iap/issues/600).

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Getting Started
 
 ## Getting started
 
-`$ npm install react-native-inappbrowser-reborn --save`
+`$ npm install react-native-iap --save`
 
 ### Mostly automatic installation
 
@@ -196,15 +196,14 @@ Linking the package manually is not required anymore with [Autolinking](https://
 ### Manual installation
 
 #### iOS
-
 1. In XCode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
-2. Go to `node_modules` ➜ `react-native-inappbrowser-reborn` and add `RNInAppBrowser.xcodeproj`
-3. In XCode, in the project navigator, select your project. Add `libRNInAppBrowser.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
+2. Go to `node_modules` ➜ `react-native-iap` and add `RNIap.xcodeproj`
+3. In XCode, in the project navigator, select your project. Add `libRNIap.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
 4. Run your project (`Cmd+R`)<
 
 #### iOS with Podfile
 1. Open up `ios/Podfile`
-  - Add `pod 'RNInAppBrowser', :path => '../node_modules/react-native-iap'`
+  - Add `pod 'RNIap', :path => '../node_modules/react-native-iap'`
 2. Run `pod install`
 
 #### Android

--- a/README.md
+++ b/README.md
@@ -142,19 +142,73 @@ Getting Started
 ---------------
 `$ npm install --save react-native-iap`
 
+## Getting started
+
+`$ npm install react-native-inappbrowser-reborn --save`
+
 ### Mostly automatic installation
+
+#### Using React Native >= 0.60
+Linking the package manually is not required anymore with [Autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).
+
+- **iOS Platform:**
+
+  `$ cd ios && pod install && cd ..` # CocoaPods on iOS needs this extra step
+
+- **Android Platform with Android Support:**
+
+  Using [Jetifier tool](https://github.com/mikehardy/jetifier) for backward-compatibility.
+
+  Modify your **android/build.gradle** configuration:
+  ```
+  buildscript {
+    ext {
+      buildToolsVersion = "28.0.3"
+      minSdkVersion = 16
+      compileSdkVersion = 28
+      targetSdkVersion = 28
+      # Only using Android Support libraries
+      supportLibVersion = "28.0.0"
+    }
+  ```
+
+- **Android Platform with AndroidX:**
+
+  Modify your **android/build.gradle** configuration:
+  ```
+  buildscript {
+    ext {
+      buildToolsVersion = "28.0.3"
+      minSdkVersion = 16
+      compileSdkVersion = 28
+      targetSdkVersion = 28
+      # Remove 'supportLibVersion' property and put specific versions for AndroidX libraries
+      androidXAnnotation = "1.1.0"
+      androidXBrowser = "1.0.0"
+      // Put here other AndroidX dependencies
+    }
+  ```
+
+#### Using React Native < 0.60
+
 `$ react-native link react-native-iap`
 
 ### Manual installation
 
 #### iOS
-1. In XCode, in the project navigator, right-click `Libraries` ➜ `Add Files to [your project's name]`
-2. Go to `node_modules` ➜ `react-native-iap` and add `RNIap.xcodeproj`
-3. In XCode, in the project navigator, select your project. Add `libRNIap.a`
-    to your project's `Build Phases` ➜ `Link Binary With Libraries`
-4. Run your project (`Cmd+R`)
+
+1. In XCode, in the project navigator, right click `Libraries` ➜ `Add Files to [your project's name]`
+2. Go to `node_modules` ➜ `react-native-inappbrowser-reborn` and add `RNInAppBrowser.xcodeproj`
+3. In XCode, in the project navigator, select your project. Add `libRNInAppBrowser.a` to your project's `Build Phases` ➜ `Link Binary With Libraries`
+4. Run your project (`Cmd+R`)<
+
+#### iOS with Podfile
+1. Open up `ios/Podfile`
+  - Add `pod 'RNInAppBrowser', :path => '../node_modules/react-native-iap'`
+2. Run `pod install`
 
 #### Android
+
 1. Open up `android/app/src/main/java/[...]/MainApplication.java`
     - Add `import com.dooboolab.RNIap.RNIapPackage;` to the imports at the top of the file
     - Add `new RNIapPackage()` to the list returned by the `getPackages()` method
@@ -167,14 +221,19 @@ Getting Started
     ```gradle
     compile project(':react-native-iap')
     ```
-4. Add the following to the `<permission>` block in `android/app/src/main/AndroidManifest.xml`:
-    ```xml
-    <uses-permission android:name="com.android.vending.BILLING" />
+4. Update ProGuard config (Optional)
+  - Append the following lines to your ProGuard config (`proguard-rules.pro`)
     ```
-
-Migration Guide
----------------
-To migrate to `3.1.0` you must migrate your Android app to AndroidX by following the [Migrating to AndroidX Guide][android-migrate-androidx].
+    -keepattributes *Annotation*
+    -keepclassmembers class ** {
+      @org.greenrobot.eventbus.Subscribe <methods>;
+    }
+    -keep enum org.greenrobot.eventbus.ThreadMode { *; }
+    ```
+5. Add the following to the `<permission>` block in `android/app/src/main/AndroidManifest.xml`:
+  ```xml
+  <uses-permission android:name="com.android.vending.BILLING" />
+  ```
 
 ### Migrating to 3.4.0
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,13 +19,18 @@ def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
+def DEFAULT_COMPILE_SDK_VERSION = 28
+def DEFAULT_BUILD_TOOLS_VERSION = "28.0.3"
+def DEFAULT_MIN_SDK_VERSION = 16
+def DEFAULT_TARGET_SDK_VERSION = 28
+
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 28)
-  buildToolsVersion safeExtGet("buildToolsVersion", '28.0.2')
+  compileSdkVersion safeExtGet("compileSdkVersion", DEFAULT_COMPILE_SDK_VERSION)
+  buildToolsVersion safeExtGet("buildToolsVersion", DEFAULT_BUILD_TOOLS_VERSION)
 
   defaultConfig {
-    minSdkVersion safeExtGet('minSdkVersion', 16)
-    targetSdkVersion safeExtGet('targetSdkVersion', 28)
+    minSdkVersion safeExtGet('minSdkVersion', DEFAULT_MIN_SDK_VERSION)
+    targetSdkVersion safeExtGet('targetSdkVersion', DEFAULT_TARGET_SDK_VERSION)
     versionCode 3
     versionName "3.0.0"
   }
@@ -45,5 +50,20 @@ repositories {
 
 dependencies {
   implementation 'com.facebook.react:react-native:+'
-  implementation 'com.android.billingclient:billing:2.0.1'
+  implementation 'com.android.billingclient:billing:2.0.3'
+  def supportLibVersion = safeExtGet('supportLibVersion', safeExtGet('supportVersion', null))
+  def androidXVersion = safeExtGet('androidXVersion', null)
+  if (supportLibVersion && androidXVersion == null) {
+    implementation "com.android.support:support-annotations:$supportLibVersion"
+    implementation "com.android.support:customtabs:$supportLibVersion"
+  } else {
+    def defaultAndroidXVersion = "1.+"
+    if (androidXVersion == null) {
+      androidXVersion = defaultAndroidXVersion
+    }
+    def androidXAnnotation = safeExtGet('androidXAnnotation', androidXVersion)
+    def androidXBrowser = safeExtGet('androidXBrowser', androidXVersion)
+    implementation "androidx.annotation:annotation:$androidXAnnotation"
+    implementation "androidx.browser:browser:$androidXBrowser"
+  }
 }

--- a/index.js.flow
+++ b/index.js.flow
@@ -10,6 +10,16 @@ declare type Common = {
 
 declare type ID = string
 
+declare type Discount = {
+  identifier: string,
+  type: string,
+  numberOfPeriods: string,
+  price: string,
+  localizedPrice: string,
+  paymentMode: string,
+  subscriptionPeriod: string,
+}
+
 export type Product<ID> = Common & {
   type: "inapp" | "iap",
   productId: ID,
@@ -18,6 +28,7 @@ export type Product<ID> = Common & {
 export type Subscription<ID> = Common & {
   type: "subs" | "sub",
   productId: ID,
+  discounts?: Discount[],
 
   introductoryPrice?: string,
   introductoryPricePaymentModeIOS?: string,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iap",
-  "version": "3.4.4",
+  "version": "3.4.5",
   "description": "React Native In App Purchase Module.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Release
- Fixes for #701 
   * Update installation doc to support all `RN` version to use `react-native-iap`.
   * Update `build.gradle` to make the updated `readme` work.
- Fixed more typings followed by #696.