### PR TITLE
Update URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/dooboolab/react-native-iap"
+    "url": "https://github.com/dooboolab/react-native-iap"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
It's more common to not include the `git+` prefix when specifying the repository URL: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository
This also leads to a clickable link when invoking `yarn upgrade-interactive`.