### PR TITLE
[Android] added subs to the list of unconsumed purchases

### DIFF
--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -544,19 +544,24 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
     ensureConnection(promise, new Runnable() {
       @Override
       public void run() {
-        Purchase.PurchasesResult purchasesResult = billingClient.queryPurchases(BillingClient.SkuType.INAPP);
-        ArrayList<Purchase> unacknowledgedPurchases = new ArrayList<>();
-        if (purchasesResult == null || purchasesResult.getPurchasesList() == null || purchasesResult.getPurchasesList().size() == 0) {
-          promise.resolve(false);
-          return;
-        }
-        for (Purchase purchase : purchasesResult.getPurchasesList()) {
-          if (!purchase.isAcknowledged()) {
-            unacknowledgedPurchases.add(purchase);
+        String[] types = { BillingClient.SkuType.INAPP, BillingClient.SkuType.SUBS };
+
+        for (String type : types) {
+          Purchase.PurchasesResult purchasesResult = billingClient.queryPurchases(type);
+          ArrayList<Purchase> unacknowledgedPurchases = new ArrayList<>();
+
+          if (purchasesResult == null || purchasesResult.getPurchasesList() == null || purchasesResult.getPurchasesList().size() == 0) {
+            continue;
           }
+          for (Purchase purchase : purchasesResult.getPurchasesList()) {
+            if (!purchase.isAcknowledged()) {
+              unacknowledgedPurchases.add(purchase);
+            }
+          }
+          onPurchasesUpdated(purchasesResult.getBillingResult(), unacknowledgedPurchases);
         }
+
         promise.resolve(true);
-        onPurchasesUpdated(purchasesResult.getBillingResult(), unacknowledgedPurchases);
       }
     });
   }


### PR DESCRIPTION
`sendUnconsumedPurchases` only send unconsumed in-app products but not subscriptions. The app i'm working on uses subscriptions and requires to be able to send receipt to the server about unacknowledged subscriptions. This fixes it.

I also saw that a promise is passed as a parameter but isn't subscribed to inside `index.ts`. As is, this promise is useless so I decided to resolve it with true no matter what at the end of the function.