### PR TITLE
Update .npmignore to remove TS errors

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,6 +6,7 @@ android/react-native-iap.iml
 android/android.iml
 tsconfig.tsbuildinfo
 *.ts
+*.tsx
 !*.d.ts
 tsconfig.json
 greenkeeper.json


### PR DESCRIPTION
A `.tsx` file is included in source, which TS loads instead of the JS file, and validates against local TS rules.

Removing this file from the source fixes the issue.