### PR TITLE
Fix discounts issues

### DIFF
--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -587,7 +587,7 @@ RCT_EXPORT_METHOD(getPendingTransactions:(RCTPromiseResolveBlock)resolve
     NSArray *discounts;
     #if __IPHONE_12_2
     if (@available(iOS 12.2, *)) {
-        discounts = [self getDiscountData:[product.discounts copy]];
+        discounts = [self getDiscountData:product];
     }
     #endif
 
@@ -612,7 +612,7 @@ RCT_EXPORT_METHOD(getPendingTransactions:(RCTPromiseResolveBlock)resolve
     return obj;
 }
 
-- (NSMutableArray *)getDiscountData:(NSArray *)discounts {
+- (NSMutableArray *)getDiscountData:(SKProduct *)product {
     NSMutableArray *mappedDiscounts = [NSMutableArray arrayWithCapacity:[discounts count]];
     NSString *localizedPrice;
     NSString *paymendMode;
@@ -620,10 +620,10 @@ RCT_EXPORT_METHOD(getPendingTransactions:(RCTPromiseResolveBlock)resolve
     NSString *discountType;
 
     if (@available(iOS 11.2, *)) {
-        for(SKProductDiscount *discount in discounts) {
+        for(SKProductDiscount *discount in product.discounts) {
             NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
             formatter.numberStyle = NSNumberFormatterCurrencyStyle;
-            formatter.locale = discount.priceLocale;
+            formatter.locale = discount.priceLocale ?: product.priceLocale;
             localizedPrice = [formatter stringFromNumber:discount.price];
             NSString *numberOfPeriods;
 

--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -687,7 +687,7 @@ RCT_EXPORT_METHOD(getPendingTransactions:(RCTPromiseResolveBlock)resolve
                                         discountIdentifier, @"identifier",
                                         discountType, @"type",
                                         numberOfPeriods, @"numberOfPeriods",
-                                        discount.price, @"price",
+                                        [discount.price stringValue], @"price",
                                         localizedPrice, @"localizedPrice",
                                         paymendMode, @"paymentMode",
                                         subscriptionPeriods, @"subscriptionPeriod",


### PR DESCRIPTION
This pull request fixes a couple of issues related to discounts (aka introductory and promotional offers):

1. The product price is a string, but the discount price is a number. Fixed by taking the `stringValue` of `discount.price` when adding to the `discount` dictionary. 

2. If `discount.priceLocale` is `nil`, `NSNumberFormatter` defaults to the system locale rather than the App Store locale. Fixed by defaulting to `product.priceLocale` if `discount.priceLocale` is `nil`. If `product.priceLocale` is also `nil`, `NSNumberFormatter` will then default to the system locale. 
