### PR TITLE
Fix some warnings and a bug

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,5 @@ android/react-native-iap.iml
 android/android.iml
 tsconfig.tsbuildinfo
 index.ts
+tsconfig.json
+

--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -214,7 +214,7 @@ RCT_EXPORT_METHOD(buyProductWithOffer:(NSString*)sku
 }
 
 RCT_EXPORT_METHOD(buyProductWithQuantityIOS:(NSString*)sku
-                  quantity:(NSInteger*)quantity
+                  quantity:(NSInteger)quantity
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
     NSLog(@"\n\n\n  buyProductWithQuantityIOS  \n\n.");
@@ -451,7 +451,7 @@ RCT_EXPORT_METHOD(getPendingTransactions:(RCTPromiseResolveBlock)resolve
         [self resolvePromisesForKey:RCTKeyForInstance(transaction.payment.productIdentifier) value:purchase];
 
         // additionally send event
-        if (hasListeners) {
+        if (self->hasListeners) {
             [self sendEventWithName:@"purchase-updated" body: purchase];
         }
     }];


### PR DESCRIPTION
- tsconfig.json should not be in the released module, this causes errors in some editors (atom-typescript)
- fix Xcode warning (explicit `self->hasListeners`)
- fix `NSInteger` vs. `NSInteger*` - the intended behaviour is probably quantity as NSInteger.
