### PR TITLE
Use React's Context to manage IAP state

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ Quick News
 Breaking Changes
 ----------------
 
+[8.0.0]
+- Now using React's Context to manage IAP state
+- Introduce `withIAPContext` HOC ([how to use](docs/docs/usage_instructions/using_hooks.md))
+
 [7.1.0]
 - `androidOldSku` is no longer required [#1438](https://github.com/dooboolab/react-native-iap/pull/1438).
 

--- a/docs/docs/usage_instructions/using_hooks.md
+++ b/docs/docs/usage_instructions/using_hooks.md
@@ -4,6 +4,45 @@ sidebar_position: 6
 
 # Using hooks
 
-From `react-native-iap@6.0.0+` we support the useIAP hook that handles purchases better. 
+## How to use hooks
+1. You have to wrap your app with the `withIAPContext` HOC
+
+```jsx
+import {withIAPContext} from 'react-native-iap';
+
+const App = () => <View />;
+
+export default withIAPContext(App);
+```
+
+2. Later then, somewhere in your components
+
+```jsx
+import {withIAP} from 'react-native-iap';
+
+const YourComponent = () => {
+  const {
+    connected,
+    products,
+    promotedProductsIOS,
+    subscriptions,
+    purchaseHistories,
+    availablePurchases,
+    currentPurchase,
+    currentPurchaseError,
+    finishTransaction,
+    getProducts,
+    getSubscriptions,
+    getAvailablePurchases,
+    getPurchaseHistories,
+  } = useIAP();
+
+  return <View />;
+};
+```
+
+## Reference
+
+From `react-native-iap@6.0.0+` we support the useIAP hook that handles purchases better.
 
 Check this [Medium post](https://medium.com/dooboolab/announcing-react-native-iap-hooks-96c7ffd3f19a) for usage instructions.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-iap",
   "version": "7.3.0",
   "description": "React Native In App Purchase Module.",
-  "main": "index.js",
+  "main": "index",
   "types": "index.d.ts",
   "postinstall": "dooboolab-welcome postinstall",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-iap",
   "version": "7.3.0",
   "description": "React Native In App Purchase Module.",
-  "main": "index",
+  "main": "index.js",
   "types": "index.d.ts",
   "postinstall": "dooboolab-welcome postinstall",
   "scripts": {

--- a/src/hooks/useIAP.ts
+++ b/src/hooks/useIAP.ts
@@ -5,6 +5,8 @@ import {
   getAvailablePurchases as iapGetAvailablePurchases,
   getProducts as iapGetProducts,
   getSubscriptions as iapGetSubscriptions,
+  requestPurchase as iapRequestPurchase,
+  requestSubscription as iapRequestSubscription,
 } from '../iap';
 import {useCallback} from 'react';
 import {useIAPContext} from './withIAPContext';
@@ -23,6 +25,8 @@ type IAP_STATUS = {
   getPurchaseHistories: () => Promise<void>;
   getProducts: (skus: string[]) => Promise<void>;
   getSubscriptions: (skus: string[]) => Promise<void>;
+  requestPurchase: typeof iapRequestPurchase;
+  requesSubscription: typeof iapRequestSubscription;
 };
 
 export function useIAP(): IAP_STATUS {
@@ -78,7 +82,7 @@ export function useIAP(): IAP_STATUS {
           developerPayloadAndroid,
         );
       } catch (err) {
-        throw new Error(err);
+        throw err;
       } finally {
         if (purchase.productId === currentPurchase?.productId)
           setCurrentPurchase(undefined);
@@ -109,5 +113,7 @@ export function useIAP(): IAP_STATUS {
     getSubscriptions,
     getAvailablePurchases,
     getPurchaseHistories,
+    requestPurchase: iapRequestPurchase,
+    requesSubscription: iapRequestSubscription,
   };
 }

--- a/src/hooks/useIAP.ts
+++ b/src/hooks/useIAP.ts
@@ -1,9 +1,4 @@
-import type {
-  Product,
-  Purchase,
-  PurchaseError,
-  Subscription,
-} from '../types';
+import type {Product, Purchase, PurchaseError, Subscription} from '../types';
 import {
   getPurchaseHistory,
   finishTransaction as iapFinishTransaction,
@@ -37,7 +32,8 @@ export function useIAP(): IAP_STATUS {
     promotedProductsIOS,
     subscriptions,
     purchaseHistories,
-    availablePurchases,currentPurchase,
+    availablePurchases,
+    currentPurchase,
     currentPurchaseError,
     setProducts,
     setSubscriptions,
@@ -47,24 +43,27 @@ export function useIAP(): IAP_STATUS {
     setCurrentPurchaseError,
   } = useIAPContext();
 
-  const getProducts = useCallback(async (skus: string[]): Promise<void> => {
-    setProducts(await iapGetProducts(skus));
-  }, []);
+  const getProducts = useCallback(
+    async (skus: string[]): Promise<void> => {
+      setProducts(await iapGetProducts(skus));
+    },
+    [setProducts],
+  );
 
   const getSubscriptions = useCallback(
     async (skus: string[]): Promise<void> => {
       setSubscriptions(await iapGetSubscriptions(skus));
     },
-    [],
+    [setSubscriptions],
   );
 
   const getAvailablePurchases = useCallback(async (): Promise<void> => {
     setAvailablePurchases(await iapGetAvailablePurchases());
-  }, []);
+  }, [setAvailablePurchases]);
 
   const getPurchaseHistories = useCallback(async (): Promise<void> => {
     setPurchaseHistories(await getPurchaseHistory());
-  }, []);
+  }, [setPurchaseHistories]);
 
   const finishTransaction = useCallback(
     async (
@@ -88,7 +87,12 @@ export function useIAP(): IAP_STATUS {
           setCurrentPurchaseError(undefined);
       }
     },
-    [currentPurchase?.productId, currentPurchaseError?.productId],
+    [
+      currentPurchase?.productId,
+      currentPurchaseError?.productId,
+      setCurrentPurchase,
+      setCurrentPurchaseError,
+    ],
   );
 
   return {

--- a/src/hooks/withIAPContext.tsx
+++ b/src/hooks/withIAPContext.tsx
@@ -1,0 +1,150 @@
+import React, {useContext, useEffect, useMemo, useState} from 'react';
+import {NativeEventEmitter, NativeModules} from 'react-native';
+import {
+  InAppPurchase,
+  Product,
+  Purchase,
+  PurchaseError,
+  Subscription,
+  SubscriptionPurchase,
+} from '../types';
+import {
+  getPromotedProductIOS,
+  initConnection,
+  purchaseErrorListener,
+  purchaseUpdatedListener,
+} from '../iap';
+
+type IAPContextType = {
+  connected: boolean;
+  products: Product[];
+  promotedProductsIOS: Product[];
+  subscriptions: Subscription[];
+  purchaseHistories: Purchase[];
+  availablePurchases: Purchase[];
+  currentPurchase?: Purchase;
+  currentPurchaseError?: PurchaseError;
+  setProducts: (products: Product[]) => void;
+  setSubscriptions: (subscriptions: Subscription[]) => void;
+  setPurchaseHistories: (purchaseHistories: Purchase[]) => void;
+  setAvailablePurchases: (availablePurchases: Purchase[]) => void;
+  setCurrentPurchase: (currentPurchase: Purchase | undefined) => void;
+  setCurrentPurchaseError: (
+    currentPurchaseError: PurchaseError | undefined,
+  ) => void;
+};
+
+const {RNIapIos} = NativeModules;
+const IAPEmitter = new NativeEventEmitter(RNIapIos);
+
+// @ts-ignore
+const IAPContext = React.createContext<IAPContextType>(null);
+
+export function useIAPContext(): IAPContextType {
+  const ctx = useContext(IAPContext);
+  if (!ctx) throw new Error('You need wrap your app with withIAPContext HOC');
+
+  return ctx;
+}
+
+export default function withIAPContext<T>(Component: React.ComponentType<T>) {
+  return function WrapperComponent(props: T) {
+    const [connected, setConnected] = useState<boolean>(false);
+    const [products, setProducts] = useState<Product[]>([]);
+
+    const [promotedProductsIOS, setPromotedProductsIOS] = useState<Product[]>(
+      [],
+    );
+    const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
+    const [purchaseHistories, setPurchaseHistories] = useState<Purchase[]>([]);
+
+    const [availablePurchases, setAvailablePurchases] = useState<Purchase[]>(
+      [],
+    );
+    const [currentPurchase, setCurrentPurchase] = useState<Purchase>();
+
+    const [currentPurchaseError, setCurrentPurchaseError] =
+      useState<PurchaseError>();
+
+    const context = useMemo(
+      () => ({
+        connected,
+        products,
+        subscriptions,
+        promotedProductsIOS,
+        purchaseHistories,
+        availablePurchases,
+        currentPurchase,
+        currentPurchaseError,
+        setProducts,
+        setSubscriptions,
+        setPurchaseHistories,
+        setAvailablePurchases,
+        setCurrentPurchase,
+        setCurrentPurchaseError,
+      }),
+      [
+        connected,
+        products,
+        subscriptions,
+        promotedProductsIOS,
+        purchaseHistories,
+        availablePurchases,
+        currentPurchase,
+        currentPurchaseError,
+        setProducts,
+        setSubscriptions,
+        setPurchaseHistories,
+        setAvailablePurchases,
+        setCurrentPurchase,
+        setCurrentPurchaseError,
+      ],
+    );
+
+    useEffect(() => {
+      initConnection().then(setConnected);
+    }, []);
+
+    useEffect(() => {
+      if (!connected) return;
+
+      const purchaseUpdateSubscription = purchaseUpdatedListener(
+        async (purchase: InAppPurchase | SubscriptionPurchase) => {
+          setCurrentPurchaseError(undefined);
+          setCurrentPurchase(purchase);
+        },
+      );
+
+      const purchaseErrorSubscription = purchaseErrorListener(
+        (error: PurchaseError) => {
+          setCurrentPurchase(undefined);
+          setCurrentPurchaseError(error);
+        },
+      );
+
+      const promotedProductsSubscription = IAPEmitter.addListener(
+        'iap-promoted-product',
+        async () => {
+          const product = await getPromotedProductIOS();
+
+          setPromotedProductsIOS((prevProducts) => [
+            ...prevProducts,
+            ...(product ? [product] : []),
+          ]);
+        },
+      );
+
+      return () => {
+        purchaseUpdateSubscription.remove();
+        purchaseErrorSubscription.remove();
+        promotedProductsSubscription.remove();
+      };
+    }, [connected]);
+
+    return (
+      <IAPContext.Provider value={context}>
+        <Component {...props} />
+      </IAPContext.Provider>
+    );
+  };
+}

--- a/src/hooks/withIAPContext.tsx
+++ b/src/hooks/withIAPContext.tsx
@@ -47,7 +47,7 @@ export function useIAPContext(): IAPContextType {
   return ctx;
 }
 
-export default function withIAPContext<T>(Component: React.ComponentType<T>) {
+export function withIAPContext<T>(Component: React.ComponentType<T>) {
   return function WrapperComponent(props: T) {
     const [connected, setConnected] = useState<boolean>(false);
     const [products, setProducts] = useState<Product[]>([]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './hooks/useIAP';
+export * from './hooks/withIAPContext';
 export * from './iap';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
   },
   "compileOnSave": true,
   "exclude": ["node_modules"],
-  "include": ["./index.ts", "src/**/*.ts"]
+  "include": ["./index.ts", "src/**/*.ts", "src/hooks/withIAPContext.tsx"]
 }


### PR DESCRIPTION
currently, every time calling `useIAP` hooks, it will call `initConnection` and register listeners with should only be done once when the app starts (as mentioning in the documentation). So I introduce new HOC `withIAPContext`

1. `withIAPContext` HOC responsible for
- Init context
- Init IAP connection
- Register listeners

2. `useIAP` same as before but removing the code that inits IAP and registers listeners.

## How to use
1. You have to wrap your app with the `withIAPContext` HOC

```jsx
import {withIAPContext} from 'react-native-iap';

const App = () => <View />;

export default withIAPContext(App);
```

2. Later then, somewhere in your components

```jsx
import {withIAP} from 'react-native-iap';

const YourComponent = () => {
  const {
    connected,
    products,
    promotedProductsIOS,
    subscriptions,
    purchaseHistories,
    availablePurchases,
    currentPurchase,
    currentPurchaseError,
    finishTransaction,
    getProducts,
    getSubscriptions,
    getAvailablePurchases,
    getPurchaseHistories,
  } = useIAP();

  return <View />;
};
```