### PR TITLE
feat(ios-purchase): add appAccountToken to requestPurchase on iOS

### DIFF
--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -18,6 +18,7 @@ RCT_EXTERN_METHOD(getAvailableItems:
                   reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(buyProduct:
                   (NSString*)sku
+                  appAccountToken:(NSString*)appAccountToken
                   andDangerouslyFinishTransactionAutomatically:(BOOL)andDangerouslyFinishTransactionAutomatically
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)

--- a/ios/RNIapIos.swift
+++ b/ios/RNIapIos.swift
@@ -178,6 +178,7 @@ class RNIapIos: RCTEventEmitter, SKRequestDelegate, SKPaymentTransactionObserver
     
     @objc public func buyProduct(
         _ sku:String,
+        appAccountToken:String,
         andDangerouslyFinishTransactionAutomatically: Bool,
         resolve: @escaping RCTPromiseResolveBlock = { _ in },
         reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
@@ -197,6 +198,7 @@ class RNIapIos: RCTEventEmitter, SKRequestDelegate, SKPaymentTransactionObserver
             addPromise(forKey: prod.productIdentifier, resolve: resolve, reject: reject)
             
             let payment = SKMutablePayment(product: prod)
+            payment.applicationUsername = appAccountToken 
             SKPaymentQueue.default().add(payment)
         } else{
             if hasListeners {

--- a/src/iap.ts
+++ b/src/iap.ts
@@ -244,6 +244,7 @@ export const getAvailablePurchases = (): Promise<
 /**
  * Request a purchase for product. This will be received in `PurchaseUpdatedListener`.
  * @param {string} sku The product's sku/ID
+ * @param {string} [appAccountToken] The purchaser's user ID
  * @param {boolean} [andDangerouslyFinishTransactionAutomaticallyIOS] You should set this to false and call finishTransaction manually when you have delivered the purchased goods to the user. It defaults to true to provide backwards compatibility. Will default to false in version 4.0.0.
  * @param {string} [obfuscatedAccountIdAndroid] Specifies an optional obfuscated string that is uniquely associated with the user's account in your app.
  * @param {string} [obfuscatedProfileIdAndroid] Specifies an optional obfuscated string that is uniquely associated with the user's profile in your app.
@@ -251,6 +252,7 @@ export const getAvailablePurchases = (): Promise<
  */
 export const requestPurchase = (
   sku: string,
+  appAccountToken: string,
   andDangerouslyFinishTransactionAutomaticallyIOS: boolean = false,
   obfuscatedAccountIdAndroid: string | undefined = undefined,
   obfuscatedProfileIdAndroid: string | undefined = undefined,
@@ -268,6 +270,7 @@ export const requestPurchase = (
 
         return getIosModule().buyProduct(
           sku,
+          appAccountToken,
           andDangerouslyFinishTransactionAutomaticallyIOS,
         );
       },


### PR DESCRIPTION
According to the issue https://github.com/dooboolab/react-native-iap/issues/1576 there is a need for an extra param for iOS transactions. 