### PR TITLE
swift guard against possible nil value

### DIFF
--- a/ios/RNIapIos.swift
+++ b/ios/RNIapIos.swift
@@ -773,7 +773,7 @@ class RNIapIos: RCTEventEmitter, SKRequestDelegate, SKPaymentTransactionObserver
             for discount in product.discounts {
                 let formatter = NumberFormatter()
                 formatter.numberStyle = .currency
-                formatter.locale = discount.priceLocale
+                guard formatter.locale = discount.priceLocale else { continue }
                 localizedPrice = formatter.string(from: discount.price)
                 var numberOfPeriods: String?
                 


### PR DESCRIPTION
Attempt to fix: https://github.com/dooboolab/react-native-iap/issues/1717

Not a swift expert but it seems like this would work. I found that we have to check for possibly nil even if the type is not optional as per https://stackoverflow.com/a/44060466/570612