### PR TITLE
fix: NativeEventEmitter warnings since ReactNative 0.65

### DIFF
--- a/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonModule.java
+++ b/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonModule.java
@@ -117,4 +117,13 @@ public class RNIapAmazonModule extends ReactContextBaseJavaModule {
   public void startListening(final Promise promise) {
     sendUnconsumedPurchases(promise);
   }
+    @ReactMethod
+  public void addListener(String eventName) {
+    // Keep: Required for RN built in Event Emitter Calls.
+  }
+
+  @ReactMethod
+  public void removeListeners(double count) {
+    // Keep: Required for RN built in Event Emitter Calls.
+  }
 }

--- a/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonModule.java
+++ b/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonModule.java
@@ -117,7 +117,7 @@ public class RNIapAmazonModule extends ReactContextBaseJavaModule {
   public void startListening(final Promise promise) {
     sendUnconsumedPurchases(promise);
   }
-  
+
   @ReactMethod
   public void addListener(String eventName) {
     // Keep: Required for RN built in Event Emitter Calls.

--- a/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonModule.java
+++ b/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonModule.java
@@ -117,7 +117,8 @@ public class RNIapAmazonModule extends ReactContextBaseJavaModule {
   public void startListening(final Promise promise) {
     sendUnconsumedPurchases(promise);
   }
-    @ReactMethod
+  
+  @ReactMethod
   public void addListener(String eventName) {
     // Keep: Required for RN built in Event Emitter Calls.
   }

--- a/android/src/play/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapModule.java
@@ -662,7 +662,7 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
   public void startListening(final Promise promise) {
     sendUnconsumedPurchases(promise);
   }
-  
+
   @ReactMethod
   public void addListener(String eventName) {
     // Keep: Required for RN built in Event Emitter Calls.

--- a/android/src/play/java/com/dooboolab/RNIap/RNIapModule.java
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapModule.java
@@ -662,6 +662,16 @@ public class RNIapModule extends ReactContextBaseJavaModule implements Purchases
   public void startListening(final Promise promise) {
     sendUnconsumedPurchases(promise);
   }
+  
+  @ReactMethod
+  public void addListener(String eventName) {
+    // Keep: Required for RN built in Event Emitter Calls.
+  }
+
+  @ReactMethod
+  public void removeListeners(double count) {
+    // Keep: Required for RN built in Event Emitter Calls.
+  }
 
   @ReactMethod
   public String getPackageName() {


### PR DESCRIPTION
closes #1524. Superseeds other PR as it also includes the change for `RNIapModule.java`