### PR TITLE
Fix promise not resolving on IOS14

### DIFF
--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -155,8 +155,7 @@ RCT_EXPORT_METHOD(buyProduct:(NSString*)sku
         }
     }
     if (product) {
-        NSString *key = RCTKeyForInstance(product.productIdentifier);
-        [self addPromiseForKey:key resolve:resolve reject:reject];
+        [self addPromiseForKey:product.productIdentifier resolve:resolve reject:reject];
             
         SKMutablePayment *payment = [SKMutablePayment paymentWithProduct:product];
         [[SKPaymentQueue defaultQueue] addPayment:payment];
@@ -190,8 +189,7 @@ RCT_EXPORT_METHOD(buyProductWithOffer:(NSString*)sku
         }
     }
     if (product) {
-        NSString *key = RCTKeyForInstance(product.productIdentifier);
-        [self addPromiseForKey:key resolve:resolve reject:reject];
+        [self addPromiseForKey:product.productIdentifier resolve:resolve reject:reject];
 
         payment = [SKMutablePayment paymentWithProduct:product];
         #if __IPHONE_12_2
@@ -402,7 +400,6 @@ RCT_EXPORT_METHOD(getPendingTransactions:(RCTPromiseResolveBlock)resolve
             case SKPaymentTransactionStateFailed:
                 NSLog(@"\n\n\n\n\n\n Purchase Failed  !! \n\n\n\n\n");
                 [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
-                NSString *key = RCTKeyForInstance(transaction.payment.productIdentifier);
                 dispatch_sync(myQueue, ^{
                     if (hasListeners) {
                         NSString *responseCode = [@(transaction.error.code) stringValue];
@@ -415,7 +412,7 @@ RCT_EXPORT_METHOD(getPendingTransactions:(RCTPromiseResolveBlock)resolve
                                              ];
                         [self sendEventWithName:@"purchase-error" body:err];
                     }
-                    [self rejectPromisesForKey:key code:[self standardErrorCode:(int)transaction.error.code]
+                    [self rejectPromisesForKey:transaction.payment.productIdentifier code:[self standardErrorCode:(int)transaction.error.code]
                                        message:transaction.error.localizedDescription
                                          error:transaction.error];
                 });
@@ -464,7 +461,7 @@ RCT_EXPORT_METHOD(getPendingTransactions:(RCTPromiseResolveBlock)resolve
         pendingTransactionWithAutoFinish = false;
     }
     [self getPurchaseData:transaction withBlock:^(NSDictionary *purchase) {
-        [self resolvePromisesForKey:RCTKeyForInstance(transaction.payment.productIdentifier) value:purchase];
+        [self resolvePromisesForKey:transaction.payment.productIdentifier value:purchase];
 
         // additionally send event
         if (self->hasListeners) {


### PR DESCRIPTION
Hey @hyochan,

We fixed an issue causing the `requestSubscription` or `requestPurchase` promise to not resolve on IOS 14 (Issue: #1058)
The issue is due to how react-native-iap is handling the promises, currently a key is generated (using RCTKeyForInstance) which is the pointer of the product identifier.
The problem is the pointer of `transaction.payment.productIdentifier` is actually different in the `updatedTransactions` method on IOS 14 causing the key to identify the promise to be different therefore the promise isn't found.
The solution in the pull request is to use directly the product identifier instead of the pointer value.