### PR TITLE
fix: bring back TVOS. It was removed in a recent refactoring

### DIFF
--- a/RNIap.podspec
+++ b/RNIap.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "10.0" }
+  s.platforms    = { :ios => "10.0" , :tvos => "10.0"}
   s.source       = { :git => "https://github.com/dooboolab/react-native-iap.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/*.{h,m,mm,swift}"


### PR DESCRIPTION
Originally added here: https://github.com/dooboolab/react-native-iap/pull/869