### PR TITLE
Fix Android compile error for React Native v0.60.x due to missing method

### DIFF
--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -522,7 +522,8 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
         item.putBoolean("isAcknowledgedAndroid", purchase.isAcknowledged());
         item.putInt("purchaseStateAndroid", purchase.getPurchaseState());
 
-        promiseItem = item.copy();
+        promiseItem = new WritableNativeMap();
+        promiseItem.merge(item);
         sendEvent(reactContext, "purchase-updated", item);
       }
       if (purchases.size() > 0 && promiseItem != null) {


### PR DESCRIPTION
React Native 0.61 introduces the `.copy()` method to the WritableMap
interface and this is used as of version 4.0.8 of this library. To keep
compatibility with RN 0.60, manually create a copy.

Fixes #834