### PR TITLE
refactor!: make all methods take an object of params

### DIFF
--- a/IapExample/src/screens/ClassSetup.tsx
+++ b/IapExample/src/screens/ClassSetup.tsx
@@ -15,9 +15,9 @@ import {
   getAvailablePurchases,
   getProducts,
   getSubscriptions,
-  InAppPurchase,
   initConnection,
   Product,
+  ProductPurchase,
   promotedProductListener,
   PurchaseError,
   purchaseErrorListener,
@@ -86,14 +86,14 @@ export class ClassSetup extends Component<{}, State> {
     }
 
     this.purchaseUpdate = purchaseUpdatedListener(
-      async (purchase: InAppPurchase | SubscriptionPurchase) => {
+      async (purchase: ProductPurchase | SubscriptionPurchase) => {
         const receipt = purchase.transactionReceipt
           ? purchase.transactionReceipt
           : (purchase as unknown as {originalJson: string}).originalJson;
 
         if (receipt) {
           try {
-            const acknowledgeResult = await finishTransaction(purchase);
+            const acknowledgeResult = await finishTransaction({purchase});
 
             console.info('acknowledgeResult', acknowledgeResult);
           } catch (error) {
@@ -128,7 +128,7 @@ export class ClassSetup extends Component<{}, State> {
 
   getItems = async () => {
     try {
-      const products = await getProducts(constants.productSkus);
+      const products = await getProducts({skus: constants.productSkus});
 
       this.setState({productList: products});
     } catch (error) {
@@ -138,7 +138,9 @@ export class ClassSetup extends Component<{}, State> {
 
   getSubscriptions = async () => {
     try {
-      const products = await getSubscriptions(constants.subscriptionSkus);
+      const products = await getSubscriptions({
+        skus: constants.subscriptionSkus,
+      });
 
       this.setState({productList: products});
     } catch (error) {
@@ -163,7 +165,7 @@ export class ClassSetup extends Component<{}, State> {
 
   requestPurchase = async (sku: Sku) => {
     try {
-      requestPurchase({sku});
+      requestPurchase({skus: [sku]});
     } catch (error) {
       if (error instanceof PurchaseError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});

--- a/IapExample/src/screens/ClassSetup.tsx
+++ b/IapExample/src/screens/ClassSetup.tsx
@@ -165,7 +165,7 @@ export class ClassSetup extends Component<{}, State> {
 
   requestPurchase = async (sku: Sku) => {
     try {
-      requestPurchase({skus: [sku]});
+      requestPurchase({sku});
     } catch (error) {
       if (error instanceof PurchaseError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});

--- a/IapExample/src/screens/Products.tsx
+++ b/IapExample/src/screens/Products.tsx
@@ -26,7 +26,7 @@ export const Products = () => {
 
   const handleGetProducts = async () => {
     try {
-      await getProducts(constants.productSkus);
+      await getProducts({skus: constants.productSkus});
     } catch (error) {
       errorLog({message: 'handleGetProducts', error});
     }
@@ -34,7 +34,7 @@ export const Products = () => {
 
   const handleBuyProduct = async (sku: Sku) => {
     try {
-      await requestPurchase({sku});
+      await requestPurchase({skus: [sku]});
     } catch (error) {
       if (error instanceof PurchaseError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
@@ -48,7 +48,11 @@ export const Products = () => {
     const checkCurrentPurchase = async () => {
       try {
         if (currentPurchase?.transactionReceipt) {
-          await finishTransaction(currentPurchase, true);
+          await finishTransaction({
+            purchase: currentPurchase,
+            isConsumable: true,
+          });
+
           setSuccess(true);
         }
       } catch (error) {

--- a/IapExample/src/screens/Products.tsx
+++ b/IapExample/src/screens/Products.tsx
@@ -34,7 +34,7 @@ export const Products = () => {
 
   const handleBuyProduct = async (sku: Sku) => {
     try {
-      await requestPurchase({skus: [sku]});
+      await requestPurchase({sku});
     } catch (error) {
       if (error instanceof PurchaseError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});

--- a/IapExample/src/screens/Subscriptions.tsx
+++ b/IapExample/src/screens/Subscriptions.tsx
@@ -10,7 +10,7 @@ export const Subscriptions = () => {
 
   const handleGetSubscriptions = async () => {
     try {
-      await getSubscriptions(constants.subscriptionSkus);
+      await getSubscriptions({skus: constants.subscriptionSkus});
     } catch (error) {
       errorLog({message: 'handleGetSubscriptions', error});
     }

--- a/src/hooks/useIAP.ts
+++ b/src/hooks/useIAP.ts
@@ -22,15 +22,19 @@ type IAP_STATUS = {
   currentPurchase?: Purchase;
   currentPurchaseError?: PurchaseError;
   initConnectionError?: Error;
-  finishTransaction: (
-    purchase: Purchase,
-    isConsumable?: boolean,
-    developerPayloadAndroid?: string,
-  ) => Promise<string | void>;
+  finishTransaction: ({
+    purchase,
+    isConsumable,
+    developerPayloadAndroid,
+  }: {
+    purchase: Purchase;
+    isConsumable?: boolean;
+    developerPayloadAndroid?: string;
+  }) => Promise<string | void>;
   getAvailablePurchases: () => Promise<void>;
   getPurchaseHistory: () => Promise<void>;
-  getProducts: (skus: string[]) => Promise<void>;
-  getSubscriptions: (skus: string[]) => Promise<void>;
+  getProducts: ({skus}: {skus: string[]}) => Promise<void>;
+  getSubscriptions: ({skus}: {skus: string[]}) => Promise<void>;
 };
 
 export function useIAP(): IAP_STATUS {
@@ -53,15 +57,15 @@ export function useIAP(): IAP_STATUS {
   } = useIAPContext();
 
   const getProducts = useCallback(
-    async (skus: string[]): Promise<void> => {
-      setProducts(await iapGetProducts(skus));
+    async ({skus}: {skus: string[]}): Promise<void> => {
+      setProducts(await iapGetProducts({skus}));
     },
     [setProducts],
   );
 
   const getSubscriptions = useCallback(
-    async (skus: string[]): Promise<void> => {
-      setSubscriptions(await iapGetSubscriptions(skus));
+    async ({skus}: {skus: string[]}): Promise<void> => {
+      setSubscriptions(await iapGetSubscriptions({skus}));
     },
     [setSubscriptions],
   );
@@ -75,17 +79,21 @@ export function useIAP(): IAP_STATUS {
   }, [setPurchaseHistory]);
 
   const finishTransaction = useCallback(
-    async (
-      purchase: Purchase,
-      isConsumable?: boolean,
-      developerPayloadAndroid?: string,
-    ): Promise<string | void> => {
+    async ({
+      purchase,
+      isConsumable,
+      developerPayloadAndroid,
+    }: {
+      purchase: Purchase;
+      isConsumable?: boolean;
+      developerPayloadAndroid?: string;
+    }): Promise<string | void> => {
       try {
-        return await iapFinishTransaction(
+        return await iapFinishTransaction({
           purchase,
           isConsumable,
           developerPayloadAndroid,
-        );
+        });
       } catch (err) {
         throw err;
       } finally {

--- a/src/hooks/withIAPContext.tsx
+++ b/src/hooks/withIAPContext.tsx
@@ -8,8 +8,8 @@ import {
 import {getPromotedProductIOS, initConnection} from '../iap';
 import type {PurchaseError} from '../purchaseError';
 import type {
-  InAppPurchase,
   Product,
+  ProductPurchase,
   Purchase,
   Subscription,
   SubscriptionPurchase,
@@ -121,7 +121,7 @@ export function withIAPContext<T>(Component: React.ComponentType<T>) {
       }
 
       const purchaseUpdateSubscription = purchaseUpdatedListener(
-        async (purchase: InAppPurchase | SubscriptionPurchase) => {
+        async (purchase: ProductPurchase | SubscriptionPurchase) => {
           setCurrentPurchaseError(undefined);
           setCurrentPurchase(purchase);
         },

--- a/src/iap.ts
+++ b/src/iap.ts
@@ -234,20 +234,21 @@ export const getAvailablePurchases = (): Promise<
  */
 
 export const requestPurchase = ({
-  skus,
+  sku,
   andDangerouslyFinishTransactionAutomaticallyIOS = false,
   applicationUsername,
   obfuscatedAccountIdAndroid,
   obfuscatedProfileIdAndroid,
+  skus,
   isOfferPersonalized,
 }: {
-  // TODO: use typescript to define as `[Sku]` for iOS and `Sku[]` for Android
-  skus: Sku[];
+  sku?: Sku;
   andDangerouslyFinishTransactionAutomaticallyIOS?: boolean;
   applicationUsername?: string;
   obfuscatedAccountIdAndroid?: string;
   obfuscatedProfileIdAndroid?: string;
   /** For Google Play Billing Library 5 https://developer.android.com/google/play/billing/integrate#personalized-price */
+  skus?: Sku[];
   isOfferPersonalized?: boolean;
 }): Promise<ProductPurchase> =>
   (
@@ -260,7 +261,7 @@ export const requestPurchase = ({
         }
 
         return getIosModule().buyProduct(
-          skus[0],
+          sku,
           andDangerouslyFinishTransactionAutomaticallyIOS,
           applicationUsername,
         );
@@ -268,7 +269,7 @@ export const requestPurchase = ({
       android: async () => {
         return getAndroidModule().buyItemByType(
           ANDROID_ITEM_TYPE_IAP,
-          skus,
+          skus?.length ? skus : [sku],
           null,
           -1,
           obfuscatedAccountIdAndroid,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -69,15 +69,13 @@ export interface PurchaseResult {
   message?: string;
 }
 
-export type InAppPurchase = ProductPurchase;
-
 export interface SubscriptionPurchase extends ProductPurchase {
   autoRenewingAndroid?: boolean;
   originalTransactionDateIOS?: string;
   originalTransactionIdentifierIOS?: string;
 }
 
-export type Purchase = InAppPurchase | SubscriptionPurchase;
+export type Purchase = ProductPurchase | SubscriptionPurchase;
 
 export interface Discount {
   identifier: string;
@@ -148,24 +146,6 @@ export interface SubscriptionIOS extends ProductCommon {
 
 export type Subscription = SubscriptionAndroid & SubscriptionIOS;
 
-export interface RequestPurchaseBaseAndroid {
-  obfuscatedAccountIdAndroid?: string;
-  obfuscatedProfileIdAndroid?: string;
-  isOfferPersonalized?: boolean; // For AndroidBilling V5 https://developer.android.com/google/play/billing/integrate#personalized-price
-}
-
-export interface RequestPurchaseAndroid extends RequestPurchaseBaseAndroid {
-  skus?: Sku[];
-}
-
-export interface RequestPurchaseIOS {
-  sku?: Sku;
-  andDangerouslyFinishTransactionAutomaticallyIOS?: boolean;
-  applicationUsername?: string;
-}
-
-export type RequestPurchase = RequestPurchaseAndroid & RequestPurchaseIOS;
-
 /**
  * In order to purchase a new subscription, every sku must have a selected offerToken
  * @see SubscriptionAndroid.subscriptionOfferDetails.offerToken
@@ -174,14 +154,3 @@ export interface SubscriptionOffer {
   sku: Sku;
   offerToken: string;
 }
-
-export interface RequestSubscriptionAndroid extends RequestPurchaseBaseAndroid {
-  purchaseTokenAndroid?: string;
-  prorationModeAndroid?: ProrationModesAndroid;
-  subscriptionOffers?: SubscriptionOffer[]; // For AndroidBilling V5
-}
-
-export type RequestSubscriptionIOS = RequestPurchaseIOS;
-
-export type RequestSubscription = RequestSubscriptionAndroid &
-  RequestSubscriptionIOS;


### PR DESCRIPTION
I flatten the interfaces within the methods to simplify next step of rework. I will start moving (in another PR) all modules specific params as we talked some time ago. It will be as follow:

```ts
requestPurchase({
  skus: [''], // common
  ios: {
    ...
  },
  android: {
    ..
  }
})
```

## Breaking changes

- All the exposed methods are now taking an object of parameters, rather than named params. e.g. `requestSubscription('com.example.sub', false)` -> `requestSubscription({ sku: 'com.example.sub', andDangerouslyFinishTransactionAutomaticallyIOS: false })`
- `requestPurchase` now takes an array of `Sku` -> `requestPurchase({ skus: ['com.example.sub'] })`. For iOS, only one Sku can be defined, for Android, it can be multiple
- Remove the `InAppPurchase` type, which was already defined as `ProductPurchase`