### PR TITLE
fix(validateReceiptAndroid): template literals properly

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 IapExample/
 .idea/
 gen/
-src/
 node_modules/
 android/react-native-iap.iml
 android/android.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@
     - Fix more type error.
   - **[3.5.6]**
     - Resolve [#748](https://github.com/dooboolab/react-native-iap/issues/748)
-  - **[3.5.8]**
+  - **[~~3.5.8~~]**
     - `android` runtie bugfix in `3.5.7`.
+  - **[3.5.9]**
+    - Resolve issue on `andorid` project. Do not use `3.5.8`.
 - **[3.4.+]**
   - Makes module possible to be built in older XCode version [#650](https://github.com/dooboolab/react-native-iap/pull/650).
   - Makes iOS `getSubscriptions` return subscriptions that only received ids [#654](https://github.com/dooboolab/react-native-iap/pull/654).

--- a/index.ts
+++ b/index.ts
@@ -619,9 +619,9 @@ export const validateReceiptAndroid = async (
   isSub?: boolean,
 ): Promise<object | false> => {
   const type = isSub ? 'subscriptions' : 'products';
-  const url = `https://www.googleapis.com/androidpublisher/v2/applications'
-    + '/${packageName}/purchases/${type}/${productId}'
-    + '/tokens/${productToken}?access_token=${accessToken}`;
+  const url = 'https://www.googleapis.com/androidpublisher/v2/applications' +
+    `/${packageName}/purchases/${type}/${productId}` +
+    `/tokens/${productToken}?access_token=${accessToken}`;
 
   const response = await fetch(url, {
     method: 'GET',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iap",
-  "version": "3.5.8",
+  "version": "3.5.9",
   "description": "React Native In App Purchase Module.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
* fix `validateReceiptAndroid`
  - Make template literals properly
* Additionally resolve #757 