### PR TITLE
ci: publishing packages dedicated to branches

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -1,13 +1,13 @@
-name: Publish main package
+name: Publish next package
 
 on:
   release:
-    types: [created]
+    types: [prereleased]
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/next'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -24,12 +24,12 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
 
-      - name: Run lint scripts
+      - name: Build typescript
         run: yarn lint:ci
 
       - name: Verify no files have changed after auto-fix
         run: git diff -- ":(exclude)IapExample/*" --exit-code HEAD
 
-      - run: npm publish
+      - run: npm publish --tag next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Thanks to @jeremybarbet on resource https://stackoverflow.com/questions/58139406/only-run-job-on-specific-branch-with-github-actions/58142412#58142412.

Try publishing packages dedicated to branches.