### PR TITLE
Fixes finishTransaction not resolving for iOS

### DIFF
--- a/ios/RNIapIos.swift
+++ b/ios/RNIapIos.swift
@@ -318,9 +318,9 @@ class RNIapIos: RCTEventEmitter, SKRequestDelegate, SKPaymentTransactionObserver
             for transaction in pendingTrans {
                 SKPaymentQueue.default().finishTransaction(transaction)
             }
-        } else {
-            resolve(nil)
         }
+        resolve(nil)
+
     }
     
     

--- a/ios/RNIapIos.swift
+++ b/ios/RNIapIos.swift
@@ -379,6 +379,7 @@ class RNIapIos: RCTEventEmitter, SKRequestDelegate, SKPaymentTransactionObserver
         reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
     ) {
         finishTransaction(withIdentifier: transactionIdentifier)
+        resolve(nil)
     }
     
     


### PR DESCRIPTION
Fixes https://github.com/dooboolab/react-native-iap/issues/1645 by calling resolve once the `SKPaymentQueue` `finishTransaction` has been triggered

Following the history of the file, it looks like this was broken trying to fix https://github.com/dooboolab/react-native-iap/issues/1637 , by adding the promise methods in the header but not calling resolve/reject. I have fixed both methods (finishTransaction and clearTransaction) here credit goes to the people commenting on the issue, it helped a lot to narrow the problem