### PR TITLE
Refresh SkuDetails

### DIFF
--- a/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
@@ -227,9 +227,7 @@ class RNIapModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
                         }
                         if (skuDetailsList != null) {
                             for (sku in skuDetailsList) {
-                                if (!skus.contains(sku)) {
-                                    skus.add(sku)
-                                }
+                                skus.put(sku.getSku(), sku)
                             }
                         }
                         val items = WritableNativeArray()
@@ -402,13 +400,7 @@ class RNIapModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
                         PROMISE_BUY_ITEM, promise
                     )
                     val builder = BillingFlowParams.newBuilder()
-                    var selectedSku: SkuDetails? = null
-                    for (skuDetail in skus) {
-                        if (skuDetail.sku == sku) {
-                            selectedSku = skuDetail
-                            break
-                        }
-                    }
+                    var selectedSku: SkuDetails? = skus.get(sku)
                     if (selectedSku == null) {
                         val debugMessage =
                             "The sku was not found. Please fetch products first by calling getItems"
@@ -674,7 +666,7 @@ class RNIapModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
 
     init {
         this.reactContext = reactContext
-        skus = ArrayList()
+        skus = mutableMapOf<String, SkuDetails>()
         val lifecycleEventListener: LifecycleEventListener = object : LifecycleEventListener {
             override fun onHostResume() {}
             override fun onHostPause() {}

--- a/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
@@ -49,7 +49,7 @@ class RNIapModule(reactContext: ReactApplicationContext) : ReactContextBaseJavaM
     val TAG = "RNIapModule"
     private val reactContext: ReactContext
     private var billingClientCache: BillingClient? = null
-    private val skus: MutableList<SkuDetails>
+    private val skus: MutableMap<String, SkuDetails>
     override fun getName(): String {
         return "RNIapModule"
     }


### PR DESCRIPTION
From @rrrasti 's PR. all credit to them:

In the current Android implementation is it possible to get the following error during the invocation of RNIap.requestPurchase(...):

{
	message: 'Google is indicating that we have some issue connecting to payment.',
	debugMessage: 'Invalid SKU details.',
	code: 'E_DEVELOPER_ERROR',
	responseCode: 5
}
It appears that the problem is caused by the changing content of SkuDetails (e. g. skuDetailsToken in originalJson) over time even for the same product. It can happen that after several invocations of RNIap.getProducts(...) there will be multiple instances of SkuDetails in the skus list with the same sku/productId and later a wrong instance is chosen to purchase a product during the invocation of RNIap.requestPurchase(...). The proposed implementation should minimize aforementioned error.