### PR TITLE
First check for billing to be avaiable

### DIFF
--- a/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
@@ -119,7 +119,7 @@ class RNIapModule(
     @ReactMethod
     fun endConnection(promise: Promise) {
         billingClientCache?.endConnection()
-
+        billingClientCache = null
         promise.safeResolve(true)
     }
 

--- a/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
@@ -58,7 +58,10 @@ class RNIapModule(
             val nested = PromiseImpl(
                 {
                     if (it.isNotEmpty() && it[0] is Boolean && it[0] as Boolean) {
-                        billingClientCache?.let(callback) ?: run {
+                        val connectedBillingClient = billingClientCache
+                        if (connectedBillingClient?.isReady == true) {
+                            callback(connectedBillingClient)
+                        } else {
                             promise.safeReject(DoobooUtils.E_NOT_PREPARED, "Unable to auto-initialize connection")
                         }
                     } else {

--- a/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
@@ -98,7 +98,7 @@ class RNIapModule(
             return
         }
         billingClientCache = builder.setListener(this).build().also {
-            
+
             it.startConnection(
                 object : BillingClientStateListener {
                     override fun onBillingSetupFinished(billingResult: BillingResult) {

--- a/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
@@ -100,20 +100,20 @@ class RNIapModule(
             promise.safeResolve(true)
             return
         }
-        billingClientCache = builder.setListener(this).build().also {
-
+        builder.setListener(this).build().also {
+            billingClientCache = it
             it.startConnection(
-                object : BillingClientStateListener {
-                    override fun onBillingSetupFinished(billingResult: BillingResult) {
-                        if (!isValidResult(billingResult, promise)) return
+            object : BillingClientStateListener {
+                override fun onBillingSetupFinished(billingResult: BillingResult) {
+                    if (!isValidResult(billingResult, promise)) return
 
-                        promise.safeResolve(true)
-                    }
+                    promise.safeResolve(true)
+                }
 
-                    override fun onBillingServiceDisconnected() {
-                        Log.i(TAG, "Billing service disconnected")
-                    }
-                })
+                override fun onBillingServiceDisconnected() {
+                    Log.i(TAG, "Billing service disconnected")
+                }
+            })
         }
     }
 

--- a/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
@@ -195,11 +195,9 @@ class RNIapModule(
 
                 val items = Arguments.createArray()
                 if (skuDetailsList != null) {
-                    for (sku in skuDetailsList) {
-                        skus[sku.sku] = sku
-                    }
-
                     for (skuDetails in skuDetailsList) {
+                        skus[skuDetails.sku] = skuDetails
+
                         val item = Arguments.createMap()
                         item.putString("productId", skuDetails.sku)
                         val introductoryPriceMicros = skuDetails.introductoryPriceAmountMicros

--- a/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
@@ -181,7 +181,7 @@ class RNIapModule(
         ) {
             val skuList = ArrayList<String>()
             for (i in 0 until skuArr.size()) {
-                if(skuArr.getType(i) == ReadableType.String) {
+                if (skuArr.getType(i) == ReadableType.String) {
                     val sku = skuArr.getString(i)
                     skuList.add(sku)
                 }

--- a/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
@@ -103,17 +103,17 @@ class RNIapModule(
         builder.setListener(this).build().also {
             billingClientCache = it
             it.startConnection(
-            object : BillingClientStateListener {
-                override fun onBillingSetupFinished(billingResult: BillingResult) {
-                    if (!isValidResult(billingResult, promise)) return
+                object : BillingClientStateListener {
+                    override fun onBillingSetupFinished(billingResult: BillingResult) {
+                        if (!isValidResult(billingResult, promise)) return
 
-                    promise.safeResolve(true)
-                }
+                        promise.safeResolve(true)
+                    }
 
-                override fun onBillingServiceDisconnected() {
-                    Log.i(TAG, "Billing service disconnected")
-                }
-            })
+                    override fun onBillingServiceDisconnected() {
+                        Log.i(TAG, "Billing service disconnected")
+                    }
+                })
         }
     }
 

--- a/android/src/testPlay/java/com/dooboolab/RNIap/RNIapModuleTest.kt
+++ b/android/src/testPlay/java/com/dooboolab/RNIap/RNIapModuleTest.kt
@@ -62,7 +62,7 @@ class RNIapModuleTest {
         every { billingClient.isReady } returns true
 
         val promise = mockk<Promise>(relaxed = true)
-        //already connected
+        // Already connected
         module.initConnection(promise)
         verify(exactly = 0) { promise.reject(any(), any<String>()) }
         verify { promise.resolve(true) }

--- a/android/src/testPlay/java/com/dooboolab/RNIap/RNIapModuleTest.kt
+++ b/android/src/testPlay/java/com/dooboolab/RNIap/RNIapModuleTest.kt
@@ -183,7 +183,7 @@ class RNIapModuleTest {
         every { availability.isGooglePlayServicesAvailable(any()) } returns ConnectionResult.SUCCESS
         val promise = mockk<Promise>(relaxed = true)
         var isCallbackCalled = false
-        val callback = {
+        val callback = { _: BillingClient ->
             isCallbackCalled = true
             promise.resolve(true)
         }

--- a/android/src/testPlay/java/com/dooboolab/RNIap/RNIapModuleTest.kt
+++ b/android/src/testPlay/java/com/dooboolab/RNIap/RNIapModuleTest.kt
@@ -11,6 +11,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableType
 import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
 import com.google.android.gms.common.ConnectionResult
@@ -55,9 +56,13 @@ class RNIapModuleTest {
 
     @Test
     fun `initConnection Already connected should resolve to true`() {
-        every { billingClient.isReady } returns true
-        val promise = mockk<Promise>(relaxed = true)
+        every { availability.isGooglePlayServicesAvailable(any()) } returns ConnectionResult.SUCCESS
+        module.initConnection(mockk())
 
+        every { billingClient.isReady } returns true
+
+        val promise = mockk<Promise>(relaxed = true)
+        //already connected
         module.initConnection(promise)
         verify(exactly = 0) { promise.reject(any(), any<String>()) }
         verify { promise.resolve(true) }
@@ -112,8 +117,10 @@ class RNIapModuleTest {
 
     @Test
     fun `endConnection resolves`() {
+        every { availability.isGooglePlayServicesAvailable(any()) } returns ConnectionResult.SUCCESS
         val promise = mockk<Promise>(relaxed = true)
 
+        module.initConnection(mockk())
         module.endConnection(promise)
 
         verify { billingClient.endConnection() }
@@ -123,12 +130,14 @@ class RNIapModuleTest {
 
     @Test
     fun `flushFailedPurchasesCachedAsPending resolves to false if no pending purchases`() {
+        every { availability.isGooglePlayServicesAvailable(any()) } returns ConnectionResult.SUCCESS
         every { billingClient.isReady } returns true
         val promise = mockk<Promise>(relaxed = true)
         val listener = slot<PurchasesResponseListener>()
         every { billingClient.queryPurchasesAsync(any(), capture(listener)) } answers {
             listener.captured.onQueryPurchasesResponse(BillingResult.newBuilder().build(), listOf())
         }
+        module.initConnection(mockk())
         module.flushFailedPurchasesCachedAsPending(promise)
 
         verify(exactly = 0) { promise.reject(any(), any<String>()) }
@@ -137,6 +146,7 @@ class RNIapModuleTest {
 
     @Test
     fun `flushFailedPurchasesCachedAsPending resolves to true if pending purchases`() {
+        every { availability.isGooglePlayServicesAvailable(any()) } returns ConnectionResult.SUCCESS
         every { billingClient.isReady } returns true
         val promise = mockk<Promise>(relaxed = true)
         val listener = slot<PurchasesResponseListener>()
@@ -161,7 +171,7 @@ class RNIapModuleTest {
                 ""
             )
         }
-
+        module.initConnection(mockk())
         module.flushFailedPurchasesCachedAsPending(promise)
 
         verify(exactly = 0) { promise.reject(any(), any<String>()) }
@@ -178,7 +188,15 @@ class RNIapModuleTest {
             promise.resolve(true)
         }
 
-        every { billingClient.isReady } returns false andThen true
+        every { billingClient.isReady } returns true
+        val listener = slot<BillingClientStateListener>()
+        every { billingClient.startConnection(capture(listener)) } answers {
+            listener.captured.onBillingSetupFinished(
+                BillingResult.newBuilder().setResponseCode(BillingClient.BillingResponseCode.OK)
+                    .build()
+            )
+        }
+
         module.ensureConnection(promise, callback)
         verify { promise.resolve(true) } // at least one pending transactions
         assertTrue("Should call callback", isCallbackCalled)
@@ -186,6 +204,7 @@ class RNIapModuleTest {
 
     @Test
     fun getItemsByType() {
+        every { availability.isGooglePlayServicesAvailable(any()) } returns ConnectionResult.SUCCESS
         every { billingClient.isReady } returns true
         val promise = mockk<Promise>(relaxed = true)
         val listener = slot<SkuDetailsResponseListener>()
@@ -219,6 +238,7 @@ class RNIapModuleTest {
         val skus = mockk<ReadableArray>() {
             every { size() } returns 1
             every { getString(0) } returns "sku0"
+            every { getType(0) } returns ReadableType.String
         }
         mockkStatic(Arguments::class)
 
@@ -231,7 +251,7 @@ class RNIapModuleTest {
         every { itemsArr.pushMap(any()) } answers {
             itemsSize++
         }
-
+        module.initConnection(mockk())
         module.getItemsByType("subs", skus, promise)
         verify { promise.resolve(any()) }
         assertEquals(itemsSize, 1)


### PR DESCRIPTION
There is a crash on Android when attempting to test the app using an emulator/device without Play Services. The crash happens before the app initializes. This is because we were creating the billing client in the constructor instead of first checking it Google Play Services was available. This PR fixes it