### PR TITLE
🛠️  : Fix  NativeModules.RNIapModule.getPackageName()

### DIFF
--- a/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
@@ -609,7 +609,7 @@ class RNIapModule(
 
     @get:ReactMethod
     val packageName: String
-        get() = reactApplicationContext.packageName()
+        get() = reactApplicationContext.getPackageName()
 
     private fun sendEvent(
         reactContext: ReactContext,

--- a/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
@@ -609,7 +609,7 @@ class RNIapModule(
 
     @get:ReactMethod
     val packageName: String
-        get() = reactApplicationContext.packageName
+        get() = reactApplicationContext.packageName()
 
     private fun sendEvent(
         reactContext: ReactContext,


### PR DESCRIPTION
this is required for deepLinkToAndroidSubscription(sku)