### PR TITLE
fix: call correct methods in finishTransaction Android

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -403,12 +403,12 @@ export const finishTransaction = (
     },
     android: async () => {
       if (isConsumable) {
-        return RNIapModule.consumePurchaseAndroid(
+        return RNIapModule.consumeProduct(
           transactionId,
           developerPayloadAndroid,
         );
       }
-      return RNIapModule.acknowledgePurchaseAndroid(
+      return RNIapModule.acknowledgePurchase(
         transactionId,
         developerPayloadAndroid,
       );


### PR DESCRIPTION
`finishTransaction` on Android calls non-existing native methods. This should fix it.