### PR TITLE
refactor!: remove support for default export

### DIFF
--- a/IapExample/__tests__/App-test.js
+++ b/IapExample/__tests__/App-test.js
@@ -1,10 +1,7 @@
-/**
- * @format
- */
-
 import 'react-native';
+
 import React from 'react';
-import App from '../App';
+import {App} from '../App';
 
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';

--- a/IapExample/src/navigators/StackNavigator.tsx
+++ b/IapExample/src/navigators/StackNavigator.tsx
@@ -6,7 +6,7 @@ import {
   ClassSetup,
   Examples,
   Products,
-  PurchaseHistories,
+  PurchaseHistory,
   Subscriptions,
 } from '../screens';
 import {AvailablePurchases} from '../screens/AvailablePurchases';
@@ -28,8 +28,8 @@ export const examples = [
     emoji: '💳',
   },
   {
-    name: 'PurchaseHistories',
-    component: withIAPContext(PurchaseHistories),
+    name: 'PurchaseHistory',
+    component: withIAPContext(PurchaseHistory),
     section: 'Context',
     color: '#c241b3',
     emoji: '📄',
@@ -54,7 +54,7 @@ export type Screens = {
   Examples: undefined;
   Products: undefined;
   Subscriptions: undefined;
-  PurchaseHistories: undefined;
+  PurchaseHistory: undefined;
   AvailablePurchases: undefined;
   Listeners: undefined;
   ClassSetup: undefined;

--- a/IapExample/src/screens/AvailablePurchases.tsx
+++ b/IapExample/src/screens/AvailablePurchases.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {ScrollView, StyleSheet, View} from 'react-native';
-import RNIap, {useIAP} from 'react-native-iap';
+import {useIAP} from 'react-native-iap';
 
 import {Box, Button, Heading, Row, State} from '../components';
 import {contentContainerStyle, errorLog} from '../utils';
@@ -12,11 +12,7 @@ export const AvailablePurchases = () => {
     try {
       await getAvailablePurchases();
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
-        errorLog({message: `[${error.code}]: ${error.message}`, error});
-      } else {
-        errorLog({message: 'handleGetAvailablePurchases', error});
-      }
+      errorLog({message: 'handleGetAvailablePurchases', error});
     }
   };
 

--- a/IapExample/src/screens/ClassSetup.tsx
+++ b/IapExample/src/screens/ClassSetup.tsx
@@ -7,9 +7,24 @@ import {
   Text,
   View,
 } from 'react-native';
-import RNIap, {
+import {
+  clearTransactionIOS,
+  endConnection,
+  finishTransaction,
+  flushFailedPurchasesCachedAsPendingAndroid,
+  getAvailablePurchases,
+  getProducts,
+  getSubscriptions,
+  IapError,
   InAppPurchase,
+  initConnection,
   Product,
+  promotedProductListener,
+  purchaseErrorListener,
+  purchaseUpdatedListener,
+  requestPurchase,
+  requestSubscription,
+  Sku,
   Subscription,
   SubscriptionPurchase,
 } from 'react-native-iap';
@@ -46,10 +61,10 @@ export class ClassSetup extends Component<{}, State> {
 
   async componentDidMount() {
     try {
-      await RNIap.initConnection();
+      await initConnection();
 
       if (isAndroid) {
-        await RNIap.flushFailedPurchasesCachedAsPendingAndroid();
+        await flushFailedPurchasesCachedAsPendingAndroid();
       } else {
         /**
          * WARNING This line should not be included in production code
@@ -60,17 +75,17 @@ export class ClassSetup extends Component<{}, State> {
          * TL;DR you will no longer receive any updates from Apple on
          * every launch for pending purchases
          */
-        await RNIap.clearTransactionIOS();
+        await clearTransactionIOS();
       }
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof IapError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'finishTransaction', error});
       }
     }
 
-    this.purchaseUpdate = RNIap.purchaseUpdatedListener(
+    this.purchaseUpdate = purchaseUpdatedListener(
       async (purchase: InAppPurchase | SubscriptionPurchase) => {
         const receipt = purchase.transactionReceipt
           ? purchase.transactionReceipt
@@ -78,11 +93,11 @@ export class ClassSetup extends Component<{}, State> {
 
         if (receipt) {
           try {
-            const acknowledgeResult = await RNIap.finishTransaction(purchase);
+            const acknowledgeResult = await finishTransaction(purchase);
 
             console.info('acknowledgeResult', acknowledgeResult);
           } catch (error) {
-            if (error instanceof RNIap.IapError) {
+            if (error instanceof IapError) {
               errorLog({message: `[${error.code}]: ${error.message}`, error});
             } else {
               errorLog({message: 'finishTransaction', error});
@@ -94,13 +109,11 @@ export class ClassSetup extends Component<{}, State> {
       },
     );
 
-    this.purchaseError = RNIap.purchaseErrorListener(
-      (error: RNIap.IapError) => {
-        Alert.alert('purchase error', JSON.stringify(error));
-      },
-    );
+    this.purchaseError = purchaseErrorListener((error: IapError) => {
+      Alert.alert('purchase error', JSON.stringify(error));
+    });
 
-    this.promotedProduct = RNIap.promotedProductListener((productId?: string) =>
+    this.promotedProduct = promotedProductListener((productId?: string) =>
       Alert.alert('Product promoted', productId),
     );
   }
@@ -110,7 +123,7 @@ export class ClassSetup extends Component<{}, State> {
     this.purchaseError?.remove();
     this.promotedProduct?.remove();
 
-    RNIap.endConnection();
+    endConnection();
   }
 
   goNext = () => {
@@ -119,11 +132,11 @@ export class ClassSetup extends Component<{}, State> {
 
   getItems = async () => {
     try {
-      const products = await RNIap.getProducts(constants.productSkus);
+      const products = await getProducts(constants.productSkus);
 
       this.setState({productList: products});
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof IapError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'getItems', error});
@@ -133,11 +146,11 @@ export class ClassSetup extends Component<{}, State> {
 
   getSubscriptions = async () => {
     try {
-      const products = await RNIap.getSubscriptions(constants.subscriptionSkus);
+      const products = await getSubscriptions(constants.subscriptionSkus);
 
       this.setState({productList: products});
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof IapError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'getSubscriptions', error});
@@ -147,7 +160,7 @@ export class ClassSetup extends Component<{}, State> {
 
   getAvailablePurchases = async () => {
     try {
-      const purchases = await RNIap.getAvailablePurchases();
+      const purchases = await getAvailablePurchases();
 
       if (purchases?.length > 0) {
         this.setState({
@@ -156,7 +169,7 @@ export class ClassSetup extends Component<{}, State> {
         });
       }
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof IapError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'getAvailablePurchases', error});
@@ -164,11 +177,11 @@ export class ClassSetup extends Component<{}, State> {
     }
   };
 
-  requestPurchase = async (sku: string) => {
+  requestPurchase = async (sku: Sku) => {
     try {
-      RNIap.requestPurchase({sku});
+      requestPurchase({sku});
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof IapError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'requestPurchase', error});
@@ -176,11 +189,11 @@ export class ClassSetup extends Component<{}, State> {
     }
   };
 
-  requestSubscription = async (sku: string) => {
+  requestSubscription = async (sku: Sku) => {
     try {
-      RNIap.requestSubscription({sku});
+      requestSubscription({sku});
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof IapError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'requestSubscription', error});

--- a/IapExample/src/screens/Products.tsx
+++ b/IapExample/src/screens/Products.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {ScrollView, StyleSheet, Text, View} from 'react-native';
-import RNIap, {Sku, useIAP} from 'react-native-iap';
+import {IapError, requestPurchase, Sku, useIAP} from 'react-native-iap';
 
 import {Box, Button, Heading, Row, State} from '../components';
 import {
@@ -22,18 +22,13 @@ export const Products = () => {
     initConnectionError,
     finishTransaction,
     getProducts,
-    requestPurchase,
   } = useIAP();
 
   const handleGetProducts = async () => {
     try {
       await getProducts(constants.productSkus);
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
-        errorLog({message: `[${error.code}]: ${error.message}`, error});
-      } else {
-        errorLog({message: 'handleGetProducts', error});
-      }
+      errorLog({message: 'handleGetProducts', error});
     }
   };
 
@@ -41,7 +36,7 @@ export const Products = () => {
     try {
       await requestPurchase({sku});
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof IapError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'handleBuyProduct', error});
@@ -57,7 +52,7 @@ export const Products = () => {
           setSuccess(true);
         }
       } catch (error) {
-        if (error instanceof RNIap.IapError) {
+        if (error instanceof IapError) {
           errorLog({message: `[${error.code}]: ${error.message}`, error});
         } else {
           errorLog({message: 'handleBuyProduct', error});

--- a/IapExample/src/screens/PurchaseHistory.tsx
+++ b/IapExample/src/screens/PurchaseHistory.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
 import {ScrollView, StyleSheet, View} from 'react-native';
-import RNIap, {useIAP} from 'react-native-iap';
+import {IapError, useIAP} from 'react-native-iap';
 
 import {Box, Button, Heading, Row, State} from '../components';
 import {contentContainerStyle, errorLog} from '../utils';
 
-export const PurchaseHistories = () => {
-  const {connected, purchaseHistories, getPurchaseHistories} = useIAP();
+export const PurchaseHistory = () => {
+  const {connected, purchaseHistory, getPurchaseHistory} = useIAP();
 
-  const handleGetPurchaseHistories = async () => {
+  const handleGetPurchaseHistory = async () => {
     try {
-      await getPurchaseHistories();
+      await getPurchaseHistory();
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof IapError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
-        errorLog({message: 'handleGetPurchaseHistories', error});
+        errorLog({message: 'handleGetPurchaseHistory', error});
       }
     }
   };
@@ -28,23 +28,23 @@ export const PurchaseHistories = () => {
         <View style={styles.container}>
           <Heading copy="Purchase histories" />
 
-          {purchaseHistories.map((purchaseHistory, index) => (
+          {purchaseHistory.map((purchase, index) => (
             <Row
-              key={purchaseHistory.productId}
+              key={purchase.productId}
               fields={[
                 {
                   label: 'Product Id',
-                  value: purchaseHistory.productId,
+                  value: purchase.productId,
                 },
               ]}
-              isLast={purchaseHistories.length - 1 === index}
+              isLast={purchaseHistory.length - 1 === index}
             />
           ))}
         </View>
 
         <Button
           title="Get the purchase histories"
-          onPress={handleGetPurchaseHistories}
+          onPress={handleGetPurchaseHistory}
         />
       </Box>
     </ScrollView>

--- a/IapExample/src/screens/Subscriptions.tsx
+++ b/IapExample/src/screens/Subscriptions.tsx
@@ -1,19 +1,18 @@
 import React from 'react';
 import {Platform, ScrollView, StyleSheet, View} from 'react-native';
-import RNIap, {useIAP} from 'react-native-iap';
+import {IapError, requestSubscription, useIAP} from 'react-native-iap';
 
 import {Box, Button, Heading, Row, State} from '../components';
 import {constants, contentContainerStyle, errorLog} from '../utils';
 
 export const Subscriptions = () => {
-  const {connected, subscriptions, getSubscriptions, requestSubscription} =
-    useIAP();
+  const {connected, subscriptions, getSubscriptions} = useIAP();
 
   const handleGetSubscriptions = async () => {
     try {
       await getSubscriptions(constants.subscriptionSkus);
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof IapError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'handleGetSubscriptions', error});
@@ -38,7 +37,7 @@ export const Subscriptions = () => {
         }),
       });
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof IapError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'handleBuySubscription', error});

--- a/IapExample/src/screens/index.ts
+++ b/IapExample/src/screens/index.ts
@@ -1,5 +1,5 @@
 export * from './ClassSetup';
 export * from './Examples';
 export * from './Products';
-export * from './PurchaseHistories';
+export * from './PurchaseHistory';
 export * from './Subscriptions';

--- a/docs/docs/usage_instructions/connection_lifecycle.md
+++ b/docs/docs/usage_instructions/connection_lifecycle.md
@@ -8,24 +8,30 @@ sidebar_position: 1
 
 In order to initialize the native modules, call `initConnection()` early in the lifecycle of your application. This should be done at a top-level component as the library caches the native connection. Initializing just before you needed is discouraged as it incurrs on a performance hit. Calling this method multiple times without ending the previous connection will result in an error. Not calling this method will cause other method calls to be rejected as connection needs to be established ahead of time.
 
-```ts
-import * as RNIap from 'react-native-iap';
+```tsx
+import React, {Component} from 'react';
+import {initConnection} from 'react-native-iap';
 
-componentDidMount() {
-  RNIap.initConnection();
-  // ...
+class App extends Component {
+  async componentDidMount() {
+    await initConnection();
+  }
+}
 ```
 
 ## Ending Connection
 
 In order to release the resources, call `endConnection()` when you no longer need any interaction with the library.
 
-```ts
-import * as RNIap from 'react-native-iap';
+```tsx
+import React, {Component} from 'react';
+import {endConnection} from 'react-native-iap';
 
-componentWillUnmount() {
-  // ...
-  RNIap.endConnection();
+class App extends Component {
+  componentWillUnmount() {
+    // ...
+    endConnection();
+  }
 }
 ```
 
@@ -35,55 +41,61 @@ You shoud not call `initConnection` and `endConnection` every time you need to i
 
 ### :white_check_mark: DO:
 
-```ts
-import * as RNIap from 'react-native-iap';
+```tsx
+import React, {Component} from 'react';
+import {initConnection, getProducts, endConnection} from 'react-native-iap';
 
-componentDidMount() {
-  await RNIap.initConnection();
-  await RNIap.getProducts(productIds)
-  // ...
-}
+class App extends Component {
+  async componentDidMount() {
+    await initConnection();
+    await getProducts(productIds);
+    // ...
+  }
 
-buyProductButtonClick() {
-  // startPurchaseCode
-}
+  buyProductButtonClick() {
+    // startPurchaseCode
+  }
 
-subscribeButtonClick() {
-  // startPurchaseCode
-}
+  subscribeButtonClick() {
+    // startPurchaseCode
+  }
 
-componentWillUnmount() {
-  // ...
-  RNIap.endConnection();
+  componentWillUnmount() {
+    // ...
+    endConnection();
+  }
 }
 ```
 
 ### :x: DON'T :
 
-```ts
-import * as RNIap from 'react-native-iap';
+```tsx
+import React, {Component} from 'react';
+import {initConnection, getProducts, endConnection} from 'react-native-iap';
 
-componentDidMount() {
-  // ...
-}
+class App extends Component {
+  componentDidMount() {
+    // ...
+  }
 
-const buyProductButtonClick = async() => {
-  await RNIap.initConnection();
-  await RNIap.getProducts(productIds)
-  // Purchase IAP Code
-  // ...
-  await RNIap.endConnection();
-}
+  buyProductButtonClick = async () => {
+    await initConnection();
+    await getProducts(productIds);
+    // Purchase IAP Code
+    // ...
+    await endConnection();
+  };
 
-const subscribeButtonClick = async() => {
-  await RNIap.initConnection();
-  await RNIap.getProducts(productIds)
-  // Purchase Subscription Code
-  // ...
-  await RNIap.endConnection();
-}
+  subscribeButtonClick = async () => {
+    await initConnection();
+    await getProducts(productIds);
+    // Purchase Subscription Code
+    // ...
+    await endConnection();
+  };
 
-componentWillUnmount() {
-  // ...
+  componentWillUnmount() {
+    // ...
+  }
 }
 ```

--- a/docs/docs/usage_instructions/purchase.md
+++ b/docs/docs/usage_instructions/purchase.md
@@ -20,23 +20,25 @@ Once you have called `getProducts()`, and have a valid response, you can call `r
 
 Before you request any purchase, you should set `purchaseUpdatedListener` from `react-native-iap`. It is recommended that you start listening to updates as soon as your application launches. And don't forget that even at launch you may receive successful purchases that either completed while your app was closed or that failed to be finished, consumed or acknowledged due to network errors or bugs.
 
-```ts
-import RNIap, {
+```tsx
+import {
+  initConnection,
   purchaseErrorListener,
   purchaseUpdatedListener,
   type ProductPurchase,
   type PurchaseError,
+  flushFailedPurchasesCachedAsPendingAndroid,
 } from 'react-native-iap';
 
-class RootComponent extends Component<*> {
+class App extends Component {
   purchaseUpdateSubscription = null;
   purchaseErrorSubscription = null;
 
   componentDidMount() {
-    RNIap.initConnection().then(() => {
+    initConnection().then(() => {
       // we make sure that "ghost" pending payment are removed
       // (ghost = failed pending payment that are still marked as pending in Google's native Vending module cache)
-      RNIap.flushFailedPurchasesCachedAsPendingAndroid()
+      flushFailedPurchasesCachedAsPendingAndroid()
         .catch(() => {
           // exception can happen here if:
           // - there are pending purchases that are still pending (we can't consume a pending purchase)
@@ -61,13 +63,13 @@ class RootComponent extends Component<*> {
                       // the purchase event will reappear on every relaunch of the app until you succeed
                       // in doing the below. It will also be impossible for the user to purchase consumables
                       // again until you do this.
-                      await RNIap.finishTransaction(purchase);
+                      await finishTransaction(purchase);
 
                       // From react-native-iap@4.1.0 you can simplify above `method`. Try to wrap the statement with `try` and `catch` to also grab the `error` message.
                       // If consumable (can be purchased again)
-                      await RNIap.finishTransaction(purchase, true);
+                      await finishTransaction(purchase, true);
                       // If not consumable
-                      await RNIap.finishTransaction(purchase, false);
+                      await finishTransaction(purchase, false);
                     } else {
                       // Retry / conclude the purchase is fraudulent, etc...
                     }
@@ -90,6 +92,7 @@ class RootComponent extends Component<*> {
       this.purchaseUpdateSubscription.remove();
       this.purchaseUpdateSubscription = null;
     }
+
     if (this.purchaseErrorSubscription) {
       this.purchaseErrorSubscription.remove();
       this.purchaseErrorSubscription = null;
@@ -100,25 +103,30 @@ class RootComponent extends Component<*> {
 
 Then define the method like below and call it when user press the button.
 
-```ts
+```tsx
+class App extends Component {
   requestPurchase = async (sku: string) => {
     try {
-      await RNIap.requestPurchase({
+      await requestPurchase({
         sku,
         andDangerouslyFinishTransactionAutomaticallyIOS: false,
       });
     } catch (err) {
       console.warn(err.code, err.message);
     }
-  }
+  };
 
   requestSubscription = async (sku: string, offerToken: string?) => {
     try {
-      await RNIap.requestSubscription({ sku }, ...(offerToken && {subscriptionOfffers:{sku,offerToken}}));
+      await requestSubscription(
+        {sku},
+        ...(offerToken && {subscriptionOfffers: {sku, offerToken}}),
+      );
     } catch (err) {
       console.warn(err.code, err.message);
     }
-  }
+  };
+
   /**
    * For one-time products
    */
@@ -127,26 +135,34 @@ Then define the method like below and call it when user press the button.
       <Pressable onPress={() => this.requestPurchase(product.productId)}>
         {/* ... */}
       </Pressable>
-    )
+    );
   }
+
   /**
    * For subscriptions products
    */
   render() {
-    if(Platform.OS =='android'){
-      return product.subscriptionOfferDetails.map((offer) =>
-        <Pressable onPress={() => this.requestSubscription(product.productId, offer.offerToken)}>
+    if (Platform.OS == 'android') {
+      return product.subscriptionOfferDetails.map((offer) => (
+        <Pressable
+          onPress={() =>
+            this.requestSubscription(product.productId, offer.offerToken)
+          }
+        >
           {/* ... */}
         </Pressable>
-        )
-    }else{
+      ));
+    } else {
       return (
-        <Pressable onPress={() => this.requestSubscription(product.productId, null)}>
+        <Pressable
+          onPress={() => this.requestSubscription(product.productId, null)}
+        >
           {/* ... */}
         </Pressable>
-        )
+      );
     }
   }
+}
 ```
 
 ## New Purchase Flow

--- a/src/hooks/useIAP.ts
+++ b/src/hooks/useIAP.ts
@@ -4,10 +4,8 @@ import {
   finishTransaction as iapFinishTransaction,
   getAvailablePurchases as iapGetAvailablePurchases,
   getProducts as iapGetProducts,
-  getPurchaseHistory,
+  getPurchaseHistory as iapGetPurchaseHistory,
   getSubscriptions as iapGetSubscriptions,
-  requestPurchase as iapRequestPurchase,
-  requestSubscription as iapRequestSubscription,
 } from '../iap';
 import type {Product, Purchase, PurchaseError, Subscription} from '../types';
 
@@ -18,7 +16,7 @@ type IAP_STATUS = {
   products: Product[];
   promotedProductsIOS: Product[];
   subscriptions: Subscription[];
-  purchaseHistories: Purchase[];
+  purchaseHistory: Purchase[];
   availablePurchases: Purchase[];
   currentPurchase?: Purchase;
   currentPurchaseError?: PurchaseError;
@@ -29,11 +27,9 @@ type IAP_STATUS = {
     developerPayloadAndroid?: string,
   ) => Promise<string | void>;
   getAvailablePurchases: () => Promise<void>;
-  getPurchaseHistories: () => Promise<void>;
+  getPurchaseHistory: () => Promise<void>;
   getProducts: (skus: string[]) => Promise<void>;
   getSubscriptions: (skus: string[]) => Promise<void>;
-  requestPurchase: typeof iapRequestPurchase;
-  requestSubscription: typeof iapRequestSubscription;
 };
 
 export function useIAP(): IAP_STATUS {
@@ -42,7 +38,7 @@ export function useIAP(): IAP_STATUS {
     products,
     promotedProductsIOS,
     subscriptions,
-    purchaseHistories,
+    purchaseHistory,
     availablePurchases,
     currentPurchase,
     currentPurchaseError,
@@ -50,7 +46,7 @@ export function useIAP(): IAP_STATUS {
     setProducts,
     setSubscriptions,
     setAvailablePurchases,
-    setPurchaseHistories,
+    setPurchaseHistory,
     setCurrentPurchase,
     setCurrentPurchaseError,
   } = useIAPContext();
@@ -73,9 +69,9 @@ export function useIAP(): IAP_STATUS {
     setAvailablePurchases(await iapGetAvailablePurchases());
   }, [setAvailablePurchases]);
 
-  const getPurchaseHistories = useCallback(async (): Promise<void> => {
-    setPurchaseHistories(await getPurchaseHistory());
-  }, [setPurchaseHistories]);
+  const getPurchaseHistory = useCallback(async (): Promise<void> => {
+    setPurchaseHistory(await iapGetPurchaseHistory());
+  }, [setPurchaseHistory]);
 
   const finishTransaction = useCallback(
     async (
@@ -114,7 +110,7 @@ export function useIAP(): IAP_STATUS {
     products,
     promotedProductsIOS,
     subscriptions,
-    purchaseHistories,
+    purchaseHistory,
     availablePurchases,
     currentPurchase,
     currentPurchaseError,
@@ -123,8 +119,6 @@ export function useIAP(): IAP_STATUS {
     getProducts,
     getSubscriptions,
     getAvailablePurchases,
-    getPurchaseHistories,
-    requestPurchase: iapRequestPurchase,
-    requestSubscription: iapRequestSubscription,
+    getPurchaseHistory,
   };
 }

--- a/src/hooks/withIAPContext.tsx
+++ b/src/hooks/withIAPContext.tsx
@@ -21,14 +21,14 @@ type IAPContextType = {
   products: Product[];
   promotedProductsIOS: Product[];
   subscriptions: Subscription[];
-  purchaseHistories: Purchase[];
+  purchaseHistory: Purchase[];
   availablePurchases: Purchase[];
   currentPurchase?: Purchase;
   currentPurchaseError?: PurchaseError;
   initConnectionError?: Error;
   setProducts: (products: Product[]) => void;
   setSubscriptions: (subscriptions: Subscription[]) => void;
-  setPurchaseHistories: (purchaseHistories: Purchase[]) => void;
+  setPurchaseHistory: (purchaseHistory: Purchase[]) => void;
   setAvailablePurchases: (availablePurchases: Purchase[]) => void;
   setCurrentPurchase: (currentPurchase: Purchase | undefined) => void;
   setCurrentPurchaseError: (
@@ -58,7 +58,7 @@ export function withIAPContext<T>(Component: React.ComponentType<T>) {
       [],
     );
     const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
-    const [purchaseHistories, setPurchaseHistories] = useState<Purchase[]>([]);
+    const [purchaseHistory, setPurchaseHistory] = useState<Purchase[]>([]);
 
     const [availablePurchases, setAvailablePurchases] = useState<Purchase[]>(
       [],
@@ -76,14 +76,14 @@ export function withIAPContext<T>(Component: React.ComponentType<T>) {
         products,
         subscriptions,
         promotedProductsIOS,
-        purchaseHistories,
+        purchaseHistory,
         availablePurchases,
         currentPurchase,
         currentPurchaseError,
         initConnectionError,
         setProducts,
         setSubscriptions,
-        setPurchaseHistories,
+        setPurchaseHistory,
         setAvailablePurchases,
         setCurrentPurchase,
         setCurrentPurchaseError,
@@ -93,14 +93,14 @@ export function withIAPContext<T>(Component: React.ComponentType<T>) {
         products,
         subscriptions,
         promotedProductsIOS,
-        purchaseHistories,
+        purchaseHistory,
         availablePurchases,
         currentPurchase,
         currentPurchaseError,
         initConnectionError,
         setProducts,
         setSubscriptions,
-        setPurchaseHistories,
+        setPurchaseHistory,
         setAvailablePurchases,
         setCurrentPurchase,
         setCurrentPurchaseError,

--- a/src/iap.ts
+++ b/src/iap.ts
@@ -19,6 +19,7 @@ import type {
   PurchaseResult,
   RequestPurchase,
   RequestSubscription,
+  Sku,
   Subscription,
   SubscriptionPurchase,
 } from './types';
@@ -387,7 +388,7 @@ export const requestSubscription = ({
  * @returns {Promise<void>}
  */
 export const requestPurchaseWithQuantityIOS = (
-  sku: string,
+  sku: Sku,
   quantity: number,
 ): Promise<InAppPurchase> =>
   getIosModule().buyProductWithQuantityIOS(sku, quantity);
@@ -477,7 +478,7 @@ export const acknowledgePurchaseAndroid = (
  * @returns {Promise<void>}
  */
 export const deepLinkToSubscriptionsAndroid = async (
-  sku: string,
+  sku: Sku,
 ): Promise<void> => {
   checkNativeAndroidAvailable();
 
@@ -562,7 +563,7 @@ const requestAgnosticReceiptValidationIos = async (
  * @returns {Promise<void>}
  */
 export const requestPurchaseWithOfferIOS = (
-  sku: string,
+  sku: Sku,
   forUser: string,
   withOffer: Apple.PaymentDiscount,
 ): Promise<void> => getIosModule().buyProductWithOffer(sku, forUser, withOffer);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,4 @@
-import * as iap from './iap';
-
 export * from './iap';
 export * from './types';
 export * from './hooks/useIAP';
 export * from './hooks/withIAPContext';
-
-export default iap;


### PR DESCRIPTION
I'm getting a bit lost on my main [PR](https://github.com/dooboolab/react-native-iap/pull/1797), so I will split everything up, should be easier 

## Breaking changes:
- You can't use default export to access method, you need to import it from the object `import RNIap from 'react-native-iap';` -> `import {getProducts} from 'react-native-iap';`
- The hook no longer export `requestPurchase` and `requestSubscription`, they should be import directly from `import { requestPurchase } from 'react-native-iap';`
- `purchaseHistories` and `setPurchaseHistories` has been renamed to `purchaseHistory` and `setPurchaseHistory` to match the original methods