### PR TITLE
feat: improve initConnection errors on android

### DIFF
--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -142,7 +142,7 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
           if (responseCode == BillingClient.BillingResponseCode.OK) {
             promise.resolve(true);
           } else {
-            promise.reject("initConnection", billingResult.getDebugMessage());
+            DoobooUtils.getInstance().rejectPromiseWithBillingError(promise, responseCode);
           }
         } catch (ObjectAlreadyConsumedException oce) {
           Log.e(TAG, oce.getMessage());


### PR DESCRIPTION
With this PR it's now possible to know why `initConnection` failed on JS side. So you can distinguish network errors from cases when billing is unavailable.