### PR TITLE
Fix/avoid blindly consuming success purchases

### DIFF
--- a/IapExample/App.js
+++ b/IapExample/App.js
@@ -116,7 +116,7 @@ class Page extends Component {
   async componentDidMount(): void {
     try {
       const result = await RNIap.initConnection();
-      await RNIap.consumeAllItemsAndroid();
+      await RNIap.flushFailedPurchasesCachedAsPendingAndroid();
       console.log('result', result);
     } catch (err) {
       console.warn(err.code, err.message);

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ _*deprecated_<br>~~`buySubscription(sku: string)`~~<ul><li>sku: subscription ID/
 `getPendingPurchasesIOS()` | `Promise<ProductPurchase[]>` | **IOS only**<br>Gets all the transactions which are pending to be finished.
 `validateReceiptIos(body: Record<string, unknown>, devMode: boolean)`<ul><li>body: receiptBody</li><li>devMode: isTest</li></ul> | `Object\|boolean` | **iOS only**<br>Validate receipt.
 `endConnection()` | `Promise<void>` | End billing connection.
-`consumeAllItemsAndroid()` | `Promise<void>` | **Android only**<br>Consume all items so they are able to buy again.
+`consumeAllItemsAndroid()` | `Promise<void>` | **Android only**<br>Consume all items so they are able to buy again. ⚠️ Use in dev only (as you should deliver the purchased feature BEFORE consuming it)
+`flushFailedPurchasesCachedAsPendingAndroid()` | `Promise<void>` | **Android only**<br>Consume all 'ghost' purchases (that is, pending payment that already failed but is still marked as pending in Play Store cache)
 `consumePurchaseAndroid(token: string, payload?: string)`<ul><li>token: purchase token</li><li>payload: developerPayload</li></ul>     | `void` | **Android only**<br>Finish a purchase. All purchases should be finished once you have delivered the purchased items. E.g. by recording the purchase in your database or on your server.
 `acknowledgePurchaseAndroid(token: string, payload?: string)`<ul><li>token: purchase token</li><li>payload: developerPayload</li></ul> | `Promise<PurchaseResult>` | **Android only**<br>Acknowledge a product. Like above for non-consumables. Use `finishTransaction` instead for both platforms since version 4.1.0 or later.
 `consumePurchaseAndroid(token: string, payload?: string)`<ul><li>token: purchase token</li><li>payload: developerPayload</li></ul>     | `Promise<PurchaseResult>` | **Android only**<br>Consume a product. Like above for consumables. Use `finishTransaction` instead for both platforms since version 4.1.0 or later.

--- a/README.md
+++ b/README.md
@@ -348,42 +348,52 @@ class RootComponent extends Component<*> {
   purchaseErrorSubscription = null
 
   componentDidMount() {
-    this.purchaseUpdateSubscription = purchaseUpdatedListener((purchase: InAppPurchase | SubscriptionPurchase | ProductPurchase ) => {
-      console.log('purchaseUpdatedListener', purchase);
-      const receipt = purchase.transactionReceipt;
-      if (receipt) {
-        yourAPI.deliverOrDownloadFancyInAppPurchase(purchase.transactionReceipt)
-        .then( async (deliveryResult) => {
-          if (isSuccess(deliveryResult)) {
-            // Tell the store that you have delivered what has been paid for.
-            // Failure to do this will result in the purchase being refunded on Android and
-            // the purchase event will reappear on every relaunch of the app until you succeed
-            // in doing the below. It will also be impossible for the user to purchase consumables
-            // again until you do this.
-            if (Platform.OS === 'ios') {
-              await RNIap.finishTransactionIOS(purchase.transactionId);
-            } else if (Platform.OS === 'android') {
-              // If consumable (can be purchased again)
-              await RNIap.consumePurchaseAndroid(purchase.purchaseToken);
-              // If not consumable
-              await RNIap.acknowledgePurchaseAndroid(purchase.purchaseToken);
-            }
+    Iap.initConnection().then(() => {
+      // we make sure that "ghost" pending payment are removed
+      // (ghost = failed pending payment that are still marked as pending in Google's native Vending module cache)
+      Iap.flushFailedPurchasesCachedAsPendingAndroid().catch(() => {
+        // exception can happen here if:
+        // - there are pending purchases that are still pending (we can't consume a pending purchase)
+        // in any case, you might not want to do anything special with the error
+      }).then(() => {
+        this.purchaseUpdateSubscription = purchaseUpdatedListener((purchase: InAppPurchase | SubscriptionPurchase | ProductPurchase ) => {
+          console.log('purchaseUpdatedListener', purchase);
+          const receipt = purchase.transactionReceipt;
+          if (receipt) {
+            yourAPI.deliverOrDownloadFancyInAppPurchase(purchase.transactionReceipt)
+            .then( async (deliveryResult) => {
+              if (isSuccess(deliveryResult)) {
+                // Tell the store that you have delivered what has been paid for.
+                // Failure to do this will result in the purchase being refunded on Android and
+                // the purchase event will reappear on every relaunch of the app until you succeed
+                // in doing the below. It will also be impossible for the user to purchase consumables
+                // again until you do this.
+                if (Platform.OS === 'ios') {
+                  await RNIap.finishTransactionIOS(purchase.transactionId);
+                } else if (Platform.OS === 'android') {
+                  // If consumable (can be purchased again)
+                  await RNIap.consumePurchaseAndroid(purchase.purchaseToken);
+                  // If not consumable
+                  await RNIap.acknowledgePurchaseAndroid(purchase.purchaseToken);
+                }
 
-            // From react-native-iap@4.1.0 you can simplify above `method`. Try to wrap the statement with `try` and `catch` to also grab the `error` message.
-            // If consumable (can be purchased again)
-            await RNIap.finishTransaction(purchase, true);
-            // If not consumable
-            await RNIap.finishTransaction(purchase, false);
-          } else {
-            // Retry / conclude the purchase is fraudulent, etc...
+                // From react-native-iap@4.1.0 you can simplify above `method`. Try to wrap the statement with `try` and `catch` to also grab the `error` message.
+                // If consumable (can be purchased again)
+                await RNIap.finishTransaction(purchase, true);
+                // If not consumable
+                await RNIap.finishTransaction(purchase, false);
+              } else {
+                // Retry / conclude the purchase is fraudulent, etc...
+              }
+            });
           }
         });
-      }
-    });
 
-    this.purchaseErrorSubscription = purchaseErrorListener((error: PurchaseError) => {
-      console.warn('purchaseErrorListener', error);
-    });
+        this.purchaseErrorSubscription = purchaseErrorListener((error: PurchaseError) => {
+          console.warn('purchaseErrorListener', error);
+        });
+      })
+    })
   }
 
   componentWillUnmount() {

--- a/index.ts
+++ b/index.ts
@@ -208,7 +208,7 @@ export const consumeAllItemsAndroid = (): Promise<string[]> =>
   Platform.select({
     ios: async () => Promise.resolve(),
     android: async () => {
-      checkNativeAndroidAvailable();
+      await checkNativeAndroidAvailable();
       return RNIapModule.refreshItems();
     },
   })();
@@ -250,7 +250,7 @@ export const getSubscriptions = (skus: string[]): Promise<Subscription[]> =>
       );
     },
     android: async () => {
-      checkNativeAndroidAvailable();
+      await checkNativeAndroidAvailable();
       return RNIapModule.getItemsByType(ANDROID_ITEM_TYPE_SUBSCRIPTION, skus);
     },
   })();
@@ -264,11 +264,11 @@ InAppPurchase | SubscriptionPurchase
 )[]> =>
   Platform.select({
     ios: async () => {
-      checkNativeiOSAvailable();
+      await checkNativeiOSAvailable();
       return RNIapIos.getAvailableItems();
     },
     android: async () => {
-      checkNativeAndroidAvailable();
+      await checkNativeAndroidAvailable();
       const products = await RNIapModule.getPurchaseHistoryByType(
         ANDROID_ITEM_TYPE_IAP,
       );
@@ -288,11 +288,11 @@ InAppPurchase | SubscriptionPurchase
 )[]> =>
   Platform.select({
     ios: async () => {
-      checkNativeiOSAvailable();
+      await checkNativeiOSAvailable();
       return RNIapIos.getAvailableItems();
     },
     android: async () => {
-      checkNativeAndroidAvailable();
+      await checkNativeAndroidAvailable();
       const products = await RNIapModule.getAvailableItemsByType(
         ANDROID_ITEM_TYPE_IAP,
       );
@@ -328,14 +328,14 @@ export const requestPurchase = (
           'You are dangerously allowing react-native-iap to finish your transaction automatically. You should set andDangerouslyFinishTransactionAutomatically to false when calling requestPurchase and call finishTransaction manually when you have delivered the purchased goods to the user. It defaults to true to provide backwards compatibility. Will default to false in version 4.0.0.',
         );
       }
-      checkNativeiOSAvailable();
+      await checkNativeiOSAvailable();
       return RNIapIos.buyProduct(
         sku,
         andDangerouslyFinishTransactionAutomaticallyIOS,
       );
     },
     android: async () => {
-      checkNativeAndroidAvailable();
+      await checkNativeAndroidAvailable();
       return RNIapModule.buyItemByType(
         ANDROID_ITEM_TYPE_IAP,
         sku,
@@ -376,14 +376,14 @@ export const requestSubscription = (
           'You are dangerously allowing react-native-iap to finish your transaction automatically. You should set andDangerouslyFinishTransactionAutomatically to false when calling requestPurchase and call finishTransaction manually when you have delivered the purchased goods to the user. It defaults to true to provide backwards compatibility. Will default to false in version 4.0.0.',
         );
       }
-      checkNativeiOSAvailable();
+      await checkNativeiOSAvailable();
       return RNIapIos.buyProduct(
         sku,
         andDangerouslyFinishTransactionAutomaticallyIOS,
       );
     },
     android: async () => {
-      checkNativeAndroidAvailable();
+      await checkNativeAndroidAvailable();
       if (!prorationModeAndroid) prorationModeAndroid = -1;
       return RNIapModule.buyItemByType(
         ANDROID_ITEM_TYPE_SUBSCRIPTION,
@@ -407,7 +407,7 @@ export const requestPurchaseWithQuantityIOS = (
 ): Promise<InAppPurchase> =>
   Platform.select({
     ios: async () => {
-      checkNativeiOSAvailable();
+      await checkNativeiOSAvailable();
       return RNIapIos.buyProductWithQuantityIOS(sku, quantity);
     },
   })();
@@ -423,7 +423,7 @@ export const requestPurchaseWithQuantityIOS = (
 export const finishTransactionIOS = (transactionId: string): Promise<void> =>
   Platform.select({
     ios: async () => {
-      checkNativeiOSAvailable();
+      await checkNativeiOSAvailable();
       return RNIapIos.finishTransaction(transactionId);
     },
   })();
@@ -442,7 +442,7 @@ export const finishTransaction = (
 ): Promise<string | void> => {
   return Platform.select({
     ios: async () => {
-      checkNativeiOSAvailable();
+      await checkNativeiOSAvailable();
       return RNIapIos.finishTransaction(purchase.transactionId);
     },
     android: async () => {
@@ -480,7 +480,7 @@ export const finishTransaction = (
 export const clearTransactionIOS = (): Promise<void> => {
   return Platform.select({
     ios: async () => {
-      checkNativeiOSAvailable();
+      await checkNativeiOSAvailable();
       return RNIapIos.clearTransaction();
     },
     android: async () => Promise.resolve(),
@@ -492,13 +492,13 @@ export const clearTransactionIOS = (): Promise<void> => {
  *   Remove all products which are validated by Apple server.
  * @returns {void}
  */
-export const clearProductsIOS = (): void =>
+export const clearProductsIOS = (): Promise<void> =>
   Platform.select({
-    ios: () => {
-      checkNativeiOSAvailable();
+    ios: async () => {
+      await checkNativeiOSAvailable();
       return RNIapIos.clearProducts();
     },
-    android: async () => Promise.resolve,
+    android: async () => undefined,
   })();
 
 /**
@@ -513,7 +513,7 @@ export const acknowledgePurchaseAndroid = (
   Platform.select({
     ios: async () => Promise.resolve(),
     android: async () => {
-      checkNativeAndroidAvailable();
+      await checkNativeAndroidAvailable();
       return RNIapModule.acknowledgePurchase(token, developerPayload);
     },
   })();
@@ -530,7 +530,7 @@ export const consumePurchaseAndroid = (
   Platform.select({
     ios: async () => Promise.resolve(),
     android: async () => {
-      checkNativeAndroidAvailable();
+      await checkNativeAndroidAvailable();
       return RNIapModule.consumeProduct(token, developerPayload);
     },
   })();
@@ -543,7 +543,7 @@ export const consumePurchaseAndroid = (
 export const getPromotedProductIOS = (): Promise<string> =>
   Platform.select({
     ios: async () => {
-      checkNativeiOSAvailable();
+      await checkNativeiOSAvailable();
       return RNIapIos.promotedProduct();
     },
     android: async () => Promise.resolve(),
@@ -557,7 +557,7 @@ export const getPromotedProductIOS = (): Promise<string> =>
 export const buyPromotedProductIOS = (): Promise<void> =>
   Platform.select({
     ios: async () => {
-      checkNativeiOSAvailable();
+      await checkNativeiOSAvailable();
       return RNIapIos.buyPromotedProduct();
     },
     android: async () => Promise.resolve(),
@@ -585,7 +585,7 @@ export const requestPurchaseWithOfferIOS = (
 ): Promise<void> =>
   Platform.select({
     ios: async () => {
-      checkNativeiOSAvailable();
+      await checkNativeiOSAvailable();
       return RNIapIos.buyProductWithOffer(sku, forUser, withOffer);
     },
     android: async () => Promise.resolve(),
@@ -700,9 +700,9 @@ export const purchaseErrorListener = (
  * Get the current receipt base64 encoded in IOS.
  * @returns {Promise<string>}
  */
-export const getReceiptIOS = (): Promise<string> => {
+export const getReceiptIOS = async (): Promise<string> => {
   if (Platform.OS === 'ios') {
-    checkNativeiOSAvailable();
+    await checkNativeiOSAvailable();
     return RNIapIos.requestReceipt();
   }
 };
@@ -711,9 +711,9 @@ export const getReceiptIOS = (): Promise<string> => {
  * Get the pending purchases in IOS.
  * @returns {Promise<ProductPurchase[]>}
  */
-export const getPendingPurchasesIOS = (): Promise<ProductPurchase[]> => {
+export const getPendingPurchasesIOS = async (): Promise<ProductPurchase[]> => {
   if (Platform.OS === 'ios') {
-    checkNativeiOSAvailable();
+    await checkNativeiOSAvailable();
     return RNIapIos.getPendingTransactions();
   }
 };

--- a/index.ts
+++ b/index.ts
@@ -208,14 +208,16 @@ export const endConnectionAndroid = (): Promise<void> => {
  * @deprecated
  * @returns {Promise<string[]>}
  */
-export const consumeAllItemsAndroid = (): Promise<string[]> =>
-  Platform.select({
+export const consumeAllItemsAndroid = (): Promise<string[]> => {
+  console.warn('consumeAllItemsAndroid is deprecated and will be removed in the future. Please use flushFailedPurchasesCachedAsPendingAndroid instead');
+  return Platform.select({
     ios: async () => Promise.resolve(),
     android: async () => {
       await checkNativeAndroidAvailable();
       return RNIapModule.refreshItems();
     },
   })();
+};
 
 /**
  * Consume all 'ghost' purchases (that is, pending payment that already failed but is still marked as pending in Play Store cache). Android only.

--- a/index.ts
+++ b/index.ts
@@ -202,6 +202,10 @@ export const endConnectionAndroid = (): Promise<void> => {
 
 /**
  * Consume all remaining tokens. Android only.
+ * This is considered dangerous as you should deliver the purchased feature BEFORE consuming it.
+ * If you used this method to refresh Play Store cache (of failed pending payment still marked as failed),
+ *  prefer using flushFailedPurchasesCachedAsPendingAndroid
+ * @deprecated
  * @returns {Promise<string[]>}
  */
 export const consumeAllItemsAndroid = (): Promise<string[]> =>
@@ -210,6 +214,19 @@ export const consumeAllItemsAndroid = (): Promise<string[]> =>
     android: async () => {
       await checkNativeAndroidAvailable();
       return RNIapModule.refreshItems();
+    },
+  })();
+
+/**
+ * Consume all 'ghost' purchases (that is, pending payment that already failed but is still marked as pending in Play Store cache). Android only.
+ * @returns {Promise<boolean>}
+ */
+export const flushFailedPurchasesCachedAsPendingAndroid = (): Promise<string[]> =>
+  Platform.select({
+    ios: async () => Promise.resolve(),
+    android: async () => {
+      await checkNativeAndroidAvailable();
+      return RNIapModule.flushFailedPurchasesCachedAsPending();
     },
   })();
 
@@ -729,6 +746,7 @@ const iapUtils = {
   getAvailablePurchases,
   getPendingPurchasesIOS,
   consumeAllItemsAndroid,
+  flushFailedPurchasesCachedAsPendingAndroid,
   clearProductsIOS,
   clearTransactionIOS,
   acknowledgePurchaseAndroid,


### PR DESCRIPTION
### The issue

I noticed that using `consumeAllItemsAndroid` is **pretty dangerous in non-dev** environnement:
If a purchase becomes successful while the app is offline or killed, then calling `consumeAllItemsAndroid` will consume the successful purchase without ever notifying the host app, preventing the purchased product from being delivered (although it is billed)

However `consumeAllItemsAndroid` still appears to be pretty **useful in some prod cases**:
When a pending payment fails:
- the app is never notified of the fail (#1012)
- the purchase remains pending due to Play Store cache (related Android issues: https://github.com/android/play-billing-samples/issues/272, https://issuetracker.google.com/issues/73982566 & https://issuetracker.google.com/issues/149668311)

The only way (that I am aware of) to force the cache refresh is to try to consume the pending purchase. You would then get a `BillingResponseCode.ITEM_NOT_OWNED` error, and the item is available for purchase again. (credit to [this post](https://github.com/android/play-billing-samples/issues/272#issuecomment-667688696))
This fix was already suggested in some issues: https://github.com/dooboolab/react-native-iap/issues/126#issuecomment-439084872


### The solution suggested in this PR

We should expose a method to flush all failed purchases that are still - wrongly - marked as pending.

It would simply fetch all **pending** purchases, and try to consume then individually:
- if they are indeed pending, we would get `BillingResponseCode.DEVELOPER_ERROR`
- if they were actually already failed, we would get `BillingResponseCode.ITEM_NOT_OWNED`

-----

Happy to get your feedback on the implementation/naming/...

I am not a big fan of the "callback hell" of the readme. I guess migrating the example/doc to hooks would help but that a subject for another PR


Worthy discussion:
- should that be the behaviour by default (done by default in `initConnection`)?