### PR TITLE
Fix a wrong package.json setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-iap",
   "version": "6.2.0",
   "description": "React Native In App Purchase Module.",
-  "main": "index.ts",
+  "main": "index.js",
   "types": "index.d.ts",
   "postinstall": "dooboolab-welcome postinstall",
   "scripts": {


### PR DESCRIPTION
The value of `main` property in `package.json` is "index.ts".
 I think this is problematic. For example, `Flow` throws a "Cannot resolve module" error.