### PR TITLE
refactor!: create a PurchaseError class

### DIFF
--- a/IapExample/src/screens/AvailablePurchases.tsx
+++ b/IapExample/src/screens/AvailablePurchases.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {ScrollView, StyleSheet, View} from 'react-native';
-import RNIap, {useIAP} from 'react-native-iap';
+import {PurchaseError, useIAP} from 'react-native-iap';
 
 import {Box, Button, Heading, Row, State} from '../components';
 import {contentContainerStyle, errorLog} from '../utils';
@@ -12,7 +12,7 @@ export const AvailablePurchases = () => {
     try {
       await getAvailablePurchases();
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof PurchaseError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'handleGetAvailablePurchases', error});

--- a/IapExample/src/screens/ClassSetup.tsx
+++ b/IapExample/src/screens/ClassSetup.tsx
@@ -10,6 +10,7 @@ import {
 import RNIap, {
   InAppPurchase,
   Product,
+  PurchaseError,
   Subscription,
   SubscriptionPurchase,
 } from 'react-native-iap';
@@ -63,7 +64,7 @@ export class ClassSetup extends Component<{}, State> {
         await RNIap.clearTransactionIOS();
       }
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof PurchaseError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'finishTransaction', error});
@@ -82,7 +83,7 @@ export class ClassSetup extends Component<{}, State> {
 
             console.info('acknowledgeResult', acknowledgeResult);
           } catch (error) {
-            if (error instanceof RNIap.IapError) {
+            if (error instanceof PurchaseError) {
               errorLog({message: `[${error.code}]: ${error.message}`, error});
             } else {
               errorLog({message: 'finishTransaction', error});
@@ -94,11 +95,9 @@ export class ClassSetup extends Component<{}, State> {
       },
     );
 
-    this.purchaseError = RNIap.purchaseErrorListener(
-      (error: RNIap.IapError) => {
-        Alert.alert('purchase error', JSON.stringify(error));
-      },
-    );
+    this.purchaseError = RNIap.purchaseErrorListener((error: PurchaseError) => {
+      Alert.alert('purchase error', JSON.stringify(error));
+    });
 
     this.promotedProduct = RNIap.promotedProductListener((productId?: string) =>
       Alert.alert('Product promoted', productId),
@@ -123,7 +122,7 @@ export class ClassSetup extends Component<{}, State> {
 
       this.setState({productList: products});
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof PurchaseError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'getItems', error});
@@ -137,7 +136,7 @@ export class ClassSetup extends Component<{}, State> {
 
       this.setState({productList: products});
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof PurchaseError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'getSubscriptions', error});
@@ -156,7 +155,7 @@ export class ClassSetup extends Component<{}, State> {
         });
       }
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof PurchaseError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'getAvailablePurchases', error});
@@ -168,7 +167,7 @@ export class ClassSetup extends Component<{}, State> {
     try {
       RNIap.requestPurchase({sku});
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof PurchaseError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'requestPurchase', error});
@@ -180,7 +179,7 @@ export class ClassSetup extends Component<{}, State> {
     try {
       RNIap.requestSubscription({sku});
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof PurchaseError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'requestSubscription', error});

--- a/IapExample/src/screens/Products.tsx
+++ b/IapExample/src/screens/Products.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {ScrollView, StyleSheet, Text, View} from 'react-native';
-import RNIap, {Sku, useIAP} from 'react-native-iap';
+import {PurchaseError, Sku, useIAP} from 'react-native-iap';
 
 import {Box, Button, Heading, Row, State} from '../components';
 import {
@@ -29,7 +29,7 @@ export const Products = () => {
     try {
       await getProducts(constants.productSkus);
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof PurchaseError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'handleGetProducts', error});
@@ -41,7 +41,7 @@ export const Products = () => {
     try {
       await requestPurchase({sku});
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof PurchaseError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'handleBuyProduct', error});
@@ -57,7 +57,7 @@ export const Products = () => {
           setSuccess(true);
         }
       } catch (error) {
-        if (error instanceof RNIap.IapError) {
+        if (error instanceof PurchaseError) {
           errorLog({message: `[${error.code}]: ${error.message}`, error});
         } else {
           errorLog({message: 'handleBuyProduct', error});

--- a/IapExample/src/screens/PurchaseHistories.tsx
+++ b/IapExample/src/screens/PurchaseHistories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {ScrollView, StyleSheet, View} from 'react-native';
-import RNIap, {useIAP} from 'react-native-iap';
+import {PurchaseError, useIAP} from 'react-native-iap';
 
 import {Box, Button, Heading, Row, State} from '../components';
 import {contentContainerStyle, errorLog} from '../utils';
@@ -12,7 +12,7 @@ export const PurchaseHistories = () => {
     try {
       await getPurchaseHistories();
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof PurchaseError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'handleGetPurchaseHistories', error});

--- a/IapExample/src/screens/Subscriptions.tsx
+++ b/IapExample/src/screens/Subscriptions.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Platform, ScrollView, StyleSheet, View} from 'react-native';
-import RNIap, {useIAP} from 'react-native-iap';
+import {PurchaseError, useIAP} from 'react-native-iap';
 
 import {Box, Button, Heading, Row, State} from '../components';
 import {constants, contentContainerStyle, errorLog} from '../utils';
@@ -13,7 +13,7 @@ export const Subscriptions = () => {
     try {
       await getSubscriptions(constants.subscriptionSkus);
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof PurchaseError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'handleGetSubscriptions', error});
@@ -38,7 +38,7 @@ export const Subscriptions = () => {
         }),
       });
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof PurchaseError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'handleBuySubscription', error});

