### PR TITLE
Refactored ensure connection to reconnect

### DIFF
--- a/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
@@ -28,37 +28,47 @@ import com.facebook.react.bridge.WritableNativeMap
 import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
 import com.google.android.gms.common.ConnectionResult
 import com.google.android.gms.common.GoogleApiAvailability
-import java.lang.Exception
 import java.math.BigDecimal
 import java.util.ArrayList
 
-class RNIapModule(reactContext: ReactApplicationContext) :
+class RNIapModule(private val reactContext: ReactApplicationContext) :
     ReactContextBaseJavaModule(reactContext),
     PurchasesUpdatedListener {
-    val TAG = "RNIapModule"
-    private val reactContext: ReactContext
-    private var billingClientCache: BillingClient? = null
-    private val skus: MutableMap<String, SkuDetails>
+
+    private val billingClient: BillingClient = BillingClient.newBuilder(reactContext).enablePendingPurchases().setListener(this)
+        .build()
+    private val skus: MutableMap<String, SkuDetails> = mutableMapOf()
     override fun getName(): String {
         return "RNIapModule"
     }
 
-    private interface EnsureConnectionCallback {
-        fun run(billingClient: BillingClient)
-    }
-
-    private fun ensureConnection(promise: Promise, callback: EnsureConnectionCallback) {
-        val billingClient = billingClientCache
-        if (billingClient?.isReady == true) {
-            callback.run(billingClient)
+    private fun ensureConnection(promise: Promise, callback: () -> Unit) {
+        if (billingClient.isReady) {
+            callback()
             return
+        } else {
+            val nested = PromiseImpl({
+                if (it.isNotEmpty() && it[0] is Boolean && it[0] as Boolean) {
+                    callback()
+                } else {
+                    Log.i(TAG, "Incorrect parameter in resolve")
+                }
+            }, {
+                if (it.size > 1 && it[0] is String && it[1] is String) {
+                    promise.reject(
+                        it[0] as String, it[1] as String
+                    )
+                } else {
+                    Log.i(TAG, "Incorrect parameters in reject")
+                }
+            })
+            initConnection(nested)
         }
-        promise.reject(DoobooUtils.E_NOT_PREPARED, "Not initialized, Please call initConnection()")
     }
 
     @ReactMethod
     fun initConnection(promise: Promise) {
-        if (billingClientCache?.isReady == true) {
+        if (billingClient.isReady) {
             Log.i(
                 TAG,
                 "Already initialized, you should only call initConnection() once when your app starts"
@@ -70,13 +80,11 @@ class RNIapModule(reactContext: ReactApplicationContext) :
             != ConnectionResult.SUCCESS
         ) {
             Log.i(TAG, "Google Play Services are not available on this device")
-            promise.resolve(false)
+            promise.reject(DoobooUtils.E_NOT_PREPARED, "Google Play Services are not available on this device")
             return
         }
-        billingClientCache =
-            BillingClient.newBuilder(reactContext).enablePendingPurchases().setListener(this)
-                .build()
-        billingClientCache!!.startConnection(
+
+        billingClient.startConnection(
             object : BillingClientStateListener {
                 override fun onBillingSetupFinished(billingResult: BillingResult) {
                     val responseCode = billingResult.responseCode
@@ -93,32 +101,15 @@ class RNIapModule(reactContext: ReactApplicationContext) :
                 }
 
                 override fun onBillingServiceDisconnected() {
-                    try {
-                        billingClientCache = null
-                        promise.reject("initConnection", "Billing service disconnected")
-                    } catch (oce: ObjectAlreadyConsumedException) {
-                        Log.e(TAG, oce.message!!)
-                    }
+                    Log.i(TAG, "Billing service disconnected")
                 }
             })
     }
 
     @ReactMethod
     fun endConnection(promise: Promise) {
-        if (billingClientCache != null) {
-            billingClientCache = try {
-                billingClientCache!!.endConnection()
-                null
-            } catch (e: Exception) {
-                promise.reject("endConnection", e.message)
-                return
-            }
-        }
-        try {
-            promise.resolve(true)
-        } catch (oce: ObjectAlreadyConsumedException) {
-            Log.e(TAG, oce.message!!)
-        }
+        billingClient.endConnection()
+        promise.resolve(true)
     }
 
     private fun consumeItems(
@@ -128,251 +119,236 @@ class RNIapModule(reactContext: ReactApplicationContext) :
     ) {
         for (purchase in purchases) {
             ensureConnection(
-                promise,
-                object : EnsureConnectionCallback {
-                    override fun run(billingClient: BillingClient) {
-                        val consumeParams =
-                            ConsumeParams.newBuilder().setPurchaseToken(purchase.purchaseToken)
-                                .build()
-                        val listener =
-                            ConsumeResponseListener { billingResult: BillingResult, outToken: String? ->
-                                if (billingResult.responseCode != expectedResponseCode) {
-                                    PlayUtils.instance
-                                        .rejectPromiseWithBillingError(
-                                            promise,
-                                            billingResult.responseCode
-                                        )
-                                    return@ConsumeResponseListener
-                                }
-                                try {
-                                    promise.resolve(true)
-                                } catch (oce: ObjectAlreadyConsumedException) {
-                                    promise.reject(oce.message)
-                                }
-                            }
-                        billingClient.consumeAsync(consumeParams, listener)
+                promise
+            ) {
+                val consumeParams =
+                    ConsumeParams.newBuilder().setPurchaseToken(purchase.purchaseToken)
+                        .build()
+                val listener =
+                    ConsumeResponseListener { billingResult: BillingResult, outToken: String? ->
+                        if (billingResult.responseCode != expectedResponseCode) {
+                            PlayUtils.instance
+                                .rejectPromiseWithBillingError(
+                                    promise,
+                                    billingResult.responseCode
+                                )
+                            return@ConsumeResponseListener
+                        }
+                        try {
+                            promise.resolve(true)
+                        } catch (oce: ObjectAlreadyConsumedException) {
+                            promise.reject(oce.message)
+                        }
                     }
-                }
-            )
+                billingClient.consumeAsync(consumeParams, listener)
+            }
         }
     }
 
     @ReactMethod
     fun flushFailedPurchasesCachedAsPending(promise: Promise) {
         ensureConnection(
-            promise,
-            object : EnsureConnectionCallback {
-                override fun run(billingClient: BillingClient) {
-                    val array = WritableNativeArray()
-                    billingClient.queryPurchasesAsync(
-                        BillingClient.SkuType.INAPP
-                    ) { billingResult: BillingResult?, list: List<Purchase>? ->
-                        if (list == null) {
-                            // No purchases found
-                            promise.resolve(false)
-                            return@queryPurchasesAsync
-                        }
-                        val pendingPurchases: MutableList<Purchase> = ArrayList()
-                        for (purchase in list) {
-                            // we only want to try to consume PENDING items, in order to force cache-refresh
-                            // for
-                            // them
-                            if (purchase.purchaseState == Purchase.PurchaseState.PENDING) {
-                                pendingPurchases.add(purchase)
-                            }
-                        }
-                        if (pendingPurchases.size == 0) {
-                            promise.resolve(false)
-                            return@queryPurchasesAsync
-                        }
-                        consumeItems(
-                            pendingPurchases,
-                            promise,
-                            BillingClient.BillingResponseCode.ITEM_NOT_OWNED
-                        )
+            promise
+        ) {
+            val array = WritableNativeArray()
+            billingClient.queryPurchasesAsync(
+                BillingClient.SkuType.INAPP
+            ) { _: BillingResult?, list: List<Purchase>? ->
+                if (list == null) {
+                    // No purchases found
+                    promise.resolve(false)
+                    return@queryPurchasesAsync
+                }
+                val pendingPurchases: MutableList<Purchase> = ArrayList()
+                for (purchase in list) {
+                    // we only want to try to consume PENDING items, in order to force cache-refresh
+                    // for
+                    // them
+                    if (purchase.purchaseState == Purchase.PurchaseState.PENDING) {
+                        pendingPurchases.add(purchase)
                     }
                 }
+                if (pendingPurchases.size == 0) {
+                    promise.resolve(false)
+                    return@queryPurchasesAsync
+                }
+                consumeItems(
+                    pendingPurchases,
+                    promise,
+                    BillingClient.BillingResponseCode.ITEM_NOT_OWNED
+                )
             }
-        )
+        }
     }
 
     @ReactMethod
     fun getItemsByType(type: String?, skuArr: ReadableArray, promise: Promise) {
         ensureConnection(
-            promise,
-            object : EnsureConnectionCallback {
-                override fun run(billingClient: BillingClient) {
-                    val skuList = ArrayList<String>()
-                    for (i in 0 until skuArr.size()) {
-                        val sku = skuArr.getString(i)
-                        if (sku is String) {
-                            skuList.add(sku)
-                        }
-                    }
-                    val params = SkuDetailsParams.newBuilder()
-                    params.setSkusList(skuList).setType(type!!)
-                    billingClient.querySkuDetailsAsync(
-                        params.build()
-                    ) { billingResult: BillingResult, skuDetailsList: List<SkuDetails>? ->
-                        Log.d(TAG, "responseCode: " + billingResult.responseCode)
-                        if (billingResult.responseCode != BillingClient.BillingResponseCode.OK) {
-                            PlayUtils.instance
-                                .rejectPromiseWithBillingError(promise, billingResult.responseCode)
-                            return@querySkuDetailsAsync
-                        }
-                        if (skuDetailsList != null) {
-                            for (sku in skuDetailsList) {
-                                skus.put(sku.getSku(), sku)
-                            }
-                        }
-                        val items = WritableNativeArray()
-                        for (skuDetails in skuDetailsList!!) {
-                            val item = Arguments.createMap()
-                            item.putString("productId", skuDetails.sku)
-                            val introductoryPriceMicros = skuDetails.introductoryPriceAmountMicros
-                            val priceAmountMicros = skuDetails.priceAmountMicros
-                            // Use valueOf instead of constructors.
-                            // See:
-                            // https://www.javaworld.com/article/2073176/caution--double-to-bigdecimal-in-java.html
-                            val priceAmount = BigDecimal.valueOf(priceAmountMicros)
-                            val introductoryPriceAmount =
-                                BigDecimal.valueOf(introductoryPriceMicros)
-                            val microUnitsDivisor = BigDecimal.valueOf(1000000)
-                            val price = priceAmount.divide(microUnitsDivisor).toString()
-                            val introductoryPriceAsAmountAndroid =
-                                introductoryPriceAmount.divide(microUnitsDivisor).toString()
-                            item.putString("price", price)
-                            item.putString("currency", skuDetails.priceCurrencyCode)
-                            item.putString("type", skuDetails.type)
-                            item.putString("localizedPrice", skuDetails.price)
-                            item.putString("title", skuDetails.title)
-                            item.putString("description", skuDetails.description)
-                            item.putString("introductoryPrice", skuDetails.introductoryPrice)
-                            item.putString("typeAndroid", skuDetails.type)
-                            item.putString("packageNameAndroid", skuDetails.zzc())
-                            item.putString("originalPriceAndroid", skuDetails.originalPrice)
-                            item.putString(
-                                "subscriptionPeriodAndroid",
-                                skuDetails.subscriptionPeriod
-                            )
-                            item.putString("freeTrialPeriodAndroid", skuDetails.freeTrialPeriod)
-                            item.putString(
-                                "introductoryPriceCyclesAndroid",
-                                skuDetails.introductoryPriceCycles.toString()
-                            )
-                            item.putString(
-                                "introductoryPricePeriodAndroid", skuDetails.introductoryPricePeriod
-                            )
-                            item.putString(
-                                "introductoryPriceAsAmountAndroid", introductoryPriceAsAmountAndroid
-                            )
-                            item.putString("iconUrl", skuDetails.iconUrl)
-                            item.putString("originalJson", skuDetails.originalJson)
-                            val originalPriceAmountMicros =
-                                BigDecimal.valueOf(skuDetails.originalPriceAmountMicros)
-                            val originalPrice =
-                                originalPriceAmountMicros.divide(microUnitsDivisor).toString()
-                            item.putString("originalPrice", originalPrice)
-                            items.pushMap(item)
-                        }
-                        try {
-                            promise.resolve(items)
-                        } catch (oce: ObjectAlreadyConsumedException) {
-                            Log.e(TAG, oce.message!!)
-                        }
-                    }
+            promise
+        ) {
+            val skuList = ArrayList<String>()
+            for (i in 0 until skuArr.size()) {
+                val sku = skuArr.getString(i)
+                if (sku is String) {
+                    skuList.add(sku)
                 }
             }
-        )
+            val params = SkuDetailsParams.newBuilder()
+            params.setSkusList(skuList).setType(type!!)
+            billingClient.querySkuDetailsAsync(
+                params.build()
+            ) { billingResult: BillingResult, skuDetailsList: List<SkuDetails>? ->
+                Log.d(TAG, "responseCode: " + billingResult.responseCode)
+                if (billingResult.responseCode != BillingClient.BillingResponseCode.OK) {
+                    PlayUtils.instance
+                        .rejectPromiseWithBillingError(promise, billingResult.responseCode)
+                    return@querySkuDetailsAsync
+                }
+                if (skuDetailsList != null) {
+                    for (sku in skuDetailsList) {
+                        skus[sku.sku] = sku
+                    }
+                }
+                val items = WritableNativeArray()
+                for (skuDetails in skuDetailsList!!) {
+                    val item = Arguments.createMap()
+                    item.putString("productId", skuDetails.sku)
+                    val introductoryPriceMicros = skuDetails.introductoryPriceAmountMicros
+                    val priceAmountMicros = skuDetails.priceAmountMicros
+                    // Use valueOf instead of constructors.
+                    // See:
+                    // https://www.javaworld.com/article/2073176/caution--double-to-bigdecimal-in-java.html
+                    val priceAmount = BigDecimal.valueOf(priceAmountMicros)
+                    val introductoryPriceAmount =
+                        BigDecimal.valueOf(introductoryPriceMicros)
+                    val microUnitsDivisor = BigDecimal.valueOf(1000000)
+                    val price = priceAmount.divide(microUnitsDivisor).toString()
+                    val introductoryPriceAsAmountAndroid =
+                        introductoryPriceAmount.divide(microUnitsDivisor).toString()
+                    item.putString("price", price)
+                    item.putString("currency", skuDetails.priceCurrencyCode)
+                    item.putString("type", skuDetails.type)
+                    item.putString("localizedPrice", skuDetails.price)
+                    item.putString("title", skuDetails.title)
+                    item.putString("description", skuDetails.description)
+                    item.putString("introductoryPrice", skuDetails.introductoryPrice)
+                    item.putString("typeAndroid", skuDetails.type)
+                    item.putString("packageNameAndroid", skuDetails.zzc())
+                    item.putString("originalPriceAndroid", skuDetails.originalPrice)
+                    item.putString(
+                        "subscriptionPeriodAndroid",
+                        skuDetails.subscriptionPeriod
+                    )
+                    item.putString("freeTrialPeriodAndroid", skuDetails.freeTrialPeriod)
+                    item.putString(
+                        "introductoryPriceCyclesAndroid",
+                        skuDetails.introductoryPriceCycles.toString()
+                    )
+                    item.putString(
+                        "introductoryPricePeriodAndroid", skuDetails.introductoryPricePeriod
+                    )
+                    item.putString(
+                        "introductoryPriceAsAmountAndroid", introductoryPriceAsAmountAndroid
+                    )
+                    item.putString("iconUrl", skuDetails.iconUrl)
+                    item.putString("originalJson", skuDetails.originalJson)
+                    val originalPriceAmountMicros =
+                        BigDecimal.valueOf(skuDetails.originalPriceAmountMicros)
+                    val originalPrice =
+                        originalPriceAmountMicros.divide(microUnitsDivisor).toString()
+                    item.putString("originalPrice", originalPrice)
+                    items.pushMap(item)
+                }
+                try {
+                    promise.resolve(items)
+                } catch (oce: ObjectAlreadyConsumedException) {
+                    Log.e(TAG, oce.message!!)
+                }
+            }
+        }
     }
 
     @ReactMethod
     fun getAvailableItemsByType(type: String, promise: Promise) {
         ensureConnection(
-            promise,
-            object : EnsureConnectionCallback {
-                override fun run(billingClient: BillingClient) {
-                    val items = WritableNativeArray()
-                    billingClient.queryPurchasesAsync(
-                        if (type == "subs") BillingClient.SkuType.SUBS else BillingClient.SkuType.INAPP
-                    ) { billingResult: BillingResult?, purchases: List<Purchase>? ->
-                        if (purchases != null) {
-                            for (i in purchases.indices) {
-                                val purchase = purchases[i]
-                                val item = WritableNativeMap()
-                                item.putString("productId", purchase.skus[0])
-                                item.putString("transactionId", purchase.orderId)
-                                item.putDouble("transactionDate", purchase.purchaseTime.toDouble())
-                                item.putString("transactionReceipt", purchase.originalJson)
-                                item.putString("orderId", purchase.orderId)
-                                item.putString("purchaseToken", purchase.purchaseToken)
-                                item.putString("developerPayloadAndroid", purchase.developerPayload)
-                                item.putString("signatureAndroid", purchase.signature)
-                                item.putInt("purchaseStateAndroid", purchase.purchaseState)
-                                item.putBoolean("isAcknowledgedAndroid", purchase.isAcknowledged)
-                                item.putString("packageNameAndroid", purchase.packageName)
-                                item.putString(
-                                    "obfuscatedAccountIdAndroid",
-                                    purchase.accountIdentifiers!!.obfuscatedAccountId
-                                )
-                                item.putString(
-                                    "obfuscatedProfileIdAndroid",
-                                    purchase.accountIdentifiers!!.obfuscatedProfileId
-                                )
-                                if (type == BillingClient.SkuType.SUBS) {
-                                    item.putBoolean("autoRenewingAndroid", purchase.isAutoRenewing)
-                                }
-                                items.pushMap(item)
-                            }
+            promise
+        ) {
+            val items = WritableNativeArray()
+            billingClient.queryPurchasesAsync(
+                if (type == "subs") BillingClient.SkuType.SUBS else BillingClient.SkuType.INAPP
+            ) { billingResult: BillingResult?, purchases: List<Purchase>? ->
+                if (purchases != null) {
+                    for (i in purchases.indices) {
+                        val purchase = purchases[i]
+                        val item = WritableNativeMap()
+                        item.putString("productId", purchase.skus[0])
+                        item.putString("transactionId", purchase.orderId)
+                        item.putDouble("transactionDate", purchase.purchaseTime.toDouble())
+                        item.putString("transactionReceipt", purchase.originalJson)
+                        item.putString("orderId", purchase.orderId)
+                        item.putString("purchaseToken", purchase.purchaseToken)
+                        item.putString("developerPayloadAndroid", purchase.developerPayload)
+                        item.putString("signatureAndroid", purchase.signature)
+                        item.putInt("purchaseStateAndroid", purchase.purchaseState)
+                        item.putBoolean("isAcknowledgedAndroid", purchase.isAcknowledged)
+                        item.putString("packageNameAndroid", purchase.packageName)
+                        item.putString(
+                            "obfuscatedAccountIdAndroid",
+                            purchase.accountIdentifiers!!.obfuscatedAccountId
+                        )
+                        item.putString(
+                            "obfuscatedProfileIdAndroid",
+                            purchase.accountIdentifiers!!.obfuscatedProfileId
+                        )
+                        if (type == BillingClient.SkuType.SUBS) {
+                            item.putBoolean("autoRenewingAndroid", purchase.isAutoRenewing)
                         }
-                        try {
-                            promise.resolve(items)
-                        } catch (oce: ObjectAlreadyConsumedException) {
-                            Log.e(TAG, oce.message!!)
-                        }
+                        items.pushMap(item)
                     }
                 }
+                try {
+                    promise.resolve(items)
+                } catch (oce: ObjectAlreadyConsumedException) {
+                    Log.e(TAG, oce.message!!)
+                }
             }
-        )
+        }
     }
 
     @ReactMethod
     fun getPurchaseHistoryByType(type: String, promise: Promise) {
         ensureConnection(
-            promise,
-            object : EnsureConnectionCallback {
-                override fun run(billingClient: BillingClient) {
-                    billingClient.queryPurchaseHistoryAsync(
-                        if (type == "subs") BillingClient.SkuType.SUBS else BillingClient.SkuType.INAPP
-                    ) { billingResult, purchaseHistoryRecordList ->
-                        if (billingResult.responseCode != BillingClient.BillingResponseCode.OK) {
-                            PlayUtils.instance
-                                .rejectPromiseWithBillingError(promise, billingResult.responseCode)
-                            return@queryPurchaseHistoryAsync
-                        }
-                        Log.d(TAG, purchaseHistoryRecordList.toString())
-                        val items = Arguments.createArray()
-                        for (i in purchaseHistoryRecordList!!.indices) {
-                            val item = Arguments.createMap()
-                            val purchase = purchaseHistoryRecordList[i]
-                            item.putString("productId", purchase.skus[0])
-                            item.putDouble("transactionDate", purchase.purchaseTime.toDouble())
-                            item.putString("transactionReceipt", purchase.originalJson)
-                            item.putString("purchaseToken", purchase.purchaseToken)
-                            item.putString("dataAndroid", purchase.originalJson)
-                            item.putString("signatureAndroid", purchase.signature)
-                            item.putString("developerPayload", purchase.developerPayload)
-                            items.pushMap(item)
-                        }
-                        try {
-                            promise.resolve(items)
-                        } catch (oce: ObjectAlreadyConsumedException) {
-                            Log.e(TAG, oce.message!!)
-                        }
-                    }
+            promise
+        ) {
+            billingClient.queryPurchaseHistoryAsync(
+                if (type == "subs") BillingClient.SkuType.SUBS else BillingClient.SkuType.INAPP
+            ) { billingResult, purchaseHistoryRecordList ->
+                if (billingResult.responseCode != BillingClient.BillingResponseCode.OK) {
+                    PlayUtils.instance
+                        .rejectPromiseWithBillingError(promise, billingResult.responseCode)
+                    return@queryPurchaseHistoryAsync
+                }
+                Log.d(TAG, purchaseHistoryRecordList.toString())
+                val items = Arguments.createArray()
+                for (i in purchaseHistoryRecordList!!.indices) {
+                    val item = Arguments.createMap()
+                    val purchase = purchaseHistoryRecordList[i]
+                    item.putString("productId", purchase.skus[0])
+                    item.putDouble("transactionDate", purchase.purchaseTime.toDouble())
+                    item.putString("transactionReceipt", purchase.originalJson)
+                    item.putString("purchaseToken", purchase.purchaseToken)
+                    item.putString("dataAndroid", purchase.originalJson)
+                    item.putString("signatureAndroid", purchase.signature)
+                    item.putString("developerPayload", purchase.developerPayload)
+                    items.pushMap(item)
+                }
+                try {
+                    promise.resolve(items)
+                } catch (oce: ObjectAlreadyConsumedException) {
+                    Log.e(TAG, oce.message!!)
                 }
             }
-        )
+        }
     }
 
     @ReactMethod
@@ -391,17 +367,49 @@ class RNIapModule(reactContext: ReactApplicationContext) :
             return
         }
         ensureConnection(
-            promise,
-            object : EnsureConnectionCallback {
-                override fun run(billingClient: BillingClient) {
-                    DoobooUtils.instance.addPromiseForKey(
-                        PROMISE_BUY_ITEM, promise
+            promise
+        ) {
+            DoobooUtils.instance.addPromiseForKey(
+                PROMISE_BUY_ITEM, promise
+            )
+            val builder = BillingFlowParams.newBuilder()
+            val selectedSku: SkuDetails? = skus[sku]
+            if (selectedSku == null) {
+                val debugMessage =
+                    "The sku was not found. Please fetch products first by calling getItems"
+                val error = Arguments.createMap()
+                error.putString("debugMessage", debugMessage)
+                error.putString("code", PROMISE_BUY_ITEM)
+                error.putString("message", debugMessage)
+                error.putString("productId", sku)
+                sendEvent(reactContext, "purchase-error", error)
+                promise.reject(PROMISE_BUY_ITEM, debugMessage)
+                return@ensureConnection
+            }
+            builder.setSkuDetails(selectedSku)
+            val subscriptionUpdateParamsBuilder = SubscriptionUpdateParams.newBuilder()
+            if (purchaseToken != null) {
+                subscriptionUpdateParamsBuilder.setOldSkuPurchaseToken(purchaseToken)
+            }
+            if (obfuscatedAccountId != null) {
+                builder.setObfuscatedAccountId(obfuscatedAccountId)
+            }
+            if (obfuscatedProfileId != null) {
+                builder.setObfuscatedProfileId(obfuscatedProfileId)
+            }
+            if (prorationMode != null && prorationMode != -1) {
+                if (prorationMode
+                    == BillingFlowParams.ProrationMode.IMMEDIATE_AND_CHARGE_PRORATED_PRICE
+                ) {
+                    subscriptionUpdateParamsBuilder.setReplaceSkusProrationMode(
+                        BillingFlowParams.ProrationMode.IMMEDIATE_AND_CHARGE_PRORATED_PRICE
                     )
-                    val builder = BillingFlowParams.newBuilder()
-                    var selectedSku: SkuDetails? = skus.get(sku)
-                    if (selectedSku == null) {
+                    if (type != BillingClient.SkuType.SUBS) {
                         val debugMessage =
-                            "The sku was not found. Please fetch products first by calling getItems"
+                            (
+                                "IMMEDIATE_AND_CHARGE_PRORATED_PRICE for proration mode only works in" +
+                                    " subscription purchase."
+                                )
                         val error = Arguments.createMap()
                         error.putString("debugMessage", debugMessage)
                         error.putString("code", PROMISE_BUY_ITEM)
@@ -409,80 +417,45 @@ class RNIapModule(reactContext: ReactApplicationContext) :
                         error.putString("productId", sku)
                         sendEvent(reactContext, "purchase-error", error)
                         promise.reject(PROMISE_BUY_ITEM, debugMessage)
-                        return
+                        return@ensureConnection
                     }
-                    builder.setSkuDetails(selectedSku)
-                    val subscriptionUpdateParamsBuilder = SubscriptionUpdateParams.newBuilder()
-                    if (purchaseToken != null) {
-                        subscriptionUpdateParamsBuilder.setOldSkuPurchaseToken(purchaseToken)
-                    }
-                    if (obfuscatedAccountId != null) {
-                        builder.setObfuscatedAccountId(obfuscatedAccountId)
-                    }
-                    if (obfuscatedProfileId != null) {
-                        builder.setObfuscatedProfileId(obfuscatedProfileId)
-                    }
-                    if (prorationMode != null && prorationMode != -1) {
-                        if (prorationMode
-                            == BillingFlowParams.ProrationMode.IMMEDIATE_AND_CHARGE_PRORATED_PRICE
-                        ) {
-                            subscriptionUpdateParamsBuilder.setReplaceSkusProrationMode(
-                                BillingFlowParams.ProrationMode.IMMEDIATE_AND_CHARGE_PRORATED_PRICE
-                            )
-                            if (type != BillingClient.SkuType.SUBS) {
-                                val debugMessage =
-                                    (
-                                        "IMMEDIATE_AND_CHARGE_PRORATED_PRICE for proration mode only works in" +
-                                            " subscription purchase."
-                                        )
-                                val error = Arguments.createMap()
-                                error.putString("debugMessage", debugMessage)
-                                error.putString("code", PROMISE_BUY_ITEM)
-                                error.putString("message", debugMessage)
-                                error.putString("productId", sku)
-                                sendEvent(reactContext, "purchase-error", error)
-                                promise.reject(PROMISE_BUY_ITEM, debugMessage)
-                                return
-                            }
-                        } else if (prorationMode
-                            == BillingFlowParams.ProrationMode.IMMEDIATE_WITHOUT_PRORATION
-                        ) {
-                            subscriptionUpdateParamsBuilder.setReplaceSkusProrationMode(
-                                BillingFlowParams.ProrationMode.IMMEDIATE_WITHOUT_PRORATION
-                            )
-                        } else if (prorationMode == BillingFlowParams.ProrationMode.DEFERRED) {
-                            subscriptionUpdateParamsBuilder.setReplaceSkusProrationMode(
-                                BillingFlowParams.ProrationMode.DEFERRED
-                            )
-                        } else if (prorationMode
-                            == BillingFlowParams.ProrationMode.IMMEDIATE_WITH_TIME_PRORATION
-                        ) {
-                            subscriptionUpdateParamsBuilder.setReplaceSkusProrationMode(
-                                BillingFlowParams.ProrationMode.IMMEDIATE_WITHOUT_PRORATION
-                            )
-                        } else if (prorationMode
-                            == BillingFlowParams.ProrationMode.IMMEDIATE_AND_CHARGE_FULL_PRICE
-                        ) {
-                            subscriptionUpdateParamsBuilder.setReplaceSkusProrationMode(
-                                BillingFlowParams.ProrationMode.IMMEDIATE_AND_CHARGE_FULL_PRICE
-                            )
-                        } else {
-                            subscriptionUpdateParamsBuilder.setReplaceSkusProrationMode(
-                                BillingFlowParams.ProrationMode.UNKNOWN_SUBSCRIPTION_UPGRADE_DOWNGRADE_POLICY
-                            )
-                        }
-                    }
-                    if (purchaseToken != null) {
-                        val subscriptionUpdateParams = subscriptionUpdateParamsBuilder.build()
-                        builder.setSubscriptionUpdateParams(subscriptionUpdateParams)
-                    }
-                    val flowParams = builder.build()
-                    val billingResult = billingClient.launchBillingFlow(activity, flowParams)
-                    val errorData: Array<String?> =
-                        PlayUtils.instance.getBillingResponseData(billingResult.responseCode)
+                } else if (prorationMode
+                    == BillingFlowParams.ProrationMode.IMMEDIATE_WITHOUT_PRORATION
+                ) {
+                    subscriptionUpdateParamsBuilder.setReplaceSkusProrationMode(
+                        BillingFlowParams.ProrationMode.IMMEDIATE_WITHOUT_PRORATION
+                    )
+                } else if (prorationMode == BillingFlowParams.ProrationMode.DEFERRED) {
+                    subscriptionUpdateParamsBuilder.setReplaceSkusProrationMode(
+                        BillingFlowParams.ProrationMode.DEFERRED
+                    )
+                } else if (prorationMode
+                    == BillingFlowParams.ProrationMode.IMMEDIATE_WITH_TIME_PRORATION
+                ) {
+                    subscriptionUpdateParamsBuilder.setReplaceSkusProrationMode(
+                        BillingFlowParams.ProrationMode.IMMEDIATE_WITHOUT_PRORATION
+                    )
+                } else if (prorationMode
+                    == BillingFlowParams.ProrationMode.IMMEDIATE_AND_CHARGE_FULL_PRICE
+                ) {
+                    subscriptionUpdateParamsBuilder.setReplaceSkusProrationMode(
+                        BillingFlowParams.ProrationMode.IMMEDIATE_AND_CHARGE_FULL_PRICE
+                    )
+                } else {
+                    subscriptionUpdateParamsBuilder.setReplaceSkusProrationMode(
+                        BillingFlowParams.ProrationMode.UNKNOWN_SUBSCRIPTION_UPGRADE_DOWNGRADE_POLICY
+                    )
                 }
             }
-        )
+            if (purchaseToken != null) {
+                val subscriptionUpdateParams = subscriptionUpdateParamsBuilder.build()
+                builder.setSubscriptionUpdateParams(subscriptionUpdateParams)
+            }
+            val flowParams = builder.build()
+            val billingResult = billingClient.launchBillingFlow(activity, flowParams)
+            val errorData: Array<String?> =
+                PlayUtils.instance.getBillingResponseData(billingResult.responseCode)
+        }
     }
 
     @ReactMethod
@@ -492,36 +465,33 @@ class RNIapModule(reactContext: ReactApplicationContext) :
         promise: Promise
     ) {
         ensureConnection(
-            promise,
-            object : EnsureConnectionCallback {
-                override fun run(billingClient: BillingClient) {
-                    val acknowledgePurchaseParams =
-                        AcknowledgePurchaseParams.newBuilder().setPurchaseToken(
-                            token!!
-                        ).build()
-                    billingClient.acknowledgePurchase(
-                        acknowledgePurchaseParams
-                    ) { billingResult: BillingResult ->
-                        if (billingResult.responseCode != BillingClient.BillingResponseCode.OK) {
-                            PlayUtils.instance
-                                .rejectPromiseWithBillingError(promise, billingResult.responseCode)
-                        }
-                        try {
-                            val map = Arguments.createMap()
-                            map.putInt("responseCode", billingResult.responseCode)
-                            map.putString("debugMessage", billingResult.debugMessage)
-                            val errorData: Array<String?> = PlayUtils.instance
-                                .getBillingResponseData(billingResult.responseCode)
-                            map.putString("code", errorData[0])
-                            map.putString("message", errorData[1])
-                            promise.resolve(map)
-                        } catch (oce: ObjectAlreadyConsumedException) {
-                            Log.e(TAG, oce.message!!)
-                        }
-                    }
+            promise
+        ) {
+            val acknowledgePurchaseParams =
+                AcknowledgePurchaseParams.newBuilder().setPurchaseToken(
+                    token!!
+                ).build()
+            billingClient.acknowledgePurchase(
+                acknowledgePurchaseParams
+            ) { billingResult: BillingResult ->
+                if (billingResult.responseCode != BillingClient.BillingResponseCode.OK) {
+                    PlayUtils.instance
+                        .rejectPromiseWithBillingError(promise, billingResult.responseCode)
+                }
+                try {
+                    val map = Arguments.createMap()
+                    map.putInt("responseCode", billingResult.responseCode)
+                    map.putString("debugMessage", billingResult.debugMessage)
+                    val errorData: Array<String?> = PlayUtils.instance
+                        .getBillingResponseData(billingResult.responseCode)
+                    map.putString("code", errorData[0])
+                    map.putString("message", errorData[1])
+                    promise.resolve(map)
+                } catch (oce: ObjectAlreadyConsumedException) {
+                    Log.e(TAG, oce.message!!)
                 }
             }
-        )
+        }
     }
 
     @ReactMethod
@@ -532,32 +502,29 @@ class RNIapModule(reactContext: ReactApplicationContext) :
     ) {
         val params = ConsumeParams.newBuilder().setPurchaseToken(token!!).build()
         ensureConnection(
-            promise,
-            object : EnsureConnectionCallback {
-                override fun run(billingClient: BillingClient) {
-                    billingClient.consumeAsync(
-                        params
-                    ) { billingResult: BillingResult, purchaseToken: String? ->
-                        if (billingResult.responseCode != BillingClient.BillingResponseCode.OK) {
-                            PlayUtils.instance
-                                .rejectPromiseWithBillingError(promise, billingResult.responseCode)
-                        }
-                        try {
-                            val map = Arguments.createMap()
-                            map.putInt("responseCode", billingResult.responseCode)
-                            map.putString("debugMessage", billingResult.debugMessage)
-                            val errorData: Array<String?> = PlayUtils.instance
-                                .getBillingResponseData(billingResult.responseCode)
-                            map.putString("code", errorData[0])
-                            map.putString("message", errorData[1])
-                            promise.resolve(map)
-                        } catch (oce: ObjectAlreadyConsumedException) {
-                            promise.reject(oce.message)
-                        }
-                    }
+            promise
+        ) {
+            billingClient.consumeAsync(
+                params
+            ) { billingResult: BillingResult, purchaseToken: String? ->
+                if (billingResult.responseCode != BillingClient.BillingResponseCode.OK) {
+                    PlayUtils.instance
+                        .rejectPromiseWithBillingError(promise, billingResult.responseCode)
+                }
+                try {
+                    val map = Arguments.createMap()
+                    map.putInt("responseCode", billingResult.responseCode)
+                    map.putString("debugMessage", billingResult.debugMessage)
+                    val errorData: Array<String?> = PlayUtils.instance
+                        .getBillingResponseData(billingResult.responseCode)
+                    map.putString("code", errorData[0])
+                    map.putString("message", errorData[1])
+                    promise.resolve(map)
+                } catch (oce: ObjectAlreadyConsumedException) {
+                    promise.reject(oce.message)
                 }
             }
-        )
+        }
     }
 
     override fun onPurchasesUpdated(billingResult: BillingResult, purchases: List<Purchase>?) {
@@ -625,30 +592,25 @@ class RNIapModule(reactContext: ReactApplicationContext) :
 
     private fun sendUnconsumedPurchases(promise: Promise) {
         ensureConnection(
-            promise,
-            object : EnsureConnectionCallback {
-                override fun run(billingClient: BillingClient) {
-                    val types = arrayOf(BillingClient.SkuType.INAPP, BillingClient.SkuType.SUBS)
-                    for (type in types) {
-                        billingClient.queryPurchasesAsync(
-                            type
-                        ) { billingResult: BillingResult, list: List<Purchase>? ->
-                            val unacknowledgedPurchases = ArrayList<Purchase>()
-                            if (list == null || list.size == 0) {
-                                //                    continue;
-                            }
-                            for (purchase in list!!) {
-                                if (!purchase.isAcknowledged) {
-                                    unacknowledgedPurchases.add(purchase)
-                                }
-                            }
-                            onPurchasesUpdated(billingResult, unacknowledgedPurchases)
+            promise
+        ) {
+            val types = arrayOf(BillingClient.SkuType.INAPP, BillingClient.SkuType.SUBS)
+            for (type in types) {
+                billingClient.queryPurchasesAsync(
+                    type
+                ) { billingResult: BillingResult, list: List<Purchase>? ->
+                    val unacknowledgedPurchases = ArrayList<Purchase>()
+
+                    for (purchase in list!!) {
+                        if (!purchase.isAcknowledged) {
+                            unacknowledgedPurchases.add(purchase)
                         }
                     }
-                    promise.resolve(true)
+                    onPurchasesUpdated(billingResult, unacknowledgedPurchases)
                 }
             }
-        )
+            promise.resolve(true)
+        }
     }
 
     @ReactMethod
@@ -682,19 +644,15 @@ class RNIapModule(reactContext: ReactApplicationContext) :
 
     companion object {
         private const val PROMISE_BUY_ITEM = "PROMISE_BUY_ITEM"
+        const val TAG = "RNIapModule"
     }
 
     init {
-        this.reactContext = reactContext
-        skus = mutableMapOf<String, SkuDetails>()
         val lifecycleEventListener: LifecycleEventListener = object : LifecycleEventListener {
             override fun onHostResume() {}
             override fun onHostPause() {}
             override fun onHostDestroy() {
-                if (billingClientCache != null) {
-                    billingClientCache!!.endConnection()
-                    billingClientCache = null
-                }
+                billingClient.endConnection()
             }
         }
         reactContext.addLifecycleEventListener(lifecycleEventListener)

--- a/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
@@ -17,6 +17,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.ObjectAlreadyConsumedException
 import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.PromiseImpl
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule

--- a/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
@@ -47,21 +47,24 @@ class RNIapModule(private val reactContext: ReactApplicationContext) :
             callback()
             return
         } else {
-            val nested = PromiseImpl({
-                if (it.isNotEmpty() && it[0] is Boolean && it[0] as Boolean) {
-                    callback()
-                } else {
-                    Log.i(TAG, "Incorrect parameter in resolve")
+            val nested = PromiseImpl(
+                {
+                    if (it.isNotEmpty() && it[0] is Boolean && it[0] as Boolean) {
+                        callback()
+                    } else {
+                        Log.i(TAG, "Incorrect parameter in resolve")
+                    }
+                },
+                {
+                    if (it.size > 1 && it[0] is String && it[1] is String) {
+                        promise.reject(
+                            it[0] as String, it[1] as String
+                        )
+                    } else {
+                        Log.i(TAG, "Incorrect parameters in reject")
+                    }
                 }
-            }, {
-                if (it.size > 1 && it[0] is String && it[1] is String) {
-                    promise.reject(
-                        it[0] as String, it[1] as String
-                    )
-                } else {
-                    Log.i(TAG, "Incorrect parameters in reject")
-                }
-            })
+            )
             initConnection(nested)
         }
     }


### PR DESCRIPTION
This is my proposed change to attempt a reconnection if the billing client is not initialized. It looks more dramatic than it actually is. The only real change was on `ensureConnection`. All the other changes are formating caused by removing the custom callback `EnsureConnectionCallback` and using lambdas instead since we no longer need to pass the billing Client around as a parameter