### PR TITLE
fix: limit promotedProductListener to iOS

### DIFF
--- a/src/hooks/withIAPContext.tsx
+++ b/src/hooks/withIAPContext.tsx
@@ -147,7 +147,7 @@ export function withIAPContext<T>(Component: React.ComponentType<T>) {
       return () => {
         purchaseUpdateSubscription.remove();
         purchaseErrorSubscription.remove();
-        promotedProductSubscription.remove();
+        promotedProductSubscription?.remove();
       };
     }, [connected]);
 

--- a/src/iap.ts
+++ b/src/iap.ts
@@ -30,6 +30,7 @@ import {
 
 const {RNIapIos, RNIapModule, RNIapAmazonModule} = NativeModules;
 const isAndroid = Platform.OS === 'android';
+const isIos = Platform.OS === 'ios';
 const ANDROID_ITEM_TYPE_SUBSCRIPTION = 'subs';
 const ANDROID_ITEM_TYPE_IAP = 'inapp';
 
@@ -664,11 +665,15 @@ export const purchaseErrorListener = (
  */
 export const promotedProductListener = (
   listener: () => void,
-): EmitterSubscription =>
-  new NativeEventEmitter(getIosModule()).addListener(
-    'iap-promoted-product',
-    listener,
-  );
+): EmitterSubscription | null => {
+  if (isIos) {
+    return new NativeEventEmitter(getIosModule()).addListener(
+      'iap-promoted-product',
+      listener,
+    );
+  }
+  return null;
+};
 
 /**
  * Get the current receipt base64 encoded in IOS.


### PR DESCRIPTION
This attempts to fix issue: https://github.com/dooboolab/react-native-iap/issues/1800

I'm submitting this as a recommendation, I haven't had a chance to test it.