### PR TITLE
feat: Let user know which productId was the error about

### DIFF
--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -408,6 +408,7 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
           error.putString("debugMessage", debugMessage);
           error.putString("code", PROMISE_BUY_ITEM);
           error.putString("message", debugMessage);
+          error.putString("productId", sku);
           sendEvent(reactContext, "purchase-error", error);
           promise.reject(PROMISE_BUY_ITEM, debugMessage);
           return;
@@ -427,6 +428,7 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
               error.putString("debugMessage", debugMessage);
               error.putString("code", PROMISE_BUY_ITEM);
               error.putString("message", debugMessage);
+              error.putString("productId", sku);
               sendEvent(reactContext, "purchase-error", error);
               promise.reject(PROMISE_BUY_ITEM, debugMessage);
               return;

--- a/index.ts
+++ b/index.ts
@@ -113,6 +113,7 @@ export interface PurchaseError {
   debugMessage?: string;
   code?: string;
   message?: string;
+  productId?: string;
 }
 
 export type InAppPurchase = ProductPurchase;

--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -165,6 +165,7 @@ RCT_EXPORT_METHOD(buyProduct:(NSString*)sku
                                  @"Invalid product ID.", @"debugMessage",
                                  @"E_DEVELOPER_ERROR", @"code",
                                  @"Invalid product ID.", @"message",
+                                 sku, @"productId",
                                  nil
                                  ];
             [self sendEventWithName:@"purchase-error" body:err];
@@ -212,6 +213,7 @@ RCT_EXPORT_METHOD(buyProductWithOffer:(NSString*)sku
                                  @"Invalid product ID.", @"debugMessage",
                                  @"Invalid product ID.", @"message",
                                  @"E_DEVELOPER_ERROR", @"code",
+                                 sku, @"productId",
                                  nil
                                  ];
             [self sendEventWithName:@"purchase-error" body:err];
@@ -244,6 +246,7 @@ RCT_EXPORT_METHOD(buyProductWithQuantityIOS:(NSString*)sku
                                  @"Invalid product ID.", @"debugMessage",
                                  @"Invalid product ID.", @"message",
                                  @"E_DEVELOPER_ERROR", @"code",
+                                 sku, @"productId",
                                  nil
                                  ];
             [self sendEventWithName:@"purchase-error" body:err];
@@ -405,6 +408,7 @@ RCT_EXPORT_METHOD(getPendingTransactions:(RCTPromiseResolveBlock)resolve
                                              @"The payment was deferred (awaiting approval via parental controls for instance)", @"debugMessage",
                                              @"E_DEFERRED_PAYMENT", @"code",
                                              @"The payment was deferred (awaiting approval via parental controls for instance)", @"message",
+                                             transaction.payment.productIdentifier, @"productId",
                                              nil
                                              ];
                         [self sendEventWithName:@"purchase-error" body:err];
@@ -427,6 +431,7 @@ RCT_EXPORT_METHOD(getPendingTransactions:(RCTPromiseResolveBlock)resolve
                                              transaction.error.localizedDescription, @"debugMessage",
                                              [self standardErrorCode:(int)transaction.error.code], @"code",
                                              transaction.error.localizedDescription, @"message",
+                                             transaction.payment.productIdentifier, @"productId",
                                              nil
                                              ];
                         [self sendEventWithName:@"purchase-error" body:err];


### PR DESCRIPTION
Let users know which productId is the error about, on purchaseErrorListener

Always provided for ios. Not provided for android for non product-specific error