### PR TITLE
[Amazon] Add promise handling for Amazon purchases instead of resolving immediately.

### DIFF
--- a/android/src/main/java/com/dooboolab/RNIap/RNIapAmazonListener.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapAmazonListener.java
@@ -199,6 +199,14 @@ public class RNIapAmazonListener implements PurchasingListener {
         if (response.hasMore()) {
           PurchasingService.getPurchaseUpdates(false);
         } else {
+          if (purchases.size() > 0 && promiseItem != null) {
+            DoobooUtils
+              .getInstance()
+              .resolvePromisesForKey(
+                RNIapAmazonModule.PROMISE_BUY_ITEM,
+                promiseItem
+              );
+          }
           DoobooUtils
             .getInstance()
             .resolvePromisesForKey(
@@ -301,7 +309,18 @@ public class RNIapAmazonListener implements PurchasingListener {
         item.putString("userIdAmazon", userData.getUserId());
         item.putString("userMarketplaceAmazon", userData.getMarketplace());
         item.putString("userJsonAmazon", userData.toJSON().toString());
+
+        WritableMap promiseItem = new WritableNativeMap();
+        promiseItem.merge(item);
+
         sendEvent(reactContext, "purchase-updated", item);
+
+        DoobooUtils
+          .getInstance()
+          .resolvePromisesForKey(
+            RNIapAmazonModule.PROMISE_BUY_ITEM,
+            promiseItem
+          );
         break;
       case ALREADY_PURCHASED:
         debugMessage = "You already own this item.";
@@ -311,6 +330,15 @@ public class RNIapAmazonListener implements PurchasingListener {
         error.putString("code", errorCode);
         error.putString("message", debugMessage);
         sendEvent(reactContext, "purchase-error", error);
+
+        DoobooUtils
+          .getInstance()
+          .rejectPromisesForKey(
+            RNIapAmazonModule.PROMISE_BUY_ITEM,
+            errorCode,
+            debugMessage,
+            null
+          );
         break;
       case FAILED:
         debugMessage =
@@ -321,6 +349,15 @@ public class RNIapAmazonListener implements PurchasingListener {
         error.putString("code", errorCode);
         error.putString("message", debugMessage);
         sendEvent(reactContext, "purchase-error", error);
+
+        DoobooUtils
+          .getInstance()
+          .rejectPromisesForKey(
+            RNIapAmazonModule.PROMISE_BUY_ITEM,
+            errorCode,
+            debugMessage,
+            null
+          );
         break;
       case INVALID_SKU:
         debugMessage = "That item is unavailable.";
@@ -330,6 +367,15 @@ public class RNIapAmazonListener implements PurchasingListener {
         error.putString("code", errorCode);
         error.putString("message", debugMessage);
         sendEvent(reactContext, "purchase-error", error);
+
+        DoobooUtils
+          .getInstance()
+          .rejectPromisesForKey(
+            RNIapAmazonModule.PROMISE_BUY_ITEM,
+            errorCode,
+            debugMessage,
+            null
+          );
         break;
       case NOT_SUPPORTED:
         debugMessage = "This feature is not available on your device.";
@@ -339,6 +385,15 @@ public class RNIapAmazonListener implements PurchasingListener {
         error.putString("code", errorCode);
         error.putString("message", debugMessage);
         sendEvent(reactContext, "purchase-error", error);
+
+        DoobooUtils
+          .getInstance()
+          .rejectPromisesForKey(
+            RNIapAmazonModule.PROMISE_BUY_ITEM,
+            errorCode,
+            debugMessage,
+            null
+          );
         break;
     }
   }

--- a/android/src/main/java/com/dooboolab/RNIap/RNIapAmazonModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapAmazonModule.java
@@ -43,6 +43,7 @@ import org.json.JSONArray;
 public class RNIapAmazonModule extends ReactContextBaseJavaModule {
   final String TAG = "RNIapAmazonModule";
 
+  public static final String PROMISE_BUY_ITEM = "PROMISE_BUY_ITEM";
   public static final String PROMISE_GET_PRODUCT_DATA =
     "PROMISE_GET_PRODUCT_DATA";
   public static final String PROMISE_QUERY_PURCHASES =
@@ -169,8 +170,8 @@ public class RNIapAmazonModule extends ReactContextBaseJavaModule {
     final String obfuscatedProfileId,
     final Promise promise
   ) {
+    DoobooUtils.getInstance().addPromiseForKey(PROMISE_BUY_ITEM, promise);
     RequestId requestId = PurchasingService.purchase(sku);
-    promise.resolve(true);
   }
 
   @ReactMethod


### PR DESCRIPTION
Without this addition, `buyItemByType` on Amazon immediately returns a resolved promise.

This change rejects or resolves the promise similar to how the Google Play implementation does.