### PR TITLE
Typings: Move isAcknowledgedAndroid to ProductPurchase

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -83,6 +83,7 @@ export interface ProductPurchase {
   purchaseStateAndroid?: number;
   originalTransactionDateIOS?: string;
   originalTransactionIdentifierIOS?: string;
+  isAcknowledgedAndroid?: boolean;
 }
 
 export interface PurchaseResult {
@@ -100,7 +101,6 @@ export interface PurchaseError {
 }
 
 export interface InAppPurchase extends ProductPurchase {
-  isAcknowledgedAndroid?: boolean;
 }
 
 export interface SubscriptionPurchase extends ProductPurchase {

--- a/index.ts
+++ b/index.ts
@@ -100,8 +100,7 @@ export interface PurchaseError {
   message?: string;
 }
 
-export interface InAppPurchase extends ProductPurchase {
-}
+export type InAppPurchase = ProductPurchase;
 
 export interface SubscriptionPurchase extends ProductPurchase {
   autoRenewingAndroid?: boolean;


### PR DESCRIPTION
Since after fixing #748 isAcknowledgedAndroid is available for both InAppPurchase and SubscriptionPurchase, I have moved the property to the common base interface ProductPurchase