### PR TITLE
Adding RNIap.initConnection() to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ class RootComponent extends Component<*> {
   purchaseErrorSubscription = null
 
   componentDidMount() {
+    await RNIap.initConnection();
     this.purchaseUpdateSubscription = purchaseUpdatedListener((purchase: InAppPurchase | SubscriptionPurchase | ProductPurchase ) => {
       console.log('purchaseUpdatedListener', purchase);
       const receipt = purchase.transactionReceipt;

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ class RootComponent extends Component<*> {
   purchaseUpdateSubscription = null
   purchaseErrorSubscription = null
 
-  componentDidMount() {
+  async componentDidMount() {
     await RNIap.initConnection();
     this.purchaseUpdateSubscription = purchaseUpdatedListener((purchase: InAppPurchase | SubscriptionPurchase | ProductPurchase ) => {
       console.log('purchaseUpdatedListener', purchase);


### PR DESCRIPTION
This is required for iOS. A lot of issues being opened on Github are related to developers not including this since it's not in the basic example.