### PR TITLE
[iOS] Fix issues related to pending transactions.

### DIFF
--- a/ios/RNIapIos.swift
+++ b/ios/RNIapIos.swift
@@ -955,7 +955,7 @@ class RNIapIos: RCTEventEmitter, SKRequestDelegate, SKPaymentTransactionObserver
   func paymentQueue(_ queue: SKPaymentQueue, removedTransactions transactions: [SKPaymentTransaction]) {
     debugMessage("removedTransactions - countPendingTransactions \(countPendingTransaction)")
 
-    if (countPendingTransaction > 0) {
+    if countPendingTransaction > 0 {
       countPendingTransaction -= transactions.count
 
       if countPendingTransaction <= 0 {

--- a/ios/RNIapIos.swift
+++ b/ios/RNIapIos.swift
@@ -43,7 +43,7 @@ class RNIapIos: RCTEventEmitter, SKRequestDelegate, SKPaymentTransactionObserver
   private var promotedPayment: SKPayment?
   private var promotedProduct: SKProduct?
   private var productsRequest: SKProductsRequest?
-  private var countPendingTransaction: Int?
+  private var countPendingTransaction: Int = 0
 
   override init() {
     promisesByKey = [String: [RNIapIosPromise]]()
@@ -51,7 +51,6 @@ class RNIapIos: RCTEventEmitter, SKRequestDelegate, SKPaymentTransactionObserver
     myQueue = DispatchQueue(label: "reject")
     validProducts = [SKProduct]()
     super.init()
-    SKPaymentQueue.default().add(self)
   }
 
   deinit {
@@ -136,6 +135,7 @@ class RNIapIos: RCTEventEmitter, SKRequestDelegate, SKPaymentTransactionObserver
     _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
     reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
   ) {
+    SKPaymentQueue.default().add(self)
     let canMakePayments = SKPaymentQueue.canMakePayments()
     resolve(NSNumber(value: canMakePayments))
   }
@@ -300,18 +300,19 @@ class RNIapIos: RCTEventEmitter, SKRequestDelegate, SKPaymentTransactionObserver
     _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
     reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
   ) {
-    debugMessage("clear remaining Transactions. Call this before make a new transaction")
-
     let pendingTrans = SKPaymentQueue.default().transactions
-    let countPendingTransaction = pendingTrans.count
+    countPendingTransaction = pendingTrans.count
+
+    debugMessage("clear remaining Transactions (\(countPendingTransaction)). Call this before make a new transaction")
 
     if countPendingTransaction > 0 {
       addPromise(forKey: "cleaningTransactions", resolve: resolve, reject: reject)
       for transaction in pendingTrans {
         SKPaymentQueue.default().finishTransaction(transaction)
       }
+    } else {
+      resolve(nil)
     }
-    resolve(nil)
   }
 
   @objc public func clearProducts(
@@ -936,18 +937,14 @@ class RNIapIos: RCTEventEmitter, SKRequestDelegate, SKPaymentTransactionObserver
   }
 
   func paymentQueue(_ queue: SKPaymentQueue, removedTransactions transactions: [SKPaymentTransaction]) {
-    debugMessage("removedTransactions")
+    debugMessage("removedTransactions - countPendingTransactions \(countPendingTransaction)")
 
-    guard var unwrappedCount = countPendingTransaction else {
-      return
-    }
+    if (countPendingTransaction > 0) {
+      countPendingTransaction -= transactions.count
 
-    if unwrappedCount > 0 {
-      unwrappedCount -= transactions.count
-
-      if unwrappedCount == 0 {
+      if countPendingTransaction <= 0 {
         resolvePromises(forKey: "cleaningTransactions", value: nil)
-        countPendingTransaction = nil
+        countPendingTransaction = 0
       }
     }
   }


### PR DESCRIPTION
There seems to be a problem while converting from objective-c to swift.

In a sandbox account with a lot of payment history, the following problems can be easily reproduced.

# Problems about `clearTransaction`
  * `countPendingTransaction` was not assigned ([Reference: 7.5.6 version](https://github.com/dooboolab/react-native-iap/blob/7.5.6/ios/RNIapIos.m#L264))
  * `resolve(nil)` is executed unconditionally ([Reference: 7.5.6 version](https://github.com/dooboolab/react-native-iap/blob/7.5.6/ios/RNIapIos.m#L273))

# Problem about observer
  * Not added to observer when calling `initConnection` again after calling `endConnection` ([Reference: 7.5.6 version](https://github.com/dooboolab/react-native-iap/blob/7.5.6/ios/RNIapIos.m#L115))
