### PR TITLE
[Android] Fixed promise never returned from requestSubscription()

### DIFF
--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -522,8 +522,8 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
         item.putBoolean("isAcknowledgedAndroid", purchase.isAcknowledged());
         item.putInt("purchaseStateAndroid", purchase.getPurchaseState());
 
+        promiseItem = item.copy();
         sendEvent(reactContext, "purchase-updated", item);
-        promiseItem = item;
       }
       if (purchases.size() > 0 && promiseItem != null) {
         DoobooUtils.getInstance().resolvePromisesForKey(PROMISE_BUY_ITEM, promiseItem);


### PR DESCRIPTION
Calling `requestSubscription()` on Android result in the purchase being made but the promise is never called. This is due to an exception being thrown when trying to resolve the promise, specifically `method threw 'com.facebook.react.bridge.objectalreadyconsumedexception' exception` because the WriteableMap is already consumed when `sendEvent` is called. 
By making a copy before calling it, we get a fresh WriteableMap that we can send to our promise without error.