### PR TITLE
Fix crash when init on Android Emulator

### DIFF
--- a/android/src/play/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapModule.java
@@ -95,20 +95,15 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
       Log.i(
           TAG,
           "Already initialized, you should only call initConnection() once when your app starts");
-      //      promise.reject(
-      //          DoobooUtils.E_ALREADY_PREPARED,
-      //          "Already initialized, you should only call initConnection() once when your app
-      // starts");
-      //      return;
+      promise.resolve(true);
+      return;
     }
 
     if (GoogleApiAvailability.getInstance().isGooglePlayServicesAvailable(reactContext)
         != ConnectionResult.SUCCESS) {
       Log.i(TAG, "Google Play Services are not available on this device");
-      //      promise.reject(
-      //          PlayUtils.E_PLAY_SERVICES_UNAVAILABLE,
-      //          "Google Play Services are not available on this device");
-      //      return;
+      promise.resolve(false);
+      return;
     }
 
     billingClientCache =


### PR DESCRIPTION
When calling initConnection on an Android Emulator fails if not wrapped in catch. 

Resolving to false and returning prevents the crash and is more consistent with usage
