### PR TITLE
fix countryCode typing in ProductCommon interface

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -45,8 +45,7 @@ export interface ProductCommon {
   price: string;
   currency: string;
   localizedPrice: string;
-
-  countryCodeIOS?: string;
+  countryCode?: string;
 }
 
 export interface ProductPurchase {


### PR DESCRIPTION
This fixes a type in the ProductCommon interface. 
As long as I have tested in IOS, the ProductCommon does not receive `countryCodeIOS` but `countryCode` and none in Android.