### PR TITLE
Fix an unnecessary error when canceling a purchase

### DIFF
--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -461,9 +461,12 @@ RCT_EXPORT_METHOD(presentCodeRedemptionSheet:(RCTPromiseResolveBlock)resolve
                                              ];
                         [self sendEventWithName:@"purchase-error" body:err];
                     }
-                    [self rejectPromisesForKey:transaction.payment.productIdentifier code:[self standardErrorCode:(int)transaction.error.code]
-                                       message:transaction.error.localizedDescription
-                                         error:transaction.error];
+
+                    if (transaction.error.code != SKErrorPaymentCancelled) {
+                        [self rejectPromisesForKey:transaction.payment.productIdentifier code:[self standardErrorCode:(int)transaction.error.code]
+                                        message:transaction.error.localizedDescription
+                                            error:transaction.error];
+                    }
                 });
                 break;
             }


### PR DESCRIPTION
Related to #1210

If I cancel during purchase interaction, the following error occurs.
```
Possible Unhandled Promise Rejection (id: 0):
Error: The operation couldn’t be completed. (SKErrorDomain error 2.)
promiseMethodWrapper@http://192.168.0.2:8081/index.bundle?platform=ios&dev=true&minify=false:2220:45
http://192.168.0.2:8081/index.bundle?platform=ios&dev=true&minify=false:201046:43
step@http://192.168.0.2:8081/index.bundle?platform=ios&dev=true&minify=false:200702:25
http://192.168.0.2:8081/index.bundle?platform=ios&dev=true&minify=false:200632:20
http://192.168.0.2:8081/index.bundle?platform=ios&dev=true&minify=false:200604:73
tryCallTwo@http://192.168.0.2:8081/index.bundle?platform=ios&dev=true&minify=false:3446:9
doResolve@http://192.168.0.2:8081/index.bundle?platform=ios&dev=true&minify=false:3610:25
Promise@http://192.168.0.2:8081/index.bundle?platform=ios&dev=true&minify=false:3469:14
http://192.168.0.2:8081/index.bundle?platform=ios&dev=true&minify=false:200583:36
ios@http://192.168.0.2:8081/index.bundle?platform=ios&dev=true&minify=false:201041:25
requestSubscription@http://192.168.0.2:8081/index.bundle?platform=ios&dev=true&minify=false:201058:27
```

I think It'd be better to ignore errors caused by user cancellation.