### PR TITLE
Fix that getPendingPurchasesIOS() may returns undefined.

### DIFF
--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -305,12 +305,9 @@ RCT_EXPORT_METHOD(finishTransaction:(NSString*)transactionIdentifier) {
 RCT_EXPORT_METHOD(getPendingTransactions:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
     [self requestReceiptDataWithBlock:^(NSData *receiptData, NSError *error) {
-        if (receiptData == nil) {
-            resolve(nil);
-        }
-        else {
+        NSMutableArray *output = [NSMutableArray array];
+        if (receiptData != nil) {
             NSArray<SKPaymentTransaction *> *transactions = [[SKPaymentQueue defaultQueue] transactions];
-            NSMutableArray *output = [NSMutableArray array];
 
             for (SKPaymentTransaction *item in transactions) {
                 NSMutableDictionary *purchase = [NSMutableDictionary dictionaryWithObjectsAndKeys:
@@ -322,9 +319,8 @@ RCT_EXPORT_METHOD(getPendingTransactions:(RCTPromiseResolveBlock)resolve
                                                  ];
                 [output addObject:purchase];
             }
-
-            resolve(output);
         }
+        resolve(output);
     }];
 }
 


### PR DESCRIPTION
Although `getPendingPurchasesIOS()` typescript definition mentioned like below, 
```ts
/**
 * Get the pending purchases in IOS.
 * @returns {Promise<ProductPurchase[]>}
 */
export const getPendingPurchasesIOS = async (): Promise<ProductPurchase[]> => {
  if (Platform.OS === 'ios') {
    await checkNativeiOSAvailable();

    return RNIapIos.getPendingTransactions();
  }
};
```
Objective-C code had possibility to return `undefined` because it passed `nil` for `resolve()`.

(My app received a crash report because of this. 😭 )