### PR TITLE
Handle deffered proration in purchasedUpdated listner in android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelogs
 
+## 6.0.8
+- [Android] Handle deffered proration in `purchaseUpdated` listener [#1357](https://github.com/dooboolab/react-native-iap/pull/1357)
+
 ## 6.0.7
 - [Amazon] Fire tv detection [#1356](https://github.com/dooboolab/react-native-iap/pull/1356)
 

--- a/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/main/java/com/dooboolab/RNIap/RNIapModule.java
@@ -601,14 +601,12 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
         DoobooUtils.getInstance().resolvePromisesForKey(PROMISE_BUY_ITEM, promiseItem);
       }
     } else {
-      WritableMap error = Arguments.createMap();
-      error.putInt("responseCode", billingResult.getResponseCode());
-      error.putString("debugMessage", billingResult.getDebugMessage());
-      String[] errorData = DoobooUtils.getInstance().getBillingResponseData(billingResult.getResponseCode());
-      error.putString("code", errorData[0]);
-      error.putString("message", "purchases are null.");
-      sendEvent(reactContext, "purchase-error", error);
-      DoobooUtils.getInstance().rejectPromisesWithBillingError(PROMISE_BUY_ITEM, billingResult.getResponseCode());
+      WritableMap result = Arguments.createMap();
+      result.putInt("responseCode", billingResult.getResponseCode());
+      result.putString("debugMessage", billingResult.getDebugMessage());
+      result.putString("extraMessage", "The purchases are null. This is a normal behavior if you have requested DEFERRED proration. If not please report an issue.");
+      sendEvent(reactContext, "purchase-updated", result);
+      DoobooUtils.getInstance().resolvePromisesForKey(PROMISE_BUY_ITEM, null);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-iap",
-  "version": "6.0.7",
+  "version": "6.0.8",
   "description": "React Native In App Purchase Module.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
As described in the issue below, when requested `proration mode` with `deferred`, purchases can be `null`. Handle this case in the event to know that this was successful.

Resolve #888