### PR TITLE
Sandbox (Testflight) checker for iOS

### DIFF
--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -38,6 +38,17 @@
     return YES;
 }
 
+- (NSDictionary *)constantsToExport
+{
+    BOOL isSandbox = false;
+    #if DEBUG
+        isSandbox = true;
+    #else
+        isSandbox = ([receiptURLString rangeOfString:@"sandboxReceipt"].location != NSNotFound);
+    #endif
+    return @{ @"isSandbox": isSandbox };
+}
+
 - (void)flushUnheardEvents {
     [self paymentQueue:[SKPaymentQueue defaultQueue] updatedTransactions:[[SKPaymentQueue defaultQueue] transactions]];
 }


### PR DESCRIPTION
This is a draft suggestion about having:

```
import RNIAP from 'react-native-iap';

RNIAP.isSandbox
```

so we can find out if we're on Production, Testflight, or Development.

Pending documentation but I'm waiting for input from the maintainers.