### PR TITLE
Fix double precision issue and inconsistent return type on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,10 +290,10 @@ Each `product` returns from `getProducts()` contains:
 
 Property                                 | iOS | And | Comment
 --------                                 | :-: | :-: | -------
-`price`                                  | ✓   | ✓   | Will return localizedPrice on Android (default) or a string price (eg. `1.99`) (iOS).
+`price`                                  | ✓   | ✓   | Localized price string, with only number (eg. `1.99`).
 `productId`                              | ✓   | ✓   | Returns a string needed to purchase the item later.
 `currency`                               | ✓   | ✓   | Returns the currency code.
-`localizedPrice`                         | ✓   | ✓   | Use localizedPrice if you want to display the price to the user so you don't need to worry about currency symbols.
+`localizedPrice`                         | ✓   | ✓   | Localized price string, with number and currency symbol (eg. `$1.99`).
 `title`                                  | ✓   | ✓   | Returns the title Android and localizedTitle on iOS.
 `description`                            | ✓   | ✓   | Returns the localized description on Android and iOS.
 `introductoryPrice`                      | ✓   | ✓   | Formatted introductory price of a subscription, including its currency sign, such as €3.99.<br>The price doesn't include tax.

--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -18,6 +18,7 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ObjectAlreadyConsumedException;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -255,7 +256,13 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
             for (SkuDetails skuDetails : skuDetailsList) {
               WritableMap item = Arguments.createMap();
               item.putString("productId", skuDetails.getSku());
-              item.putDouble("price", skuDetails.getPriceAmountMicros() / 1000000f);
+              long priceAmountMicros = skuDetails.getPriceAmountMicros();
+              // Use valueOf instead of constructors.
+              // See: https://www.javaworld.com/article/2073176/caution--double-to-bigdecimal-in-java.html
+              BigDecimal priceAmount = BigDecimal.valueOf(priceAmountMicros);
+              BigDecimal microUnitsDivisor = BigDecimal.valueOf(1000000);
+              String price = priceAmount.divide(microUnitsDivisor).toString();
+              item.putString("price", price);
               item.putString("currency", skuDetails.getPriceCurrencyCode());
               item.putString("type", skuDetails.getType());
               item.putString("localizedPrice", skuDetails.getPrice());
@@ -269,7 +276,9 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
               // new
               item.putString("iconUrl", skuDetails.getIconUrl());
               item.putString("originalJson", skuDetails.getOriginalJson());
-              item.putDouble("originalPrice", skuDetails.getOriginalPriceAmountMicros() / 1000000f);
+              BigDecimal originalPriceAmountMicros = BigDecimal.valueOf(skuDetails.getOriginalPriceAmountMicros());
+              String originalPrice = originalPriceAmountMicros.divide(microUnitsDivisor).toString();
+              item.putString("originalPrice", originalPrice);
               items.pushMap(item);
             }
 


### PR DESCRIPTION
1. Fix double precision issue when doing calculations with large numbers. In our case, `priceAmountMicros` can be 3290000000, and `priceAmountMicros / 1000000f` will give incorrect value 3289.999755859375 (3290 is expected).
2. Fix inconsistent return type. On documentation and iOS implementation, all properties of Product are String types. Earlier implementation on Android gives Double type.

We also update documentation of `price` and `localizedPrice` to make it clearer.
