### PR TITLE
Add missing fields to PurchaseResult & PurchaseError

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -79,11 +79,15 @@ export type ProductPurchase = {|
 export type PurchaseResult = {
   responseCode: number,
   debugMessage: string,
+  code: number,
+  message: string,
 }
 
 export type PurchaseError = {
   responseCode: number,
   debugMessage: string,
+  code: number,
+  message: string,
 }
 
 export type SubscriptionPurchase = ProductPurchase & {


### PR DESCRIPTION
These were added as part of https://github.com/dooboolab/react-native-iap/pull/616 but the flow file never got updated