### PR TITLE
ignore yarn cache in npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -21,3 +21,4 @@ docs/
 .eslintignore
 .prettierrc.js
 .gitattributes
+.yarn/cache


### PR DESCRIPTION
Hello,

when installing your package I noticed that its size was over 200 MB. When checking package files, I found out that `.yarn/cache` folder takes those 200 MB. I tried to pack with the updated `.npmignore` and the package size is just 1.0 MB.

You probably accidentally included it in published package, it is ignored in `.gitignore` but not in `.npmignore`.

<img width="1305" alt="image" src="https://user-images.githubusercontent.com/10141960/148393926-87a33914-612f-4ae1-b2c4-bc5170b3bdba.png">
