### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,16 @@ jobs:
   build_android:
 
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        java-version: [ 11.0.3, 11 ]
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 11
+    - name: Set up JDK ${{ matrix.java-version }} 
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
-        java-version: '11'
+        distribution: 'zulu'
+        java-version: ${{ matrix.java-version }}
     - name: Grant execute permission for gradlew
       run: chmod +x android/gradlew
     - name: Build with Library with Gradle and check lints
@@ -41,16 +43,19 @@ jobs:
   build_android_example:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: [ 11.0.3, 11 ]
 
     steps:
     - uses: actions/checkout@v2
     - name: Setup kernel for react native, increase watchers
       run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
-    - name: Set up JDK 11
+    - name: Set up JDK ${{ matrix.java-version }}
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
-        java-version: '11'
+        distribution: 'zulu'
+        java-version: ${{ matrix.java-version }}
     - name: Install base modules
       run: yarn; yarn build
     - name: Install modules


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). Switching the distribution to Azul Zulu. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. 

Also added are fixed (major) release version(s) such as `JDK 11.0.3`. This is often a good practice whenever a build/test triggers (push/pull events) to help determine if the latest (`JDK 11`) had failed the from the **latest build** vs something in **your code** caused (or introduced). 

**For example**, when building with `JDK 11.0.3` (fixed version) the build/tests passes (Green) and JDK 11 fails (Red) will mean that the latest `JDK 11` was the cause and not your code. 

**Note:** Other distributions such as Temurin do not support archived fixed releases prior to Sept. 2021 and many non LTS (long term support) releases if you plan to try out newer features in the language.