### PR TITLE
fix: make all types optional for requestPurchase

### DIFF
--- a/IapExample/src/App.tsx
+++ b/IapExample/src/App.tsx
@@ -187,8 +187,7 @@ export class App extends Component<Props, State> {
 
   requestPurchase = async (sku: string) => {
     try {
-      // TODO: wait for https://github.com/dooboolab/react-native-iap/pull/1792 to be merged
-      RNIap.requestPurchase({sku} as any);
+      RNIap.requestPurchase({sku});
     } catch (error) {
       if (error instanceof RNIapPurchaseError) {
         console.warn(error.code, error.message);
@@ -198,8 +197,7 @@ export class App extends Component<Props, State> {
 
   requestSubscription = async (sku: string) => {
     try {
-      // TODO: wait for https://github.com/dooboolab/react-native-iap/pull/1792 to be merged
-      RNIap.requestSubscription({sku} as any);
+      RNIap.requestSubscription({sku});
     } catch (error) {
       if (error instanceof RNIapPurchaseError) {
         Alert.alert(error.message ?? '');

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -150,14 +150,14 @@ export interface Subscription extends ProductCommon {
 
 export interface RequestPurchase {
   sku: Sku;
-  andDangerouslyFinishTransactionAutomaticallyIOS: boolean;
+  andDangerouslyFinishTransactionAutomaticallyIOS?: boolean;
   applicationUsername?: string;
   obfuscatedAccountIdAndroid?: string;
   obfuscatedProfileIdAndroid?: string;
-  selectedOfferIndex: number;
+  selectedOfferIndex?: number;
 }
 
 export interface RequestSubscription extends RequestPurchase {
   purchaseTokenAndroid?: string;
-  prorationModeAndroid: ProrationModesAndroid;
+  prorationModeAndroid?: ProrationModesAndroid;
 }


### PR DESCRIPTION
All theses types are being optional on native side and have either default value or being undefined on TS side

Also, question @andresesfm, we have `requestSubscription` to buy a subscription, wouldn't it make more sense to have `requestProduct` for a product, rather than `requestPurchase`? (could be done on another PR, just a curiosity question)