### PR TITLE
Release 4.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelogs
 
+- **[4.4.2]**
+  - Attempt to fix [#934](https://github.com/dooboolab/react-native-iap/issues/934).
+
 - **[4.4.1]**
   - Upgrade packages.
 

--- a/ios/IAPPromotionObserver.m
+++ b/ios/IAPPromotionObserver.m
@@ -24,13 +24,13 @@
   [IAPPromotionObserver sharedObserver];
 }
 
-- (instancetype)init {
-  if ((self = [super init])) {
-    [SKPaymentQueue.defaultQueue addTransactionObserver:self];
-  }
+// - (instancetype)init {
+//   if ((self = [super init])) {
+//     [SKPaymentQueue.defaultQueue addTransactionObserver:self];
+//   }
 
-  return self;
-}
+//   return self;
+// }
 
 -(void) dealloc {
   [[SKPaymentQueue defaultQueue] removeTransactionObserver:self];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iap",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "React Native In App Purchase Module.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Attempt to fix #934
- Refered to https://stackoverflow.com/questions/34001868/ios-this-in-app-purchase-has-already-been-bought-pop-up.

@meteorra I will land this shortly to `4.4.2`, please try this out.