### PR TITLE
[8.0] android: remove deprecated method createJSModules in module package

### DIFF
--- a/android/src/amazon/java/com/dooboolab/RNIap/RNIapPackage.kt
+++ b/android/src/amazon/java/com/dooboolab/RNIap/RNIapPackage.kt
@@ -38,10 +38,6 @@ import com.facebook.react.uimanager.ViewManager
 
 class RNIapPackage : ReactPackage {
 
-    override fun createJSModules(): MutableList<Class<out JavaScriptModule>> {
-        return mutableListOf()
-    }
-
     override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
         return emptyList()
     }

--- a/android/src/play/java/com/dooboolab/RNIap/RNIapPackage.kt
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapPackage.kt
@@ -46,10 +46,6 @@ import com.facebook.react.uimanager.ViewManager
 
 class RNIapPackage : ReactPackage {
 
-    override fun createJSModules(): MutableList<Class<out JavaScriptModule>> {
-        return mutableListOf()
-    }
-
     override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
         return emptyList()
     }


### PR DESCRIPTION
RN 0.47 deprecated the method. Remove it entirely.

Some may just remove the `override` to pass the build (`createJSModules overrides nothing` error), but this function is actually can be removed entirely.

see: https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8