### PR TITLE
Avoid finishing transactions that can still succeed and have not been consumed

### DIFF
--- a/IapExample/App.js
+++ b/IapExample/App.js
@@ -118,6 +118,12 @@ class Page extends Component {
       await RNIap.initConnection();
       if (Platform.OS === 'android') {
         await RNIap.flushFailedPurchasesCachedAsPendingAndroid();
+      } else {
+        // WARNING This line should not be included in production code
+        // This call will call finishTransaction in all pending purchases on every launch,
+        // effectively consuming purchases that you might not have verified the receipt or given the consumer their product
+        // TD:DR you will no longer receive any updates from Apple on every launch for pending purchases
+        await RNIap.clearTransactionIOS();
       }
     } catch (err) {
       console.warn(err.code, err.message);

--- a/IapExample/App.js
+++ b/IapExample/App.js
@@ -118,8 +118,6 @@ class Page extends Component {
       await RNIap.initConnection();
       if (Platform.OS === 'android') {
         await RNIap.flushFailedPurchasesCachedAsPendingAndroid();
-      } else {
-        await RNIap.clearTransactionIOS();
       }
     } catch (err) {
       console.warn(err.code, err.message);


### PR DESCRIPTION
Recoverable errors like interrupted purchases, network failures, failures while processing receipts, etc, are being consumed even though they were recoverable.
Clear transactions calls finishTransaction, which ends updates, and therefore shouldn't be called while there are recoverable transactions awaiting updates.