### PR TITLE
fix: export modules through destructured import

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import * as iap from './iap';
 
+export * from './iap';
 export * from './types';
 export * from './hooks/useIAP';
 export * from './hooks/withIAPContext';


### PR DESCRIPTION
```ts
import { flushFailedPurchasesCachedAsPendingAndroid } from 'react-native-iap';
```
It wasn't defined anymore and others imports. Related to the refactoring from last week