--- a/src/hooks/useIAP.ts
+++ b/src/hooks/useIAP.ts
@@ -9,7 +9,8 @@ import {
   requestPurchase as iapRequestPurchase,
   requestSubscription as iapRequestSubscription,
 } from '../iap';
-import type {Product, Purchase, PurchaseError, Subscription} from '../types';
+import type {PurchaseError} from '../purchaseError';
+import type {Product, Purchase, Subscription} from '../types';
 
 import {useIAPContext} from './withIAPContext';
 

--- a/src/hooks/withIAPContext.tsx
+++ b/src/hooks/withIAPContext.tsx
@@ -7,11 +7,11 @@ import {
   purchaseErrorListener,
   purchaseUpdatedListener,
 } from '../iap';
+import type {PurchaseError} from '../purchaseError';
 import type {
   InAppPurchase,
   Product,
   Purchase,
-  PurchaseError,
   Subscription,
   SubscriptionPurchase,
 } from '../types';

--- a/src/iap.ts
+++ b/src/iap.ts
@@ -10,23 +10,19 @@ import type * as Amazon from './types/amazon';
 import type * as Android from './types/android';
 import type * as Apple from './types/apple';
 import {ReceiptValidationStatus} from './types/apple';
+import type {PurchaseError} from './purchaseError';
 import type {
   InAppPurchase,
   Product,
   ProductCommon,
   ProductPurchase,
-  PurchaseError,
   PurchaseResult,
   RequestPurchase,
   RequestSubscription,
   Subscription,
   SubscriptionPurchase,
 } from './types';
-import {
-  IAPErrorCode,
-  InstallSourceAndroid,
-  PurchaseStateAndroid,
-} from './types';
+import {InstallSourceAndroid, PurchaseStateAndroid} from './types';
 
 const {RNIapIos, RNIapModule, RNIapAmazonModule} = NativeModules;
 const isAndroid = Platform.OS === 'android';
@@ -34,13 +30,6 @@ const isAmazon = isAndroid && !!RNIapAmazonModule;
 const isIos = Platform.OS === 'ios';
 const ANDROID_ITEM_TYPE_SUBSCRIPTION = 'subs';
 const ANDROID_ITEM_TYPE_IAP = 'inapp';
