### PR TITLE
Revert "Add iOS store country code"

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,6 @@ Property                                 | iOS | And | Comment
 `price`                                  | ✓   | ✓   | Localized price string, with only number (eg. `1.99`).
 `productId`                              | ✓   | ✓   | Returns a string needed to purchase the item later.
 `currency`                               | ✓   | ✓   | Returns the currency code.
-`countryCode`                            | ✓   |     | Returns the store country code.
 `localizedPrice`                         | ✓   | ✓   | Localized price string, with number and currency symbol (eg. `$1.99`).
 `title`                                  | ✓   | ✓   | Returns the title Android and localizedTitle on iOS.
 `description`                            | ✓   | ✓   | Returns the localized description on Android and iOS.

--- a/index.ts
+++ b/index.ts
@@ -16,8 +16,6 @@ interface Common {
   price: string;
   currency: string;
   localizedPrice: string;
-
-  countryCodeIOS?: string;
 }
 
 export enum IAPErrorCode {

--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -554,7 +554,6 @@ RCT_EXPORT_METHOD(presentCodeRedemptionSheet:(RCTPromiseResolveBlock)resolve
     NSString* introductoryPriceSubscriptionPeriod = @"";
 
     NSString* currencyCode = @"";
-    NSString* countryCode = @"";
     NSString* periodNumberIOS = @"0";
     NSString* periodUnitIOS = @"";
 
@@ -630,12 +629,6 @@ RCT_EXPORT_METHOD(presentCodeRedemptionSheet:(RCTPromiseResolveBlock)resolve
         currencyCode = product.priceLocale.currencyCode;
     }
 
-    if (@available(iOS 13.0, *)) {
-        countryCode = [[SKPaymentQueue defaultQueue].storefront countryCode];
-    } else if (@available(iOS 10.0, *)) {
-        countryCode = product.priceLocale.countryCode;
-    }
-
     NSArray *discounts;
     #if __IPHONE_12_2
     if (@available(iOS 12.2, *)) {
@@ -647,7 +640,6 @@ RCT_EXPORT_METHOD(presentCodeRedemptionSheet:(RCTPromiseResolveBlock)resolve
                          product.productIdentifier, @"productId",
                          [product.price stringValue], @"price",
                          currencyCode, @"currency",
-                         countryCode, @"countryCode",
                          itemType, @"type",
                          product.localizedTitle ? product.localizedTitle : @"", @"title",
                          product.localizedDescription ? product.localizedDescription : @"", @"description",


### PR DESCRIPTION
Reverts dooboolab/react-native-iap#1186 due to https://github.com/dooboolab/react-native-iap/issues/1203
This seems to be a very optional field for now, but the change seems to be introducing issues in the production.
Let's revert this for now and release a new version please.