### PR TITLE
Fix documentation to use implementation instead of compile (android)

### DIFF
--- a/docs/docs/manual_install.md
+++ b/docs/docs/manual_install.md
@@ -28,7 +28,7 @@ sidebar_position: 100
     ```
 3. Insert the following lines inside the dependencies block in `android/app/build.gradle`:
     ```gradle
-    compile project(':react-native-iap')
+    implementation project(':react-native-iap')
     ```
 
 4. You have two options depending on the stores you support:


### PR DESCRIPTION
Fixes documentation as mentioned here https://github.com/dooboolab/react-native-iap/issues/1687