### PR TITLE
fix: methods types

### DIFF
--- a/src/iap.ts
+++ b/src/iap.ts
@@ -258,9 +258,9 @@ export const getAvailablePurchases = (): Promise<
 export const requestPurchase = ({
   sku,
   andDangerouslyFinishTransactionAutomaticallyIOS = false,
-  obfuscatedAccountIdAndroid = undefined,
-  obfuscatedProfileIdAndroid = undefined,
-  applicationUsername = undefined,
+  obfuscatedAccountIdAndroid,
+  obfuscatedProfileIdAndroid,
+  applicationUsername,
 }: RequestPurchase): Promise<InAppPurchase> =>
   (
     Platform.select({
@@ -306,11 +306,11 @@ export const requestPurchase = ({
 export const requestSubscription = ({
   sku,
   andDangerouslyFinishTransactionAutomaticallyIOS = false,
-  purchaseTokenAndroid = undefined,
+  purchaseTokenAndroid,
   prorationModeAndroid = -1,
-  obfuscatedAccountIdAndroid = undefined,
-  obfuscatedProfileIdAndroid = undefined,
-  applicationUsername = undefined,
+  obfuscatedAccountIdAndroid,
+  obfuscatedProfileIdAndroid,
+  applicationUsername,
 }: RequestSubscription): Promise<SubscriptionPurchase | null> =>
   (
     Platform.select({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+type Sku = string;
+
 export enum IAPErrorCode {
   E_IAP_NOT_AVAILABLE = 'E_IAP_NOT_AVAILABLE',
   E_UNKNOWN = 'E_UNKNOWN',
@@ -146,16 +148,38 @@ export interface Subscription extends ProductCommon {
   freeTrialPeriodAndroid?: string;
 }
 
-export interface RequestPurchase {
-  sku: string;
+interface RequestPurchaseCommon {
+  sku: Sku;
+}
+
+interface RequestPurchaseIOS extends RequestPurchaseCommon {
   andDangerouslyFinishTransactionAutomaticallyIOS: boolean;
   applicationUsername?: string;
-  obfuscatedAccountIdAndroid: string | undefined;
-  obfuscatedProfileIdAndroid: string | undefined;
+  obfuscatedAccountIdAndroid?: never;
+  obfuscatedProfileIdAndroid?: never;
+  selectedOfferIndex?: never;
+}
+
+interface RequestPurchaseAndroid extends RequestPurchaseCommon {
+  andDangerouslyFinishTransactionAutomaticallyIOS?: never;
+  applicationUsername?: never;
+  obfuscatedAccountIdAndroid?: string;
+  obfuscatedProfileIdAndroid?: string;
   selectedOfferIndex: number;
 }
 
-export interface RequestSubscription extends RequestPurchase {
-  purchaseTokenAndroid: string | undefined;
+export type RequestPurchase = RequestPurchaseIOS | RequestPurchaseAndroid;
+
+interface RequestSubscriptionIOS extends RequestPurchaseIOS {
+  purchaseTokenAndroid?: never;
+  prorationModeAndroid?: never;
+}
+
+interface RequestSubscriptionAndroid extends RequestPurchaseAndroid {
+  purchaseTokenAndroid?: string;
   prorationModeAndroid: ProrationModesAndroid;
 }
+
+export type RequestSubscription =
+  | RequestSubscriptionIOS
+  | RequestSubscriptionAndroid;


### PR DESCRIPTION
Conditional union types depending on the props passed. Makes it easier to discover which props are allowed to work together

requestPurchase:
![Screenshot 2022-08-02 at 17 04 43](https://user-images.githubusercontent.com/937328/182434496-f4654610-2db1-4184-ac0b-61cddb4ce666.png)

requestSubscription:
![Screenshot 2022-08-02 at 17 07 39](https://user-images.githubusercontent.com/937328/182434487-7e16d203-3638-4a86-b254-cb79f48e1ce7.png)
