### PR TITLE
Crash in the absence of the Internet on the device

### DIFF
--- a/ios/RNIapIos.swift
+++ b/ios/RNIapIos.swift
@@ -627,7 +627,7 @@ class RNIapIos: RCTEventEmitter, SKRequestDelegate, SKPaymentTransactionObserver
             return descriptions[0]
         }
         
-        if code > descriptions.count - 1 {
+        if code > descriptions.count - 1 || code < 0 { // Fix crash app without internet connection
             return descriptions[0]
         }
         return descriptions[code]


### PR DESCRIPTION
Fixed application crash when sending a purchase request and disconnecting the internet immediately after this request