### PR TITLE
Adding JavaVersion on build.gradle to work with Detox tests

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,6 +37,10 @@ android {
   lintOptions {
     abortOnError false
   }
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
 }
 
 repositories {


### PR DESCRIPTION
I was unable to create Detox tests without these lines of code specifying the Java version in build.gradle. Basically, without the JavaVersion, the Multidex conversion when compiling tests doesn't work well.