-
-export class IapError implements PurchaseError {
-  constructor(public code?: string, public message?: string) {
-    this.code = code;
-    this.message = message;
-  }
-}
 
 export const getInstallSourceAndroid = (): InstallSourceAndroid => {
   return RNIapModule
@@ -58,7 +47,7 @@ export const setAndroidNativeModule = (
 
 const checkNativeAndroidAvailable = (): void => {
   if (!RNIapModule && !RNIapAmazonModule) {
-    throw new Error(IAPErrorCode.E_IAP_NOT_AVAILABLE);
+    throw new Error('IAP_NOT_AVAILABLE');
   }
 };
 
@@ -74,7 +63,7 @@ const getAndroidModule = (): typeof RNIapModule | typeof RNIapAmazonModule => {
 
 const checkNativeIOSAvailable = (): void => {
   if (!RNIapIos) {
-    throw new Error(IAPErrorCode.E_IAP_NOT_AVAILABLE);
+    throw new Error('IAP_NOT_AVAILABLE');
   }
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,6 @@ export * from './iap';
 export * from './types';
 export * from './hooks/useIAP';
 export * from './hooks/withIAPContext';
+export * from './purchaseError';
 
 export default iap;

--- a/src/purchaseError.ts
+++ b/src/purchaseError.ts
@@ -1,0 +1,35 @@
+export enum ErrorCode {
+  E_UNKNOWN = 'E_UNKNOWN',
+  E_USER_CANCELLED = 'E_USER_CANCELLED',
+  E_USER_ERROR = 'E_USER_ERROR',
+  E_ITEM_UNAVAILABLE = 'E_ITEM_UNAVAILABLE',
+  E_REMOTE_ERROR = 'E_REMOTE_ERROR',
+  E_NETWORK_ERROR = 'E_NETWORK_ERROR',
+  E_SERVICE_ERROR = 'E_SERVICE_ERROR',
+  E_RECEIPT_FAILED = 'E_RECEIPT_FAILED',
+  E_RECEIPT_FINISHED_FAILED = 'E_RECEIPT_FINISHED_FAILED',
+  E_NOT_PREPARED = 'E_NOT_PREPARED',
+  E_NOT_ENDED = 'E_NOT_ENDED',
+  E_ALREADY_OWNED = 'E_ALREADY_OWNED',
+  E_DEVELOPER_ERROR = 'E_DEVELOPER_ERROR',
+  E_BILLING_RESPONSE_JSON_PARSE_ERROR = 'E_BILLING_RESPONSE_JSON_PARSE_ERROR',
+  E_DEFERRED_PAYMENT = 'E_DEFERRED_PAYMENT',
+}
+
+export class PurchaseError implements Error {
+  constructor(
+    public name: string,
+    public message: string,
+    public responseCode?: number,
+    public debugMessage?: string,
+    public code?: ErrorCode,
+    public productId?: string,
+  ) {
+    this.name = '[react-native-iap]: PurchaseError';
+    this.message = message;
+    this.responseCode = responseCode;
+    this.debugMessage = debugMessage;
+    this.code = code;
+    this.productId = productId;
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,24 +1,5 @@
 export type Sku = string;
 
-export enum IAPErrorCode {
-  E_IAP_NOT_AVAILABLE = 'E_IAP_NOT_AVAILABLE',
-  E_UNKNOWN = 'E_UNKNOWN',
-  E_USER_CANCELLED = 'E_USER_CANCELLED',
-  E_USER_ERROR = 'E_USER_ERROR',
-  E_ITEM_UNAVAILABLE = 'E_ITEM_UNAVAILABLE',
-  E_REMOTE_ERROR = 'E_REMOTE_ERROR',
-  E_NETWORK_ERROR = 'E_NETWORK_ERROR',
-  E_SERVICE_ERROR = 'E_SERVICE_ERROR',
-  E_RECEIPT_FAILED = 'E_RECEIPT_FAILED',
-  E_RECEIPT_FINISHED_FAILED = 'E_RECEIPT_FINISHED_FAILED',
-  E_NOT_PREPARED = 'E_NOT_PREPARED',
-  E_NOT_ENDED = 'E_NOT_ENDED',
-  E_ALREADY_OWNED = 'E_ALREADY_OWNED',
-  E_DEVELOPER_ERROR = 'E_DEVELOPER_ERROR',
-  E_BILLING_RESPONSE_JSON_PARSE_ERROR = 'E_BILLING_RESPONSE_JSON_PARSE_ERROR',
-  E_DEFERRED_PAYMENT = 'E_DEFERRED_PAYMENT',
-}
-
 export enum ProrationModesAndroid {
   IMMEDIATE_WITH_TIME_PRORATION = 1,
   IMMEDIATE_AND_CHARGE_PRORATED_PRICE = 2,
@@ -86,14 +67,6 @@ export interface PurchaseResult {
   debugMessage?: string;
   code?: string;
   message?: string;
-}
-
-export interface PurchaseError {
-  responseCode?: number;
-  debugMessage?: string;
-  code?: string;
-  message?: string;
-  productId?: string;
 }
 
 export type InAppPurchase = ProductPurchase;


### PR DESCRIPTION
## Breaking changes
- `IapError` has been renamed to `PurchaseError` and is now extending an Error class. It can be used as follow:
```tsx
try {
  requestPurchase(...)
} catch (error) {
  if (error instance PurchaseError) {
    // error.code, error.message, error.productId, error.debugMessage
  }
}
```