### PR TITLE
Removed unnecessary nesting of pricingPhaseList

### DIFF
--- a/IapExample/src/screens/Subscriptions.tsx
+++ b/IapExample/src/screens/Subscriptions.tsx
@@ -69,7 +69,7 @@ export const Subscriptions = () => {
                 // On Google Play Billing V5 you might have  multiple offers for a single sku
                 subscription?.subscriptionOfferDetails?.map((offer) => (
                   <Button
-                    title={`Subscribe ${offer.pricingPhases.pricingPhaseList
+                    title={`Subscribe ${offer.pricingPhases
                       .map((ppl) => ppl.billingPeriod)
                       .join(',')}`}
                     onPress={() => {

--- a/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
@@ -251,7 +251,7 @@ class RNIapModule(
                             }
                             offerDetails.putArray("offerTags", offerTags)
 
-                            val pricingPhasesList = Arguments.createArray()
+                            val pricingPhases = Arguments.createArray()
                             subscriptionOfferDetailsItem.pricingPhases.pricingPhaseList.forEach { pricingPhaseItem ->
                                 val pricingPhase = Arguments.createMap()
                                 pricingPhase.putString(
@@ -273,11 +273,9 @@ class RNIapModule(
                                 )
                                 pricingPhase.putInt("recurrenceMode", pricingPhaseItem.recurrenceMode)
 
-                                pricingPhasesList.pushMap(pricingPhase)
+                                pricingPhases.pushMap(pricingPhase)
                             }
-                            val pricingPhases = Arguments.createMap()
-                            pricingPhases.putArray("pricingPhaseList", pricingPhasesList)
-                            offerDetails.putMap("pricingPhases", pricingPhases)
+                            offerDetails.putArray("pricingPhases", pricingPhases)
                             subscriptionOfferDetails.pushMap(offerDetails)
                         }
                         item.putArray("subscriptionOfferDetails", subscriptionOfferDetails)

--- a/android/src/testPlay/java/com/dooboolab/RNIap/RNIapModuleTest.kt
+++ b/android/src/testPlay/java/com/dooboolab/RNIap/RNIapModuleTest.kt
@@ -225,15 +225,14 @@ class RNIapModuleTest {
                             every { priceCurrencyCode} returns "my code"
                             every {formattedPrice} returns "$20.00"
                             every { priceAmountMicros } returns 20000
-
-                            }
-                        every { subscriptionOfferDetails } returns  listOf( mockk {
+                        }   
+                        every { subscriptionOfferDetails } returns listOf( mockk {
                             every { offerToken } returns "sToken"
-                            every { offerTags  } returns listOf("offerTag1","offerTag2")
-                            every { pricingPhases} returns listOf(mockk{
+                            every { offerTags } returns listOf("offerTag1","offerTag2")
+                            every { pricingPhases } returns listOf( mockk {
                                 every { formattedPrice } returns "$13.0"
                                 every { priceCurrencyCode } returns "USD"
-                                every { billingPeriod } returns "1 week"
+                                every { billingPeriod } returns "P1W"
                                 every { billingCycleCount } returns 1
                                 every { priceAmountMicros } returns 13000
                                 every { recurrenceMode } returns 2

--- a/android/src/testPlay/java/com/dooboolab/RNIap/RNIapModuleTest.kt
+++ b/android/src/testPlay/java/com/dooboolab/RNIap/RNIapModuleTest.kt
@@ -230,16 +230,14 @@ class RNIapModuleTest {
                         every { subscriptionOfferDetails } returns  listOf( mockk {
                             every { offerToken } returns "sToken"
                             every { offerTags  } returns listOf("offerTag1","offerTag2")
-                            every { pricingPhases} returns mockk{
-                                every { pricingPhaseList } returns listOf(mockk{
-                                    every { formattedPrice } returns "$13.0"
-                                    every { priceCurrencyCode } returns "USD"
-                                    every { billingPeriod } returns "1 week"
-                                    every { billingCycleCount } returns 1
-                                    every { priceAmountMicros } returns 13000
-                                    every { recurrenceMode } returns 2
-                                })
-                            }
+                            every { pricingPhases} returns listOf(mockk{
+                                every { formattedPrice } returns "$13.0"
+                                every { priceCurrencyCode } returns "USD"
+                                every { billingPeriod } returns "1 week"
+                                every { billingCycleCount } returns 1
+                                every { priceAmountMicros } returns 13000
+                                every { recurrenceMode } returns 2
+                            })
                         })
                     }
                 )

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -141,7 +141,7 @@ export interface SubscriptionAndroid extends ProductCommon {
         billingCycleCount?: number;
         priceAmountMicros?: string;
         recurrenceMode?: number;
-      };
+      }[];
     };
   }[];
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -135,18 +135,16 @@ export interface SubscriptionAndroid extends ProductCommon {
   subscriptionOfferDetails?: {
     offerToken: string;
     pricingPhases: {
-      pricingPhaseList: {
-        formattedPrice: string;
-        priceCurrencyCode: string;
-        /**
-         * P1W, P1M, P1Y
-         */
-        billingPeriod: string;
-        billingCycleCount: number;
-        priceAmountMicros: string;
-        recurrenceMode: number;
-      }[];
-    };
+      formattedPrice: string;
+      priceCurrencyCode: string;
+      /**
+       * P1W, P1M, P1Y
+       */
+      billingPeriod: string;
+      billingCycleCount: number;
+      priceAmountMicros: string;
+      recurrenceMode: number;
+    }[];
   }[];
 }
 


### PR DESCRIPTION
`pricingPhases` had a single field called `pricingPhasesList` which had the actual phases. I felt this was unnecessary nesting and now `pricingPhases` is a list containing the phases.

Changed 

```
pricingPhases: {
   pricingPhaseList: {
        formattedPrice: string;
        priceCurrencyCode: string;
        /**
         * P1W, P1M, P1Y
         */
        billingPeriod: string;
        billingCycleCount: number;
        priceAmountMicros: string;
        recurrenceMode: number;
   }[];
};
``` 

to

```
pricingPhases: {
      formattedPrice: string;
      priceCurrencyCode: string;
      /**
       * P1W, P1M, P1Y
       */
      billingPeriod: string;
      billingCycleCount: number;
      priceAmountMicros: string;
      recurrenceMode: number;
}[];
```