### PR TITLE
Improve gradle versioning for androidX to fix build error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -75,8 +75,12 @@ dependencies {
     if (androidXVersion == null) {
       androidXVersion = defaultAndroidXVersion
     }
-    def androidXAnnotation = safeExtGet('androidXAnnotation', androidXVersion)
-    def androidXBrowser = safeExtGet('androidXBrowser', androidXVersion)
+
+    def androidXAnnotationVersion = safeExtGet('androidXAnnotationVersion', androidXVersion)
+    def androidXBrowserVersion = safeExtGet('androidXBrowserVersion', androidXVersion)
+
+    def androidXAnnotation = safeExtGet('androidXAnnotation', androidXAnnotationVersion)
+    def androidXBrowser = safeExtGet('androidXBrowser', androidXBrowserVersion)
     implementation "androidx.annotation:annotation:$androidXAnnotation"
     implementation "androidx.browser:browser:$androidXBrowser"
   }


### PR DESCRIPTION
I faced the below error

```
> Task :app:checkStagingReleaseAarMetadata FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:checkStagingReleaseAarMetadata'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
   > The minCompileSdk (31) specified in a
     dependency's AAR metadata (META-INF/com/android/build/gradle/aar-metadata.properties)
     is greater than this module's compileSdkVersion (android-29).
     Dependency: androidx.browser:browser:1.4.0-alpha01.
```

I think it's good to provide the version we want to be able to set. In this modified version, a specific version can be specified.

```
buildscript {
    ext {
        ...
        androidXAnnotationVersion = "1.2.0"
        androidXBrowserVersion = "1.3.0"
    }
    ....
}
```

If `minCompileSdk` of the IAP library is not 31 or higher, it seems necessary to set the default value as follows.

```
def androidXAnnotationVersion = safeExtGet('androidXAnnotationVersion', '1.2.0')
def androidXBrowserVersion = safeExtGet('androidXBrowserVersion', '1.3.0')
```
