### PR TITLE
Setting default AndroidX version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     implementation "com.android.support:support-annotations:$supportLibVersion"
     implementation "com.android.support:customtabs:$supportLibVersion"
   } else {
-    def defaultAndroidXVersion = "1.+"
+    def defaultAndroidXVersion = "1.2.0"
     if (androidXVersion == null) {
       androidXVersion = defaultAndroidXVersion
     }


### PR DESCRIPTION
It is now set to the last known working version. Note this will still fail CI until there's a new release and IapExample's package version is pointed to that new version