### PR TITLE
Adding introductoryPriceAsAmountAndroid

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Property                                 | iOS | And | Comment
 `title`                                  | ✓   | ✓   | Returns the title Android and localizedTitle on iOS.
 `description`                            | ✓   | ✓   | Returns the localized description on Android and iOS.
 `introductoryPrice`                      | ✓   | ✓   | Formatted introductory price of a subscription, including its currency sign, such as €3.99.<br>The price doesn't include tax.
+`introductoryPriceAsAmountAndroid`       |     | ✓   | Localized introductory price string, with only number (eg. `0.99`).
 `introductoryPriceAsAmountIOS`           | ✓   |     | Localized introductory price string, with only number (eg. `0.99`).
 `introductoryPricePaymentModeIOS`        | ✓   |     | The payment mode for this product discount.
 `introductoryPriceNumberOfPeriods`       | ✓   |     | An integer that indicates the number of periods the product discount is available.

--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -302,8 +302,10 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
               // Use valueOf instead of constructors.
               // See: https://www.javaworld.com/article/2073176/caution--double-to-bigdecimal-in-java.html
               BigDecimal priceAmount = BigDecimal.valueOf(priceAmountMicros);
+              BigDecimal introductoryPriceAmount = BigDecimal.valueOf(introductoryPriceMicros);
               BigDecimal microUnitsDivisor = BigDecimal.valueOf(1000000);
               String price = priceAmount.divide(microUnitsDivisor).toString();
+              String introductoryPriceAsAmountAndroid = introductoryPriceAmount.divide(microUnitsDivisor).toString();
               item.putString("price", price);
               item.putString("currency", skuDetails.getPriceCurrencyCode());
               item.putString("type", skuDetails.getType());
@@ -318,7 +320,7 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
               item.putString("freeTrialPeriodAndroid", skuDetails.getFreeTrialPeriod());
               item.putString("introductoryPriceCyclesAndroid", String.valueOf(skuDetails.getIntroductoryPriceCycles()));
               item.putString("introductoryPricePeriodAndroid", skuDetails.getIntroductoryPricePeriod());
-              item.putString("introductoryPriceAsAmountAndroid", String.valueOf(introductoryPriceMicros / 1000000d));
+              item.putString("introductoryPriceAsAmountAndroid", introductoryPriceAsAmountAndroid);
               item.putString("iconUrl", skuDetails.getIconUrl());
               item.putString("originalJson", skuDetails.getOriginalJson());
               BigDecimal originalPriceAmountMicros = BigDecimal.valueOf(skuDetails.getOriginalPriceAmountMicros());

--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -297,6 +297,7 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
             for (SkuDetails skuDetails : skuDetailsList) {
               WritableMap item = Arguments.createMap();
               item.putString("productId", skuDetails.getSku());
+              long introductoryPriceMicros = skuDetails.getIntroductoryPriceAmountMicros();
               long priceAmountMicros = skuDetails.getPriceAmountMicros();
               // Use valueOf instead of constructors.
               // See: https://www.javaworld.com/article/2073176/caution--double-to-bigdecimal-in-java.html
@@ -317,6 +318,7 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
               item.putString("freeTrialPeriodAndroid", skuDetails.getFreeTrialPeriod());
               item.putString("introductoryPriceCyclesAndroid", String.valueOf(skuDetails.getIntroductoryPriceCycles()));
               item.putString("introductoryPricePeriodAndroid", skuDetails.getIntroductoryPricePeriod());
+              item.putString("introductoryPriceAsAmountAndroid", String.valueOf(introductoryPriceMicros / 1000000d));
               item.putString("iconUrl", skuDetails.getIconUrl());
               item.putString("originalJson", skuDetails.getOriginalJson());
               BigDecimal originalPriceAmountMicros = BigDecimal.valueOf(skuDetails.getOriginalPriceAmountMicros());


### PR DESCRIPTION
We already have the iOS version for this property, I'm sure in the future both should be renamed just for `introductoryPriceAsAmount`.

But to avoid breaking changes I think this works for now, my team is already using this fork in production because we needed this for both platforms.