### PR TITLE
fire tv detection

### DIFF
--- a/IapExample/package.json
+++ b/IapExample/package.json
@@ -13,7 +13,7 @@
     "apsl-react-native-button": "^3.1.1",
     "react": "16.9.0",
     "react-native": "0.61.5",
-    "react-native-iap": "^5.0.1",
+    "react-native-iap": "^6.0.6",
     "react-navigation": "^4.3.9"
   },
   "devDependencies": {

--- a/IapExample/yarn.lock
+++ b/IapExample/yarn.lock
@@ -2683,10 +2683,10 @@ domexception@^2.0.1:
   dependencies:
     webidl-conversions "^5.0.0"
 
-dooboolab-welcome@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/dooboolab-welcome/-/dooboolab-welcome-1.2.0.tgz#295818ce85a8e97dc90c0ec0510b4008e2d722dc"
-  integrity sha512-XgEbjJHAsKLge/e8jtuHsv84Ovg1Gx0GvnOTOmOlVGV1643nduTAkT3fyo/mxKbzvyXBr47RHaJAY4R2toI0UA==
+dooboolab-welcome@^1.3.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/dooboolab-welcome/-/dooboolab-welcome-1.3.1.tgz#37c4bbae0c84616c37ba9301dc87521ae2e9af86"
+  integrity sha512-KcTf3RVRGO3QADgsEJPFixFqj1c3oZPI3SnS6rVO7soaASi4+iHmVvBFFAf+l/sQsxCbPeV8sGhsdG6ZdSLqmQ==
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -6143,12 +6143,12 @@ react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.9.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
 
-react-native-iap@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/react-native-iap/-/react-native-iap-5.0.1.tgz#12b362049812a833ac251e348c72b407e8fc4b06"
-  integrity sha512-HtN2b/L372rC6y76m2Aso2aQIj8V/9yQNRX6sEN3MLI45xJxt2vfcUnfaVGaLgD9BIQibbzr1BUsuxAVl8rEKA==
+react-native-iap@^6.0.6:
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/react-native-iap/-/react-native-iap-6.0.6.tgz#cb8690139b5036c043ca702cbe8ac4589be38ccc"
+  integrity sha512-UAwWx//SDTTmMTBj2hyhRs6FV0yjZqmnzSOWskFVx3yf8e6nyVeYdP59eJG7g42pGf116sX4ZYe75E8JooQRiQ==
   dependencies:
-    dooboolab-welcome "^1.2.0"
+    dooboolab-welcome "^1.3.0"
 
 react-native-safe-area-view@^0.14.9:
   version "0.14.9"

--- a/android/src/main/java/com/dooboolab/RNIap/DoobooUtils.java
+++ b/android/src/main/java/com/dooboolab/RNIap/DoobooUtils.java
@@ -271,8 +271,7 @@ public class DoobooUtils {
     return array;
   }
 
-
-  private static final String AMAZON_FEATURE_FIRE_TV = "amazon.hardware.fire_tv";
+    private static final String AMAZON_FEATURE_FIRE_TV = "amazon.hardware.fire_tv";
   private static final String AMAZON_FIRE_TV_MODEL_PREFIX = "AFT";
 
   /**
@@ -303,3 +302,4 @@ public class DoobooUtils {
       return APPSTORE_UNKNOWN;
     }
   }
+}

--- a/android/src/main/java/com/dooboolab/RNIap/DoobooUtils.java
+++ b/android/src/main/java/com/dooboolab/RNIap/DoobooUtils.java
@@ -272,6 +272,13 @@ public class DoobooUtils {
 
 
   /**
+   * Detects Stores:
+   * Amazon tablets and Fire TV are considered as APPSTORE_AMAZON
+   * using recommended detection logic from:
+   * https://developer.amazon.com/docs/fire-tv/identify-amazon-fire-tv-devices.html
+   * @param context Application context
+   * @return One of APPSTORE_AMAZON,APPSTORE_GOOGLE,APPSTORE_UNKNOWN
+   *
    * Suppressing deprecation since the alternative requires API level 30
    */
   @SuppressWarnings("deprecation")
@@ -280,15 +287,15 @@ public class DoobooUtils {
     PackageManager pkgManager = appContext.getPackageManager();
     String installerPackageName = pkgManager.getInstallerPackageName(appContext.getPackageName());
 
-    if (installerPackageName == null) {
-      return APPSTORE_UNKNOWN;
+    if (pkgManager.hasSystemFeature(AMAZON_FEATURE_FIRE_TV) ||
+            (installerPackageName!=null && installerPackageName.startsWith("com.amazon.")) ||
+            Build.MODEL.startsWith(AMAZON_FIRE_TV_MODEL_PREFIX)) {
+      Log.d(TAG, "Yes, this is a Fire TV device.");
+      return APPSTORE_AMAZON;
     } else if ("com.android.vending".equals(installerPackageName)) {
       return APPSTORE_GOOGLE;
-    } else if (installerPackageName.startsWith("com.amazon.")) {
-      return APPSTORE_AMAZON;
-    } else {
+    }  else {
       Log.d(TAG, "Unknown installer source: " + installerPackageName);
+      return APPSTORE_UNKNOWN;
     }
-    return APPSTORE_UNKNOWN;
-  }
 }

--- a/android/src/main/java/com/dooboolab/RNIap/DoobooUtils.java
+++ b/android/src/main/java/com/dooboolab/RNIap/DoobooUtils.java
@@ -1,5 +1,6 @@
 package com.dooboolab.RNIap;
 
+import android.os.Build;
 import android.util.Log;
 
 import com.android.billingclient.api.BillingClient;
@@ -271,6 +272,9 @@ public class DoobooUtils {
   }
 
 
+  private static final String AMAZON_FEATURE_FIRE_TV = "amazon.hardware.fire_tv";
+  private static final String AMAZON_FIRE_TV_MODEL_PREFIX = "AFT";
+
   /**
    * Detects Stores:
    * Amazon tablets and Fire TV are considered as APPSTORE_AMAZON
@@ -298,4 +302,4 @@ public class DoobooUtils {
       Log.d(TAG, "Unknown installer source: " + installerPackageName);
       return APPSTORE_UNKNOWN;
     }
-}
+  }


### PR DESCRIPTION
Aside from the installer, we can detect if the app has been installed on an Amazon device by following the guidelines described here: https://developer.amazon.com/docs/fire-tv/identify-amazon-fire-tv-devices.html
Especially useful when sideloading the app for testing purposes

Cleaner than the suggested fallback logic: 
```
if (__DEV__) {
  RNIap.setFallbackInstallSourceAndroid(RNIap.InstallSourceAndroid.AMAZON);
}
...
```