### PR TITLE
feat: added presentCodeRedemptionSheetIOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ _*deprecated_<br>~~`buySubscription(sku: string)`~~<ul><li>sku: subscription ID/
 `getReceiptIOS()`   | `Promise<string>` | **iOS only**<br>Get the current receipt.
 `getPendingPurchasesIOS()` | `Promise<ProductPurchase[]>` | **IOS only**<br>Gets all the transactions which are pending to be finished.
 `validateReceiptIos(body: Record<string, unknown>, devMode: boolean)`<ul><li>body: receiptBody</li><li>devMode: isTest</li></ul> | `Object\|boolean` | **iOS only**<br>Validate receipt.
+`presentCodeRedemptionSheetIOS()` | `Promise<null>` | **iOS only**<br>Availability: `iOS 14.0+`<br>Displays a sheet that enables users to redeem subscription offer codes that you generated in App Store Connect.
 `endConnection()` | `Promise<void>` | End billing connection.
 `consumeAllItemsAndroid()` | `Promise<void>` | **Android only**<br>Consume all items so they are able to buy again. ⚠️ Use in dev only (as you should deliver the purchased feature BEFORE consuming it)
 `flushFailedPurchasesCachedAsPendingAndroid()` | `Promise<void>` | **Android only**<br>Consume all 'ghost' purchases (that is, pending payment that already failed but is still marked as pending in Play Store cache)

--- a/index.ts
+++ b/index.ts
@@ -935,6 +935,18 @@ export const getPendingPurchasesIOS = async (): Promise<ProductPurchase[]> => {
   }
 };
 
+/**
+ * Launches a modal to register the redeem offer code in IOS.
+ * @returns {Promise<null>}
+ */
+export const presentCodeRedemptionSheetIOS = async (): Promise<null> => {
+  if (Platform.OS === 'ios') {
+    await checkNativeiOSAvailable();
+
+    return RNIapIos.presentCodeRedemptionSheet();
+  }
+};
+
 const iapUtils = {
   IAPErrorCode,
   initConnection,
@@ -963,6 +975,7 @@ const iapUtils = {
   getReceiptIOS,
   getPromotedProductIOS,
   buyPromotedProductIOS,
+  presentCodeRedemptionSheetIOS,
 };
 
 export default iapUtils;

--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -328,6 +328,16 @@ RCT_EXPORT_METHOD(getPendingTransactions:(RCTPromiseResolveBlock)resolve
     }];
 }
 
+RCT_EXPORT_METHOD(presentCodeRedemptionSheet:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    if (@available(iOS 14.0, *)) {
+        [[SKPaymentQueue defaultQueue] presentCodeRedemptionSheet];
+        resolve(nil);
+    } else {
+        reject([self standardErrorCode:2], @"This method only available above iOS 14", nil);
+    }
+}
+
 #pragma mark ===== StoreKit Delegate
 
 -(void)productsRequest:(SKProductsRequest *)request didReceiveResponse:(SKProductsResponse *)response {


### PR DESCRIPTION
This method displays a sheet that enables users to redeem subscription offer codes and works only on real-devices.

![image](https://user-images.githubusercontent.com/26326015/101307727-7afde000-388b-11eb-8625-eef5c0dbdb06.png)
