### PR TITLE
Add receipt validation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,6 +514,12 @@ Receipt validation
 ------------------
 Since `react-native-iap@0.3.16`, we support receipt validation.
 
+### With [IAPHUB](https://www.iaphub.com)
+
+IAPHUB is a service that takes care of the ios/android receipt validation for you, you can set up [webhooks](https://dashboard.iaphub.com/documentation/webhook) in order to get notifications delivered automatically to your server on events such as a purchase, a subscription renewal...
+
+You can use it by calling the API manually to [process your receipt](https://dashboard.iaphub.com/documentation/api/post-receipt) or use the [react-native-iaphub](https://github.com/iaphub/react-native-iaphub) plugin that is just a wrapper of react-native-iap with IAPHUB built-in.
+
 ### With Google Play
 
 For Android, you need separate json file from the service account to get the

--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ Since `react-native-iap@0.3.16`, we support receipt validation.
 
 IAPHUB is a service that takes care of the ios/android receipt validation for you, you can set up [webhooks](https://dashboard.iaphub.com/documentation/webhook) in order to get notifications delivered automatically to your server on events such as a purchase, a subscription renewal...
 
-You can use it by calling the API manually to [process your receipt](https://dashboard.iaphub.com/documentation/api/post-receipt) or use the [react-native-iaphub](https://github.com/iaphub/react-native-iaphub) plugin that is just a wrapper of react-native-iap with IAPHUB built-in.
+You can use it by calling the API manually to [process your receipt](https://dashboard.iaphub.com/documentation/api/post-receipt) or use the [react-native-iaphub](https://github.com/iaphub/react-native-iaphub) module that is just a wrapper of react-native-iap with IAPHUB built-in.
 
 ### With Google Play
 


### PR DESCRIPTION
Hey @hyochan !

First I have to thank you for the awesome work on react-native-iap 👍
I'm maintaining a few open source projects myself and I know the commitement and time it takes.

Secondly, thank you for starring [react-native-iaphub](https://github.com/iaphub/react-native-iaphub) 🙏 
Your module is making IAP easy on the client side and I'm trying on my side with [IAPHUB](https://www.iaphub.com) to take care of the pain validating receipts on the server side...
[react-native-iaphub](https://github.com/iaphub/react-native-iaphub) is just a simple wrapper of your library directly communicating to IAPHUB.

Was thinking it would be cool to add an option using iaphub in the "Receipt validation" section of the README 🙂 
I added the section in this PR if it sounds good to you.

Thank you!