### PR TITLE
Update iOS cancel subscription URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ Q & A
 
 - You can do this on iOS:
     ```javascript
-    Linking.openURL('https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions')
+    Linking.openURL('https://apps.apple.com/account/subscriptions')
     ```
 
 - You can do this on Android:


### PR DESCRIPTION
The link that is on README redirects to iTunes installation, I found [this](https://stackoverflow.com/a/51127481/9241832) answer on StackOverflow that references to a WWDC session. Tested and works properly.