### PR TITLE
Publish beta on merge in beta branch

### DIFF
--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '16.x'
-          registry-url: https://npm.pkg.github.com/
+          registry-url: 'https://npm.pkg.github.com/'
       - run: yarn
       - run: yarn build
       - run: npm publish

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -1,0 +1,21 @@
+name: publish-beta
+
+on:
+  push:
+    branches: [beta]
+
+jobs:
+  publish-github-registry:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          registry-url: https://npm.pkg.github.com/
+      - run: yarn
+      - run: yarn build
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -1,10 +1,24 @@
-name: publish-beta
+name: publish-next
 
 on:
   push:
-    branches: [beta]
+    branches: [next]
 
 jobs:
+  publish-npm-registry:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: yarn
+      - run: yarn build
+      - run: npm publish --tag next
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   publish-github-registry:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Manage the `next` release on the separate branch in `next` instead of publishing to the release tag with `npm`.
The downside of previous releases is that the user can't find the stable release of the version and we can't update the latest stable version when there has been a mistake.

Now, when `rebase merge` the `main` branch in `beta`, the CI will run and release the package to with `next` tag instead of the release.

- Related https://github.com/dooboolab/react-native-iap/discussions/1777
