### PR TITLE
fix: fix unresolved promise in initConnection

### DIFF
--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -137,12 +137,15 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
     billingClient.startConnection(new BillingClientStateListener() {
       @Override
       public void onBillingSetupFinished(BillingResult billingResult) {
-        if (billingResult.getResponseCode() == BillingClient.BillingResponseCode.OK) {
-          try {
+        int responseCode = billingResult.getResponseCode();
+        try {
+          if (responseCode == BillingClient.BillingResponseCode.OK) {
             promise.resolve(true);
-          } catch (ObjectAlreadyConsumedException oce) {
-            Log.e(TAG, oce.getMessage());
+          } else {
+            promise.reject("initConnection", billingResult.getDebugMessage());
           }
+        } catch (ObjectAlreadyConsumedException oce) {
+          Log.e(TAG, oce.getMessage());
         }
       }
       @Override


### PR DESCRIPTION
When running on Android emulator `initConnection` will currently be neither resolved, nor rejected, because java counterpart has doesn't always handle promise. This PR makes it always resolve or reject. In my case, on emulator this will get rejected with `Billing service unavailable on device`.

However, I'm not sure, maybe instead of being rejected, the promise should be resolved with `false` (at least for some codes)? 