### PR TITLE
Remove an unnecessary reject when canceling by user

### DIFF
--- a/android/src/play/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapModule.java
@@ -518,7 +518,8 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
                   BillingFlowParams.ProrationMode.IMMEDIATE_AND_CHARGE_PRORATED_PRICE);
               if (!type.equals(BillingClient.SkuType.SUBS)) {
                 String debugMessage =
-                    "IMMEDIATE_AND_CHARGE_PRORATED_PRICE for proration mode only works in subscription purchase.";
+                    "IMMEDIATE_AND_CHARGE_PRORATED_PRICE for proration mode only works in"
+                        + " subscription purchase.";
                 WritableMap error = Arguments.createMap();
                 error.putString("debugMessage", debugMessage);
                 error.putString("code", PROMISE_BUY_ITEM);
@@ -626,15 +627,13 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
       WritableMap error = Arguments.createMap();
       error.putInt("responseCode", responseCode);
       error.putString("debugMessage", billingResult.getDebugMessage());
-      String[] errorData =
-          PlayUtils.getInstance().getBillingResponseData(responseCode);
+      String[] errorData = PlayUtils.getInstance().getBillingResponseData(responseCode);
       error.putString("code", errorData[0]);
       error.putString("message", errorData[1]);
       sendEvent(reactContext, "purchase-error", error);
 
       if (responseCode != BillingClient.BillingResponseCode.USER_CANCELED) {
-        PlayUtils.getInstance()
-            .rejectPromisesWithBillingError(PROMISE_BUY_ITEM, responseCode);
+        PlayUtils.getInstance().rejectPromisesWithBillingError(PROMISE_BUY_ITEM, responseCode);
       }
       return;
     }
@@ -675,7 +674,8 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
       result.putString("debugMessage", billingResult.getDebugMessage());
       result.putString(
           "extraMessage",
-          "The purchases are null. This is a normal behavior if you have requested DEFERRED proration. If not please report an issue.");
+          "The purchases are null. This is a normal behavior if you have requested DEFERRED"
+              + " proration. If not please report an issue.");
       sendEvent(reactContext, "purchase-updated", result);
       DoobooUtils.getInstance().resolvePromisesForKey(PROMISE_BUY_ITEM, null);
     }


### PR DESCRIPTION
Related to #1385

I should have worked together in my previous PR, but it's missing.

Unlike iOS, Android does not throw warning errors, but It'd be better to be excluded for the same reason.

I don't think it's necessary to release a new version right now. It's enough to be included in the next version.