### PR TITLE
Fix recent jest test failing

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,4 +3,8 @@ module.exports = {
   '@babel/preset-typescript',
   "@babel/preset-env",
   '@babel/preset-react',],
+  plugins: [
+    '@babel/plugin-proposal-class-properties',
+    '@babel/plugin-proposal-private-methods',
+  ],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -171,14 +171,14 @@ module.exports = {
 
   // A map from regular expressions to paths to transformers
    transform: {
-    '^.+\\.(js|jsx)$': '<rootDir>/node_modules/react-native/jest/preprocessor.js',
+    "^.+\\.(js|jsx|ts|tsx)$": "babel-jest",
     "\\.(ts|tsx)$": "ts-jest"
   },
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-  // transformIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  transformIgnorePatterns: [
+    'node_modules/(?!@react-native|react-native)'
+  ],
 
   // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
   // unmockedModulePathPatterns: undefined,

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.14.8",
+    "@babel/plugin-proposal-class-properties": "^7.14.5",
+    "@babel/plugin-proposal-private-methods": "^7.14.5",
     "@babel/preset-env": "^7.14.8",
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.14.5",
@@ -56,6 +58,7 @@
     "@types/react-native": "0.64.12",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.1.0",
+    "babel-jest": "^27.0.6",
     "eslint": "^7.31.0",
     "flow-bin": "^0.156.0",
     "flowgen": "^1.14.1",


### PR DESCRIPTION
Recent `tests` are failing after upgrading packages.

Use `transform` from `babel-jest`.
```
transform: {
  "^.+\\.(js|jsx|ts|tsx)$": "babel-jest",
}
```

Add `transformIgnorePatterns` like below.
```
transformIgnorePatterns: [
  'node_modules/(?!@react-native|react-native)'
],
```

And adding plugins to `babel.config.js` fixed the problem.
```
plugins: [
  '@babel/plugin-proposal-class-properties',
  '@babel/plugin-proposal-private-methods',
],
```