### PR TITLE
Improve documentation for iOS subscription URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ Q & A
 #### How can a user cancel a subscription in my app?
 - For both iOS and Android your users cannot cancel subscriptions inside your app. You need to direct your users to iTunes/the App Store or Google Play.
 
-- You can do this on iOS:
+- You can do this on iOS 12 or later (for earlier iOS versions, use [this URL](https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions)):
     ```javascript
     Linking.openURL('https://apps.apple.com/account/subscriptions')
     ```


### PR DESCRIPTION
- New URL: https://apps.apple.com/account/subscriptions redirects to App Store, and only works on iOS 12 or later.
- Old URL: https://buy.itunes.apple.com/WebObjects/MZFinance.woa/wa/manageSubscriptions redirects to iTunes Store.

Apple doesn't mention those details. I tested on my own iOS 10-13 devices. So the old URL should be kept for reference.

The reason @julioxavierr described in #906 that old URL redirects to iTunes installation is, either the user [deleted iTunes Store](https://support.apple.com/en-us/HT208094) (possible since iOS 12), or the iOS [offloaded unused iTunes Store](https://support.apple.com/en-us/HT201656).