### PR TITLE
Fix return type of getPromotedProductIOS

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -539,7 +539,7 @@ export const consumePurchaseAndroid = (
  *   Indicates the the App Store purchase should continue from the app instead of the App Store.
  * @returns {Promise<Product>}
  */
-export const getPromotedProductIOS = (): Promise<Product> =>
+export const getPromotedProductIOS = (): Promise<string> =>
   Platform.select({
     ios: async () => {
       checkNativeiOSAvailable();


### PR DESCRIPTION
The OC code returns `productIdentifier` which is a string type.