### PR TITLE
Add quantity in purchase data

### DIFF
--- a/docs/docs/api_reference/available_purchase.md
+++ b/docs/docs/api_reference/available_purchase.md
@@ -7,6 +7,7 @@ Property                           | Type      | iOS | And | Comment
 `transactionReceipt`               | `string`  | ✓   | ✓   | **iOS**: The `receipt`. **Android**: Stringified JSON of the original purchase object.
 `transactionId`                    | `string`  | ✓   | ✓   | A unique order identifier for the transaction.
 `transactionDate`                  | `number`  | ✓   | ✓   | The time the product was purchased, in milliseconds since the epoch (Jan 1, 1970).
+`quantityIOS`                      | `number`  | ✓   |     | The number of items purchased.
 `originalTransactionDateIOS`       | `number`  | ✓   |     | For a transaction that restores a previous transaction, the date of the original transaction.
 `originalTransactionIdentifierIOS` | `string`  | ✓   |     | For a transaction that restores a previous transaction, the transaction identifier of the original transaction.
 `purchaseToken`                    | `string`  |     | ✓   | A token that uniquely identifies a purchase for a given item and user pair.

--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -769,7 +769,7 @@ RCT_EXPORT_METHOD(presentCodeRedemptionSheet:(RCTPromiseResolveBlock)resolve
                                              @(transaction.transactionDate.timeIntervalSince1970 * 1000), @"transactionDate",
                                              transaction.transactionIdentifier, @"transactionId",
                                              transaction.payment.productIdentifier, @"productId",
-                                             item.payment.quantity, @"quantity",
+                                             transaction.payment.quantity, @"quantity",
                                              [receiptData base64EncodedStringWithOptions:0], @"transactionReceipt",
                                              nil
                                              ];

--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -327,6 +327,7 @@ RCT_EXPORT_METHOD(getPendingTransactions:(RCTPromiseResolveBlock)resolve
                                                  @(item.transactionDate.timeIntervalSince1970 * 1000), @"transactionDate",
                                                  item.transactionIdentifier, @"transactionId",
                                                  item.payment.productIdentifier, @"productId",
+                                                 item.payment.quantity, @"quantity",
                                                  [receiptData base64EncodedStringWithOptions:0], @"transactionReceipt",
                                                  nil
                                                  ];
@@ -768,6 +769,7 @@ RCT_EXPORT_METHOD(presentCodeRedemptionSheet:(RCTPromiseResolveBlock)resolve
                                              @(transaction.transactionDate.timeIntervalSince1970 * 1000), @"transactionDate",
                                              transaction.transactionIdentifier, @"transactionId",
                                              transaction.payment.productIdentifier, @"productId",
+                                             item.payment.quantity, @"quantity",
                                              [receiptData base64EncodedStringWithOptions:0], @"transactionReceipt",
                                              nil
                                              ];

--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -327,7 +327,7 @@ RCT_EXPORT_METHOD(getPendingTransactions:(RCTPromiseResolveBlock)resolve
                                                  @(item.transactionDate.timeIntervalSince1970 * 1000), @"transactionDate",
                                                  item.transactionIdentifier, @"transactionId",
                                                  item.payment.productIdentifier, @"productId",
-                                                 @(item.payment.quantity), @"quantity",
+                                                 @(item.payment.quantity), @"quantityIOS",
                                                  [receiptData base64EncodedStringWithOptions:0], @"transactionReceipt",
                                                  nil
                                                  ];
@@ -769,7 +769,7 @@ RCT_EXPORT_METHOD(presentCodeRedemptionSheet:(RCTPromiseResolveBlock)resolve
                                              @(transaction.transactionDate.timeIntervalSince1970 * 1000), @"transactionDate",
                                              transaction.transactionIdentifier, @"transactionId",
                                              transaction.payment.productIdentifier, @"productId",
-                                             @(transaction.payment.quantity), @"quantity",
+                                             @(transaction.payment.quantity), @"quantityIOS",
                                              [receiptData base64EncodedStringWithOptions:0], @"transactionReceipt",
                                              nil
                                              ];

--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -327,7 +327,7 @@ RCT_EXPORT_METHOD(getPendingTransactions:(RCTPromiseResolveBlock)resolve
                                                  @(item.transactionDate.timeIntervalSince1970 * 1000), @"transactionDate",
                                                  item.transactionIdentifier, @"transactionId",
                                                  item.payment.productIdentifier, @"productId",
-                                                 item.payment.quantity, @"quantity",
+                                                 @(item.payment.quantity), @"quantity",
                                                  [receiptData base64EncodedStringWithOptions:0], @"transactionReceipt",
                                                  nil
                                                  ];
@@ -769,7 +769,7 @@ RCT_EXPORT_METHOD(presentCodeRedemptionSheet:(RCTPromiseResolveBlock)resolve
                                              @(transaction.transactionDate.timeIntervalSince1970 * 1000), @"transactionDate",
                                              transaction.transactionIdentifier, @"transactionId",
                                              transaction.payment.productIdentifier, @"productId",
-                                             transaction.payment.quantity, @"quantity",
+                                             @(transaction.payment.quantity), @"quantity",
                                              [receiptData base64EncodedStringWithOptions:0], @"transactionReceipt",
                                              nil
                                              ];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -56,6 +56,7 @@ export interface ProductPurchase {
   transactionReceipt: string;
   purchaseToken?: string;
   //iOS
+  quantityIOS?: number;
   originalTransactionDateIOS?: string;
   originalTransactionIdentifierIOS?: string;
   //Android


### PR DESCRIPTION
On iOS, we can `requestPurchaseWithQuantityIOS` which purchase a productId with a specific quantity.

However, in the purchase info when a purchase is completed, we only receive the productId.

I have done some changes so we can now receive both the productId and the requested quantity when a purchase is completed.

The quantity is fetched from the associated payment in the transaction. 

Documentation : https://developer.apple.com/documentation/storekit/skpayment/1506077-quantity?language=objc