### PR TITLE
Release 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,11 @@
 - Fixed android receipt validation url.
 
 ## 5.2.12
-
 - Rebuild again incase of missing pre-build.
+
+## 6.0.0
+
+- React Naitve IAP hook is out. [Follow the medium post](https://medium.com/dooboolab/announcing-react-native-iap-hooks-96c7ffd3f19a) on how to use it.
 
 ## 5.2.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 ## 5.2.12
 
 - Rebuild again incase of missing pre-build.
+## 6.0.0
+
+- React Naitve IAP hook is out. [Follow the medium post](https://medium.com/dooboolab/announcing-react-native-iap-hooks-96c7ffd3f19a) on how to use it.
 
 ## 5.2.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@
 
 - React Naitve IAP hook is out. [Follow the medium post](https://medium.com/dooboolab/announcing-react-native-iap-hooks-96c7ffd3f19a) on how to use it.
 
+## 5.2.13
+
+- Fixed android receipt validation url [#1262](https://github.com/dooboolab/react-native-iap/issues/1262).
+
 ## 5.2.11
 
 - Fixed fetch requestheader [#1258](https://github.com/dooboolab/react-native-iap/issues/1258).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelogs
 
+## 6.0.0
+
+- React Naitve IAP hook is out. [Follow the medium post](https://medium.com/dooboolab/announcing-react-native-iap-hooks-96c7ffd3f19a) on how to use it.
+
 ## 5.2.14
 
 - Remove IAPPromotionObserver for manual installation process [#1267](https://github.com/dooboolab/react-native-iap/pull/1267).
@@ -9,29 +13,7 @@
 - Fixed android receipt validation url [#1262](https://github.com/dooboolab/react-native-iap/issues/1262).
 
 ## 5.2.12
-
 - Rebuild again incase of missing pre-build.
-## 6.0.0
-
-- React Naitve IAP hook is out. [Follow the medium post](https://medium.com/dooboolab/announcing-react-native-iap-hooks-96c7ffd3f19a) on how to use it.
-
-## 5.2.13
-
-- Fixed android receipt validation url [#1262](https://github.com/dooboolab/react-native-iap/issues/1262).
-## 5.2.12
-
-- Fixed android receipt validation url.
-
-## 5.2.12
-- Rebuild again incase of missing pre-build.
-
-## 6.0.0
-
-- React Naitve IAP hook is out. [Follow the medium post](https://medium.com/dooboolab/announcing-react-native-iap-hooks-96c7ffd3f19a) on how to use it.
-
-## 5.2.13
-
-- Fixed android receipt validation url [#1262](https://github.com/dooboolab/react-native-iap/issues/1262).
 
 ## 5.2.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@
 
 - React Naitve IAP hook is out. [Follow the medium post](https://medium.com/dooboolab/announcing-react-native-iap-hooks-96c7ffd3f19a) on how to use it.
 
+## 5.2.13
+
+- Fixed android receipt validation url [#1262](https://github.com/dooboolab/react-native-iap/issues/1262).
+
 ## 5.2.11
 
 - Fixed fetch requestheader [#1258](https://github.com/dooboolab/react-native-iap/issues/1258).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 ## 5.2.13
 
 - Fixed android receipt validation url [#1262](https://github.com/dooboolab/react-native-iap/issues/1262).
+## 5.2.12
+
+- Rebuild again incase of missing pre-build.
 
 ## 5.2.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 - Fixed android receipt validation url [#1262](https://github.com/dooboolab/react-native-iap/issues/1262).
 ## 5.2.12
 
+- Fixed android receipt validation url.
+
+## 5.2.12
+
 - Rebuild again incase of missing pre-build.
 
 ## 5.2.11

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 React Native IAP hook is out. You can see [medium post](https://medium.com/dooboolab/announcing-react-native-iap-hooks-96c7ffd3f19a) on how to use it.
 
 The `react-native-iap` module hasn't been maintained well recently. We are thinking of participating again and make the module healthier. Please refer to [2021 Maintenance plan](https://github.com/dooboolab/react-native-iap/issues/1241) and share with us how you or your organization is using it. Happy new year 🎉
+- The sample code is out in [Sponsor page](https://github.com/hyochan/dooboolab.com/blob/master/src/components/pages/Sponsor.tsx) in [dooboolab.com](https://github.com/hyochan/dooboolab.com) repository which sadly is rejected by Apple because of lacking product features. I will work on another example project to support this module.
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Announcement
 
-React Native IAP hook is out. You can see [medium post](https://medium.com/dooboolab/announcing-react-native-iap-hooks-96c7ffd3f19a) on how to use it. This is currently available in `next` package from `react-native-iap@next`. The `master` branch is currently heading to `stable` package and `next` version is in `next` branch.
+React Native IAP hook is out. You can see [medium post](https://medium.com/dooboolab/announcing-react-native-iap-hooks-96c7ffd3f19a) on how to use it.
 
 The `react-native-iap` module hasn't been maintained well recently. We are thinking of participating again and make the module healthier. Please refer to [2021 Maintenance plan](https://github.com/dooboolab/react-native-iap/issues/1241) and share with us how you or your organization is using it. Happy new year 🎉
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iap",
-  "version": "6.0.0-rc.14",
+  "version": "6.0.0-rc.15",
   "description": "React Native In App Purchase Module.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iap",
-  "version": "6.0.0-rc.22",
+  "version": "6.0.0-rc.23",
   "description": "React Native In App Purchase Module.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iap",
-  "version": "6.0.0-rc.15",
+  "version": "6.0.0-rc.21",
   "description": "React Native In App Purchase Module.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iap",
-  "version": "6.0.0-rc.6",
+  "version": "6.0.0-rc.12",
   "description": "React Native In App Purchase Module.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iap",
-  "version": "6.0.0-rc.21",
+  "version": "6.0.0-rc.22",
   "description": "React Native In App Purchase Module.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iap",
-  "version": "5.2.14",
+  "version": "6.0.0-rc.1",
   "description": "React Native In App Purchase Module.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iap",
-  "version": "6.0.0-rc.13",
+  "version": "6.0.0-rc.14",
   "description": "React Native In App Purchase Module.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iap",
-  "version": "6.0.0-rc.2",
+  "version": "6.0.0-rc.6",
   "description": "React Native In App Purchase Module.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iap",
-  "version": "6.0.0-rc.1",
+  "version": "6.0.0-rc.2",
   "description": "React Native In App Purchase Module.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iap",
-  "version": "6.0.0-rc.12",
+  "version": "6.0.0-rc.13",
   "description": "React Native In App Purchase Module.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iap",
-  "version": "6.0.0-rc.23",
+  "version": "6.0.0",
   "description": "React Native In App Purchase Module.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -899,7 +899,6 @@ const iapUtils = {
   presentCodeRedemptionSheetIOS,
 };
 
-export * as useIAP from './hooks/useIAP';
 export * from './types';
 export {useIAP} from './hooks/useIAP';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,6 @@ import {
   SubscriptionPurchase,
 } from './types';
 
-import useIAP from './hooks/useIAP';
-
 const {RNIapIos, RNIapModule, RNIapAmazonModule} = NativeModules;
 
 const ANDROID_ITEM_TYPE_SUBSCRIPTION = 'subs';
@@ -899,10 +897,10 @@ const iapUtils = {
   getPromotedProductIOS,
   buyPromotedProductIOS,
   presentCodeRedemptionSheetIOS,
-  useIAP,
 };
 
 export * as useIAP from './hooks/useIAP';
 export * from './types';
+export {useIAP} from './hooks/useIAP';
 
 export default iapUtils;

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,8 @@ import {
   SubscriptionPurchase,
 } from './types';
 
+import useIAP from './hooks/useIAP';
+
 const {RNIapIos, RNIapModule, RNIapAmazonModule} = NativeModules;
 
 const ANDROID_ITEM_TYPE_SUBSCRIPTION = 'subs';
@@ -897,9 +899,9 @@ const iapUtils = {
   getPromotedProductIOS,
   buyPromotedProductIOS,
   presentCodeRedemptionSheetIOS,
+  useIAP,
 };
 
-export * from './types';
 export * as useIAP from './hooks/useIAP';
 export * from './types';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -900,5 +900,6 @@ const iapUtils = {
 };
 
 export * from './types';
+export * as useIAP from './hooks/useIAP';
 
 export default iapUtils;

--- a/src/index.ts
+++ b/src/index.ts
@@ -901,5 +901,6 @@ const iapUtils = {
 
 export * from './types';
 export * as useIAP from './hooks/useIAP';
+export * from './types';
 
 export default iapUtils;


### PR DESCRIPTION
React Naitve IAP hook is out. [Follow the medium post](https://medium.com/dooboolab/announcing-react-native-iap-hooks-96c7ffd3f19a) on how to use it.

The sample code is out in [Sponsor page](https://github.com/hyochan/dooboolab.com/blob/master/src/components/pages/Sponsor.tsx) in [dooboolab.com](https://github.com/hyochan/dooboolab.com) repository which sadly is rejected by Apple because of lacking product features. I will work on another example project to support `react-native-iap`.

More description in https://github.com/dooboolab/react-native-iap/issues/1241#issuecomment-798540785.