### PR TITLE
Fix for 'RNIapModule.buyItemByType got 6 arguments, expected 7'

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -359,6 +359,7 @@ export const requestPurchase = (
         ANDROID_ITEM_TYPE_IAP,
         sku,
         null,
+        null,
         0,
       );
     },


### PR DESCRIPTION
This is a fix to issue 1131:
https://github.com/dooboolab/react-native-iap/issues/1131

The issue happened because of this change on line 420:
https://github.com/dooboolab/react-native-iap/commit/d5785e55e298934bbbb83c972497ae1d9631e359#diff-b21dbc2d57e14bf6f1b5f81c3a3c3ba5