### PR TITLE
Fix mismatch between buyProduct signatues in Obj-C and swift

### DIFF
--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -18,7 +18,6 @@ RCT_EXTERN_METHOD(getAvailableItems:
                   reject:(RCTPromiseRejectBlock)reject)
 RCT_EXTERN_METHOD(buyProduct:
                   (NSString*)sku
-                  appAccountToken:(NSString*)appAccountToken
                   andDangerouslyFinishTransactionAutomatically:(BOOL)andDangerouslyFinishTransactionAutomatically
                   applicationUsername:(NSString)applicationUsername
                   resolve:(RCTPromiseResolveBlock)resolve


### PR DESCRIPTION
Closes #1780 