### PR TITLE
ci: remove example proj on release

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -18,6 +18,9 @@ jobs:
           cache: 'yarn'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Remove example code
+        run: rm -rf IapExample
+
       - name: Install dependencies
         run: yarn install --immutable
 


### PR DESCRIPTION
Bringing up from #1817, remove the example project when releasing the package.

- Closes #1817


Co-authored-by: jeremybarbet <jeremgraph@gmail.com>