### PR TITLE
feat: Allow specyfing string subtype for product ids

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -55,9 +55,9 @@ export interface Discount {
   subscriptionPeriod: string;
 }
 
-export interface Product extends Common {
+export interface Product<ProductId extends string = string> extends Common {
   type: 'inapp' | 'iap';
-  productId: string;
+  productId: ProductId;
 }
 
 export interface Subscription extends Common {
@@ -218,14 +218,16 @@ export const consumeAllItemsAndroid = (): Promise<string[]> =>
  * @param {string[]} skus The item skus
  * @returns {Promise<Product[]>}
  */
-export const getProducts = (skus: string[]): Promise<Product[]> =>
+export const getProducts = <SkuType extends string>(
+  skus: SkuType[],
+): Promise<Array<Product<SkuType>>> =>
   Platform.select({
     ios: async () => {
       if (!RNIapIos) {
         return [];
       }
-      return RNIapIos.getItems(skus).then((items: Product[]) =>
-        items.filter((item: Product) => item.productId),
+      return RNIapIos.getItems(skus).then((items: Product<SkuType>[]) =>
+        items.filter((item: Product<SkuType>) => item.productId),
       );
     },
     android: async () => {


### PR DESCRIPTION
# Issue

I want to protect myself by restraining the acceptable skus in my application (either with `type ItemSku = 'sku1' | 'sku2' | ...` or `enum ItemSku { sku1 = 'sku1', sku2 = 'sku2', ... }`

However, `getProducts` returns products with `productId` typed as `string`

# Fix

getProducts now infers the type of `productId` from its input



This is backward compatible as the typing is optionnal and defaults to the current `string`