### PR TITLE
fix: Cancellled purchase kept promise dangling

### DIFF
--- a/android/src/play/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapModule.java
@@ -583,9 +583,7 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
       error.putString("message", errorData[1]);
       sendEvent(reactContext, "purchase-error", error);
 
-      if (responseCode != BillingClient.BillingResponseCode.USER_CANCELED) {
-        PlayUtils.getInstance().rejectPromisesWithBillingError(PROMISE_BUY_ITEM, responseCode);
-      }
+      PlayUtils.getInstance().rejectPromisesWithBillingError(PROMISE_BUY_ITEM, responseCode);
       return;
     }
 

--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -463,11 +463,9 @@ RCT_EXPORT_METHOD(presentCodeRedemptionSheet:(RCTPromiseResolveBlock)resolve
                         [self sendEventWithName:@"purchase-error" body:err];
                     }
 
-                    if (transaction.error.code != SKErrorPaymentCancelled) {
-                        [self rejectPromisesForKey:transaction.payment.productIdentifier code:[self standardErrorCode:(int)transaction.error.code]
-                                        message:transaction.error.localizedDescription
-                                            error:transaction.error];
-                    }
+                    [self rejectPromisesForKey:transaction.payment.productIdentifier code:[self standardErrorCode:(int)transaction.error.code]
+                                    message:transaction.error.localizedDescription
+                                        error:transaction.error];
                 });
                 break;
             }


### PR DESCRIPTION
If the user does not proceed with the payment, the `RNIap.requestSubscription()` promise never resolves and remains dangling. It's also an issue if you want to show a "payment in progress" spinner while the user is interacting with the system level payment flows, as you don't get informed about the user cancelling, meaning, the spinner spins forever.  

Fixes: https://github.com/dooboolab/react-native-iap/issues/1479