### PR TITLE
fix(docs): Wrong import in hooks documentation

### DIFF
--- a/docs/docs/usage_instructions/using_hooks.md
+++ b/docs/docs/usage_instructions/using_hooks.md
@@ -18,7 +18,7 @@ export default withIAPContext(App);
 2. Later then, somewhere in your components
 
 ```jsx
-import {withIAP} from 'react-native-iap';
+import {useIAP} from 'react-native-iap';
 
 const YourComponent = () => {
   const {


### PR DESCRIPTION
Thanks for the repo! It really helped me getting started with IAP 🙂 
There seems to be a slight fix needed in the [hooks document](https://react-native-iap.dooboolab.com/docs/usage_instructions/using_hooks), which might cause confusion to new users.