### PR TITLE
fix promise resolving logic

### DIFF
--- a/android/src/main/java/com/dooboolab/RNIap/DoobooUtils.java
+++ b/android/src/main/java/com/dooboolab/RNIap/DoobooUtils.java
@@ -1,6 +1,7 @@
 package com.dooboolab.RNIap;
 
 import android.util.Log;
+import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ObjectAlreadyConsumedException;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReadableArray;
@@ -32,10 +33,6 @@ public class DoobooUtils {
   public static final String E_DEVELOPER_ERROR = "E_DEVELOPER_ERROR";
   public static final String E_BILLING_RESPONSE_JSON_PARSE_ERROR =
       "E_BILLING_RESPONSE_JSON_PARSE_ERROR";
-
-  public static final String APPSTORE_UNKNOWN = "UNKNOWN";
-  public static final String APPSTORE_GOOGLE = "GOOGLE_PLAY";
-  public static final String APPSTORE_AMAZON = "AMAZON";
 
   private final HashMap<String, ArrayList<Promise>> promises = new HashMap<>();
   private static final DoobooUtils instance = new DoobooUtils();
@@ -75,7 +72,7 @@ public class DoobooUtils {
   }
 
   public void rejectPromisesForKey(
-      final String key, final String code, final String message, final Exception err) {
+      final String key, final String code, final String message, final @Nullable Exception err) {
     try {
       if (promises.containsKey(key)) {
         ArrayList<Promise> list = promises.get(key);

--- a/android/src/play/java/com/dooboolab/RNIap/PlayUtils.java
+++ b/android/src/play/java/com/dooboolab/RNIap/PlayUtils.java
@@ -2,10 +2,7 @@ package com.dooboolab.RNIap;
 
 import android.util.Log;
 import com.android.billingclient.api.BillingClient;
-import com.facebook.react.bridge.ObjectAlreadyConsumedException;
 import com.facebook.react.bridge.Promise;
-import java.util.ArrayList;
-import java.util.HashMap;
 
 public class PlayUtils {
   private static final String TAG = "DoobooUtils";
@@ -23,11 +20,6 @@ public class PlayUtils {
   public static final String E_BILLING_RESPONSE_JSON_PARSE_ERROR =
       "E_BILLING_RESPONSE_JSON_PARSE_ERROR";
 
-  public static final String APPSTORE_UNKNOWN = "UNKNOWN";
-  public static final String APPSTORE_GOOGLE = "GOOGLE_PLAY";
-  public static final String APPSTORE_AMAZON = "AMAZON";
-
-  private HashMap<String, ArrayList<Promise>> promises = new HashMap<>();
   private static PlayUtils instance = new PlayUtils();
 
   public static PlayUtils getInstance() {
@@ -94,16 +86,7 @@ public class PlayUtils {
   }
 
   public void rejectPromisesWithBillingError(final String key, final int responseCode) {
-    try {
-      if (promises.containsKey(key)) {
-        ArrayList<Promise> list = promises.get(key);
-        for (Promise promise : list) {
-          rejectPromiseWithBillingError(promise, responseCode);
-        }
-        promises.remove(key);
-      }
-    } catch (ObjectAlreadyConsumedException oce) {
-      Log.e(TAG, oce.getMessage());
-    }
+    String[] errorData = getBillingResponseData(responseCode);
+    DoobooUtils.getInstance().rejectPromisesForKey(key, errorData[0], errorData[1], null);
   }
 }


### PR DESCRIPTION
Since the code split between stores, I created a separate file to deal with Google Play-specific logic for handling errors. However, this meant that I inadvertently created a separate copy of the hashmap that holds the promises. This could create a disconnect making some promises not resolve. This PR reverts that change by only using DoobooUtils as the host of such Promises store.