### PR TITLE
fix: revert "fix: methods types (#1792)"

### DIFF
--- a/src/iap.ts
+++ b/src/iap.ts
@@ -263,9 +263,9 @@ export const getAvailablePurchases = (): Promise<
 export const requestPurchase = ({
   sku,
   andDangerouslyFinishTransactionAutomaticallyIOS = false,
-  obfuscatedAccountIdAndroid = undefined,
-  obfuscatedProfileIdAndroid = undefined,
-  applicationUsername = undefined,
+  obfuscatedAccountIdAndroid,
+  obfuscatedProfileIdAndroid,
+  applicationUsername,
 }: RequestPurchase): Promise<InAppPurchase> =>
   (
     Platform.select({
@@ -309,11 +309,11 @@ export const requestPurchase = ({
 export const requestSubscription = ({
   sku,
   andDangerouslyFinishTransactionAutomaticallyIOS = false,
-  purchaseTokenAndroid = undefined,
+  purchaseTokenAndroid,
   prorationModeAndroid = -1,
-  obfuscatedAccountIdAndroid = undefined,
-  obfuscatedProfileIdAndroid = undefined,
-  applicationUsername = undefined,
+  obfuscatedAccountIdAndroid,
+  obfuscatedProfileIdAndroid,
+  applicationUsername,
 }: RequestSubscription): Promise<SubscriptionPurchase | null> =>
   (
     Platform.select({

--- a/src/iap.ts
+++ b/src/iap.ts
@@ -263,9 +263,9 @@ export const getAvailablePurchases = (): Promise<
 export const requestPurchase = ({
   sku,
   andDangerouslyFinishTransactionAutomaticallyIOS = false,
-  obfuscatedAccountIdAndroid,
-  obfuscatedProfileIdAndroid,
-  applicationUsername,
+  obfuscatedAccountIdAndroid = undefined,
+  obfuscatedProfileIdAndroid = undefined,
+  applicationUsername = undefined,
 }: RequestPurchase): Promise<InAppPurchase> =>
   (
     Platform.select({
@@ -309,11 +309,11 @@ export const requestPurchase = ({
 export const requestSubscription = ({
   sku,
   andDangerouslyFinishTransactionAutomaticallyIOS = false,
-  purchaseTokenAndroid,
+  purchaseTokenAndroid = undefined,
   prorationModeAndroid = -1,
-  obfuscatedAccountIdAndroid,
-  obfuscatedProfileIdAndroid,
-  applicationUsername,
+  obfuscatedAccountIdAndroid = undefined,
+  obfuscatedProfileIdAndroid = undefined,
+  applicationUsername = undefined,
 }: RequestSubscription): Promise<SubscriptionPurchase | null> =>
   (
     Platform.select({

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,3 @@
-type Sku = string;
-
 export enum IAPErrorCode {
   E_IAP_NOT_AVAILABLE = 'E_IAP_NOT_AVAILABLE',
   E_UNKNOWN = 'E_UNKNOWN',
@@ -148,38 +146,16 @@ export interface Subscription extends ProductCommon {
   freeTrialPeriodAndroid?: string;
 }
 
-interface RequestPurchaseCommon {
-  sku: Sku;
-}
-
-interface RequestPurchaseIOS extends RequestPurchaseCommon {
+export interface RequestPurchase {
+  sku: string;
   andDangerouslyFinishTransactionAutomaticallyIOS: boolean;
   applicationUsername?: string;
-  obfuscatedAccountIdAndroid?: never;
-  obfuscatedProfileIdAndroid?: never;
-  selectedOfferIndex?: never;
-}
-
-interface RequestPurchaseAndroid extends RequestPurchaseCommon {
-  andDangerouslyFinishTransactionAutomaticallyIOS?: never;
-  applicationUsername?: never;
-  obfuscatedAccountIdAndroid?: string;
-  obfuscatedProfileIdAndroid?: string;
+  obfuscatedAccountIdAndroid: string | undefined;
+  obfuscatedProfileIdAndroid: string | undefined;
   selectedOfferIndex: number;
 }
 
-export type RequestPurchase = RequestPurchaseIOS | RequestPurchaseAndroid;
-
-interface RequestSubscriptionIOS extends RequestPurchaseIOS {
-  purchaseTokenAndroid?: never;
-  prorationModeAndroid?: never;
-}
-
-interface RequestSubscriptionAndroid extends RequestPurchaseAndroid {
-  purchaseTokenAndroid?: string;
+export interface RequestSubscription extends RequestPurchase {
+  purchaseTokenAndroid: string | undefined;
   prorationModeAndroid: ProrationModesAndroid;
 }
-
-export type RequestSubscription =
-  | RequestSubscriptionIOS
-  | RequestSubscriptionAndroid;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -152,12 +152,12 @@ export interface RequestPurchase {
   sku: Sku;
   andDangerouslyFinishTransactionAutomaticallyIOS: boolean;
   applicationUsername?: string;
-  obfuscatedAccountIdAndroid: string | undefined;
-  obfuscatedProfileIdAndroid: string | undefined;
+  obfuscatedAccountIdAndroid?: string;
+  obfuscatedProfileIdAndroid?: string;
   selectedOfferIndex: number;
 }
 
 export interface RequestSubscription extends RequestPurchase {
-  purchaseTokenAndroid: string | undefined;
+  purchaseTokenAndroid?: string;
   prorationModeAndroid: ProrationModesAndroid;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+type Sku = string;
+
 export enum IAPErrorCode {
   E_IAP_NOT_AVAILABLE = 'E_IAP_NOT_AVAILABLE',
   E_UNKNOWN = 'E_UNKNOWN',
@@ -147,7 +149,7 @@ export interface Subscription extends ProductCommon {
 }
 
 export interface RequestPurchase {
-  sku: string;
+  sku: Sku;
   andDangerouslyFinishTransactionAutomaticallyIOS: boolean;
   applicationUsername?: string;
   obfuscatedAccountIdAndroid: string | undefined;


### PR DESCRIPTION
This reverts commit 3ac3871.

My changes were crap. We don't care what platform we are passing arguments for, that's internally we determine what to pass to which native methods. So we could pass all android/ios related arguments if we want, doesn't have to be one platform at a time.