### PR TITLE
passing empty array instead of undefined

### DIFF
--- a/src/iap.ts
+++ b/src/iap.ts
@@ -311,7 +311,7 @@ export const requestPurchase = ({
           -1,
           obfuscatedAccountIdAndroid,
           obfuscatedProfileIdAndroid,
-          undefined,
+          [],
           isOfferPersonalized ?? false,
         );
       },


### PR DESCRIPTION
Fixes mismatched parameter between Android Native and JS