### PR TITLE
latest of next to main

### DIFF
--- a/IapExample/__tests__/App-test.js
+++ b/IapExample/__tests__/App-test.js
@@ -1,10 +1,7 @@
-/**
- * @format
- */
-
 import 'react-native';
+
 import React from 'react';
-import App from '../App';
+import {App} from '../App';
 
 // Note: test renderer must be required after react-native.
 import renderer from 'react-test-renderer';

--- a/IapExample/src/navigators/StackNavigator.tsx
+++ b/IapExample/src/navigators/StackNavigator.tsx
@@ -6,7 +6,7 @@ import {
   ClassSetup,
   Examples,
   Products,
-  PurchaseHistories,
+  PurchaseHistory,
   Subscriptions,
 } from '../screens';
 import {AvailablePurchases} from '../screens/AvailablePurchases';
@@ -28,8 +28,8 @@ export const examples = [
     emoji: '💳',
   },
   {
-    name: 'PurchaseHistories',
-    component: withIAPContext(PurchaseHistories),
+    name: 'PurchaseHistory',
+    component: withIAPContext(PurchaseHistory),
     section: 'Context',
     color: '#c241b3',
     emoji: '📄',
@@ -54,7 +54,7 @@ export type Screens = {
   Examples: undefined;
   Products: undefined;
   Subscriptions: undefined;
-  PurchaseHistories: undefined;
+  PurchaseHistory: undefined;
   AvailablePurchases: undefined;
   Listeners: undefined;
   ClassSetup: undefined;

--- a/IapExample/src/screens/AvailablePurchases.tsx
+++ b/IapExample/src/screens/AvailablePurchases.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {ScrollView, StyleSheet, View} from 'react-native';
-import RNIap, {useIAP} from 'react-native-iap';
+import {useIAP} from 'react-native-iap';
 
 import {Box, Button, Heading, Row, State} from '../components';
 import {contentContainerStyle, errorLog} from '../utils';
@@ -12,11 +12,7 @@ export const AvailablePurchases = () => {
     try {
       await getAvailablePurchases();
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
-        errorLog({message: `[${error.code}]: ${error.message}`, error});
-      } else {
-        errorLog({message: 'handleGetAvailablePurchases', error});
-      }
+      errorLog({message: 'handleGetAvailablePurchases', error});
     }
   };
 

--- a/IapExample/src/screens/Products.tsx
+++ b/IapExample/src/screens/Products.tsx
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {ScrollView, StyleSheet, Text, View} from 'react-native';
-import RNIap, {Sku, useIAP} from 'react-native-iap';
+import {PurchaseError, requestPurchase, Sku, useIAP} from 'react-native-iap';
 
 import {Box, Button, Heading, Row, State} from '../components';
 import {
@@ -22,18 +22,13 @@ export const Products = () => {
     initConnectionError,
     finishTransaction,
     getProducts,
-    requestPurchase,
   } = useIAP();
 
   const handleGetProducts = async () => {
     try {
-      await getProducts(constants.productSkus);
+      await getProducts({skus: constants.productSkus});
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
-        errorLog({message: `[${error.code}]: ${error.message}`, error});
-      } else {
-        errorLog({message: 'handleGetProducts', error});
-      }
+      errorLog({message: 'handleGetProducts', error});
     }
   };
 
@@ -41,7 +36,7 @@ export const Products = () => {
     try {
       await requestPurchase({sku});
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof PurchaseError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'handleBuyProduct', error});
@@ -53,11 +48,15 @@ export const Products = () => {
     const checkCurrentPurchase = async () => {
       try {
         if (currentPurchase?.transactionReceipt) {
-          await finishTransaction(currentPurchase, true);
+          await finishTransaction({
+            purchase: currentPurchase,
+            isConsumable: true,
+          });
+
           setSuccess(true);
         }
       } catch (error) {
-        if (error instanceof RNIap.IapError) {
+        if (error instanceof PurchaseError) {
           errorLog({message: `[${error.code}]: ${error.message}`, error});
         } else {
           errorLog({message: 'handleBuyProduct', error});

--- a/IapExample/src/screens/PurchaseHistory.tsx
+++ b/IapExample/src/screens/PurchaseHistory.tsx
@@ -1,22 +1,18 @@
 import React from 'react';
 import {ScrollView, StyleSheet, View} from 'react-native';
-import RNIap, {useIAP} from 'react-native-iap';
+import {useIAP} from 'react-native-iap';
 
 import {Box, Button, Heading, Row, State} from '../components';
 import {contentContainerStyle, errorLog} from '../utils';
 
-export const PurchaseHistories = () => {
-  const {connected, purchaseHistories, getPurchaseHistories} = useIAP();
+export const PurchaseHistory = () => {
+  const {connected, purchaseHistory, getPurchaseHistory} = useIAP();
 
-  const handleGetPurchaseHistories = async () => {
+  const handleGetPurchaseHistory = async () => {
     try {
-      await getPurchaseHistories();
+      await getPurchaseHistory();
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
-        errorLog({message: `[${error.code}]: ${error.message}`, error});
-      } else {
-        errorLog({message: 'handleGetPurchaseHistories', error});
-      }
+      errorLog({message: 'handleGetPurchaseHistory', error});
     }
   };
 
@@ -28,23 +24,23 @@ export const PurchaseHistories = () => {
         <View style={styles.container}>
           <Heading copy="Purchase histories" />
 
-          {purchaseHistories.map((purchaseHistory, index) => (
+          {purchaseHistory.map((purchase, index) => (
             <Row
-              key={purchaseHistory.productId}
+              key={purchase.productId}
               fields={[
                 {
                   label: 'Product Id',
-                  value: purchaseHistory.productId,
+                  value: purchase.productId,
                 },
               ]}
-              isLast={purchaseHistories.length - 1 === index}
+              isLast={purchaseHistory.length - 1 === index}
             />
           ))}
         </View>
 
         <Button
           title="Get the purchase histories"
-          onPress={handleGetPurchaseHistories}
+          onPress={handleGetPurchaseHistory}
         />
       </Box>
     </ScrollView>

--- a/IapExample/src/screens/Subscriptions.tsx
+++ b/IapExample/src/screens/Subscriptions.tsx
@@ -1,23 +1,18 @@
 import React from 'react';
 import {Platform, ScrollView, StyleSheet, View} from 'react-native';
-import RNIap, {useIAP} from 'react-native-iap';
+import {PurchaseError, requestSubscription, useIAP} from 'react-native-iap';
 
 import {Box, Button, Heading, Row, State} from '../components';
 import {constants, contentContainerStyle, errorLog} from '../utils';
 
 export const Subscriptions = () => {
-  const {connected, subscriptions, getSubscriptions, requestSubscription} =
-    useIAP();
+  const {connected, subscriptions, getSubscriptions} = useIAP();
 
   const handleGetSubscriptions = async () => {
     try {
-      await getSubscriptions(constants.subscriptionSkus);
+      await getSubscriptions({skus: constants.subscriptionSkus});
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
-        errorLog({message: `[${error.code}]: ${error.message}`, error});
-      } else {
-        errorLog({message: 'handleGetSubscriptions', error});
-      }
+      errorLog({message: 'handleGetSubscriptions', error});
     }
   };
 
@@ -38,7 +33,7 @@ export const Subscriptions = () => {
         }),
       });
     } catch (error) {
-      if (error instanceof RNIap.IapError) {
+      if (error instanceof PurchaseError) {
         errorLog({message: `[${error.code}]: ${error.message}`, error});
       } else {
         errorLog({message: 'handleBuySubscription', error});

--- a/IapExample/src/screens/index.ts
+++ b/IapExample/src/screens/index.ts
@@ -1,5 +1,5 @@
 export * from './ClassSetup';
 export * from './Examples';
 export * from './Products';
-export * from './PurchaseHistories';
+export * from './PurchaseHistory';
 export * from './Subscriptions';

--- a/docs/docs/usage_instructions/connection_lifecycle.md
+++ b/docs/docs/usage_instructions/connection_lifecycle.md
@@ -8,24 +8,30 @@ sidebar_position: 1
 
 In order to initialize the native modules, call `initConnection()` early in the lifecycle of your application. This should be done at a top-level component as the library caches the native connection. Initializing just before you needed is discouraged as it incurrs on a performance hit. Calling this method multiple times without ending the previous connection will result in an error. Not calling this method will cause other method calls to be rejected as connection needs to be established ahead of time.
 
-```ts
-import * as RNIap from 'react-native-iap';
+```tsx
+import React, {Component} from 'react';
+import {initConnection} from 'react-native-iap';
 
-componentDidMount() {
-  RNIap.initConnection();
-  // ...
+class App extends Component {
+  async componentDidMount() {
+    await initConnection();
+  }
+}
 ```
 
 ## Ending Connection
 
 In order to release the resources, call `endConnection()` when you no longer need any interaction with the library.
 
-```ts
-import * as RNIap from 'react-native-iap';
+```tsx
+import React, {Component} from 'react';
+import {endConnection} from 'react-native-iap';
 
-componentWillUnmount() {
-  // ...
-  RNIap.endConnection();
+class App extends Component {
+  componentWillUnmount() {
+    // ...
+    endConnection();
+  }
 }
 ```
 
@@ -35,55 +41,61 @@ You shoud not call `initConnection` and `endConnection` every time you need to i
 
 ### :white_check_mark: DO:
 
-```ts
-import * as RNIap from 'react-native-iap';
+```tsx
+import React, {Component} from 'react';
+import {initConnection, getProducts, endConnection} from 'react-native-iap';
 
-componentDidMount() {
-  await RNIap.initConnection();
-  await RNIap.getProducts(productIds)
-  // ...
-}
+class App extends Component {
+  async componentDidMount() {
+    await initConnection();
+    await getProducts(productIds);
+    // ...
+  }
 
-buyProductButtonClick() {
-  // startPurchaseCode
-}
+  buyProductButtonClick() {
+    // startPurchaseCode
+  }
 
-subscribeButtonClick() {
-  // startPurchaseCode
-}
+  subscribeButtonClick() {
+    // startPurchaseCode
+  }
 
-componentWillUnmount() {
-  // ...
-  RNIap.endConnection();
+  componentWillUnmount() {
+    // ...
+    endConnection();
+  }
 }
 ```
 
 ### :x: DON'T :
 
-```ts
-import * as RNIap from 'react-native-iap';
+```tsx
+import React, {Component} from 'react';
+import {initConnection, getProducts, endConnection} from 'react-native-iap';
 
-componentDidMount() {
-  // ...
-}
+class App extends Component {
+  componentDidMount() {
+    // ...
+  }
 
-const buyProductButtonClick = async() => {
-  await RNIap.initConnection();
-  await RNIap.getProducts(productIds)
-  // Purchase IAP Code
-  // ...
-  await RNIap.endConnection();
-}
+  buyProductButtonClick = async () => {
+    await initConnection();
+    await getProducts(productIds);
+    // Purchase IAP Code
+    // ...
+    await endConnection();
+  };
 
-const subscribeButtonClick = async() => {
-  await RNIap.initConnection();
-  await RNIap.getProducts(productIds)
-  // Purchase Subscription Code
-  // ...
-  await RNIap.endConnection();
-}
+  subscribeButtonClick = async () => {
+    await initConnection();
+    await getProducts(productIds);
+    // Purchase Subscription Code
+    // ...
+    await endConnection();
+  };
 
-componentWillUnmount() {
-  // ...
+  componentWillUnmount() {
+    // ...
+  }
 }
 ```

--- a/docs/docs/usage_instructions/purchase.md
+++ b/docs/docs/usage_instructions/purchase.md
@@ -20,23 +20,25 @@ Once you have called `getProducts()`, and have a valid response, you can call `r
 
 Before you request any purchase, you should set `purchaseUpdatedListener` from `react-native-iap`. It is recommended that you start listening to updates as soon as your application launches. And don't forget that even at launch you may receive successful purchases that either completed while your app was closed or that failed to be finished, consumed or acknowledged due to network errors or bugs.
 
-```ts
-import RNIap, {
+```tsx
+import {
+  initConnection,
   purchaseErrorListener,
   purchaseUpdatedListener,
   type ProductPurchase,
   type PurchaseError,
+  flushFailedPurchasesCachedAsPendingAndroid,
 } from 'react-native-iap';
 
-class RootComponent extends Component<*> {
+class App extends Component {
   purchaseUpdateSubscription = null;
   purchaseErrorSubscription = null;
 
   componentDidMount() {
-    RNIap.initConnection().then(() => {
+    initConnection().then(() => {
       // we make sure that "ghost" pending payment are removed
       // (ghost = failed pending payment that are still marked as pending in Google's native Vending module cache)
-      RNIap.flushFailedPurchasesCachedAsPendingAndroid()
+      flushFailedPurchasesCachedAsPendingAndroid()
         .catch(() => {
           // exception can happen here if:
           // - there are pending purchases that are still pending (we can't consume a pending purchase)
@@ -61,13 +63,13 @@ class RootComponent extends Component<*> {
                       // the purchase event will reappear on every relaunch of the app until you succeed
                       // in doing the below. It will also be impossible for the user to purchase consumables
                       // again until you do this.
-                      await RNIap.finishTransaction(purchase);
+                      await finishTransaction(purchase);
 
                       // From react-native-iap@4.1.0 you can simplify above `method`. Try to wrap the statement with `try` and `catch` to also grab the `error` message.
                       // If consumable (can be purchased again)
-                      await RNIap.finishTransaction(purchase, true);
+                      await finishTransaction(purchase, true);
                       // If not consumable
-                      await RNIap.finishTransaction(purchase, false);
+                      await finishTransaction(purchase, false);
                     } else {
                       // Retry / conclude the purchase is fraudulent, etc...
                     }
@@ -90,6 +92,7 @@ class RootComponent extends Component<*> {
       this.purchaseUpdateSubscription.remove();
       this.purchaseUpdateSubscription = null;
     }
+
     if (this.purchaseErrorSubscription) {
       this.purchaseErrorSubscription.remove();
       this.purchaseErrorSubscription = null;
@@ -100,25 +103,30 @@ class RootComponent extends Component<*> {
 
 Then define the method like below and call it when user press the button.
 
-```ts
+```tsx
+class App extends Component {
   requestPurchase = async (sku: string) => {
     try {
-      await RNIap.requestPurchase({
+      await requestPurchase({
         sku,
         andDangerouslyFinishTransactionAutomaticallyIOS: false,
       });
     } catch (err) {
       console.warn(err.code, err.message);
     }
-  }
+  };
 
   requestSubscription = async (sku: string, offerToken: string?) => {
     try {
-      await RNIap.requestSubscription({ sku }, ...(offerToken && {subscriptionOfffers:{sku,offerToken}}));
+      await requestSubscription(
+        {sku},
+        ...(offerToken && {subscriptionOfffers: {sku, offerToken}}),
+      );
     } catch (err) {
       console.warn(err.code, err.message);
     }
-  }
+  };
+
   /**
    * For one-time products
    */
@@ -127,26 +135,34 @@ Then define the method like below and call it when user press the button.
       <Pressable onPress={() => this.requestPurchase(product.productId)}>
         {/* ... */}
       </Pressable>
-    )
+    );
   }
+
   /**
    * For subscriptions products
    */
   render() {
-    if(Platform.OS =='android'){
-      return product.subscriptionOfferDetails.map((offer) =>
-        <Pressable onPress={() => this.requestSubscription(product.productId, offer.offerToken)}>
+    if (Platform.OS == 'android') {
+      return product.subscriptionOfferDetails.map((offer) => (
+        <Pressable
+          onPress={() =>
+            this.requestSubscription(product.productId, offer.offerToken)
+          }
+        >
           {/* ... */}
         </Pressable>
-        )
-    }else{
+      ));
+    } else {
       return (
-        <Pressable onPress={() => this.requestSubscription(product.productId, null)}>
+        <Pressable
+          onPress={() => this.requestSubscription(product.productId, null)}
+        >
           {/* ... */}
         </Pressable>
-        )
+      );
     }
   }
+}
 ```
 
 ## New Purchase Flow

--- a/src/eventEmitter.ts
+++ b/src/eventEmitter.ts
@@ -1,0 +1,49 @@
+import {EmitterSubscription, NativeEventEmitter} from 'react-native';
+
+import {getAndroidModule, getIosModule, getNativeModule} from './iap';
+import {isAndroid, isIos} from './internal';
+import type {PurchaseError} from './purchaseError';
+import type {Purchase} from './types';
+
+const eventEmitter = new NativeEventEmitter(getNativeModule());
+
+/**
+ * Add IAP purchase event
+ */
+export const purchaseUpdatedListener = (
+  listener: (event: Purchase) => void,
+) => {
+  const emitterSubscription = eventEmitter.addListener(
+    'purchase-updated',
+    listener,
+  );
+
+  if (isAndroid) {
+    getAndroidModule().startListening();
+  }
+
+  return emitterSubscription;
+};
+
+/**
+ * Add IAP purchase error event
+ */
+export const purchaseErrorListener = (
+  listener: (error: PurchaseError) => void,
+): EmitterSubscription => eventEmitter.addListener('purchase-error', listener);
+
+/**
+ * Add IAP promoted subscription event
+ *
+ * @platform iOS
+ */
+export const promotedProductListener = (listener: () => void) => {
+  if (isIos) {
+    return new NativeEventEmitter(getIosModule()).addListener(
+      'iap-promoted-product',
+      listener,
+    );
+  }
+
+  return null;
+};

--- a/src/hooks/useIAP.ts
+++ b/src/hooks/useIAP.ts
@@ -4,12 +4,11 @@ import {
   finishTransaction as iapFinishTransaction,
   getAvailablePurchases as iapGetAvailablePurchases,
   getProducts as iapGetProducts,
-  getPurchaseHistory,
+  getPurchaseHistory as iapGetPurchaseHistory,
   getSubscriptions as iapGetSubscriptions,
-  requestPurchase as iapRequestPurchase,
-  requestSubscription as iapRequestSubscription,
 } from '../iap';
-import type {Product, Purchase, PurchaseError, Subscription} from '../types';
+import type {PurchaseError} from '../purchaseError';
+import type {Product, Purchase, Subscription} from '../types';
 
 import {useIAPContext} from './withIAPContext';
 
@@ -18,22 +17,24 @@ type IAP_STATUS = {
   products: Product[];
   promotedProductsIOS: Product[];
   subscriptions: Subscription[];
-  purchaseHistories: Purchase[];
+  purchaseHistory: Purchase[];
   availablePurchases: Purchase[];
   currentPurchase?: Purchase;
   currentPurchaseError?: PurchaseError;
   initConnectionError?: Error;
-  finishTransaction: (
-    purchase: Purchase,
-    isConsumable?: boolean,
-    developerPayloadAndroid?: string,
-  ) => Promise<string | void>;
+  finishTransaction: ({
+    purchase,
+    isConsumable,
+    developerPayloadAndroid,
+  }: {
+    purchase: Purchase;
+    isConsumable?: boolean;
+    developerPayloadAndroid?: string;
+  }) => Promise<string | void>;
   getAvailablePurchases: () => Promise<void>;
-  getPurchaseHistories: () => Promise<void>;
-  getProducts: (skus: string[]) => Promise<void>;
-  getSubscriptions: (skus: string[]) => Promise<void>;
-  requestPurchase: typeof iapRequestPurchase;
-  requestSubscription: typeof iapRequestSubscription;
+  getPurchaseHistory: () => Promise<void>;
+  getProducts: ({skus}: {skus: string[]}) => Promise<void>;
+  getSubscriptions: ({skus}: {skus: string[]}) => Promise<void>;
 };
 
 export function useIAP(): IAP_STATUS {
@@ -42,7 +43,7 @@ export function useIAP(): IAP_STATUS {
     products,
     promotedProductsIOS,
     subscriptions,
-    purchaseHistories,
+    purchaseHistory,
     availablePurchases,
     currentPurchase,
     currentPurchaseError,
@@ -50,21 +51,21 @@ export function useIAP(): IAP_STATUS {
     setProducts,
     setSubscriptions,
     setAvailablePurchases,
-    setPurchaseHistories,
+    setPurchaseHistory,
     setCurrentPurchase,
     setCurrentPurchaseError,
   } = useIAPContext();
 
   const getProducts = useCallback(
-    async (skus: string[]): Promise<void> => {
-      setProducts(await iapGetProducts(skus));
+    async ({skus}: {skus: string[]}): Promise<void> => {
+      setProducts(await iapGetProducts({skus}));
     },
     [setProducts],
   );
 
   const getSubscriptions = useCallback(
-    async (skus: string[]): Promise<void> => {
-      setSubscriptions(await iapGetSubscriptions(skus));
+    async ({skus}: {skus: string[]}): Promise<void> => {
+      setSubscriptions(await iapGetSubscriptions({skus}));
     },
     [setSubscriptions],
   );
@@ -73,22 +74,26 @@ export function useIAP(): IAP_STATUS {
     setAvailablePurchases(await iapGetAvailablePurchases());
   }, [setAvailablePurchases]);
 
-  const getPurchaseHistories = useCallback(async (): Promise<void> => {
-    setPurchaseHistories(await getPurchaseHistory());
-  }, [setPurchaseHistories]);
+  const getPurchaseHistory = useCallback(async (): Promise<void> => {
+    setPurchaseHistory(await iapGetPurchaseHistory());
+  }, [setPurchaseHistory]);
 
   const finishTransaction = useCallback(
-    async (
-      purchase: Purchase,
-      isConsumable?: boolean,
-      developerPayloadAndroid?: string,
-    ): Promise<string | void> => {
+    async ({
+      purchase,
+      isConsumable,
+      developerPayloadAndroid,
+    }: {
+      purchase: Purchase;
+      isConsumable?: boolean;
+      developerPayloadAndroid?: string;
+    }): Promise<string | void> => {
       try {
-        return await iapFinishTransaction(
+        return await iapFinishTransaction({
           purchase,
           isConsumable,
           developerPayloadAndroid,
-        );
+        });
       } catch (err) {
         throw err;
       } finally {
@@ -114,7 +119,7 @@ export function useIAP(): IAP_STATUS {
     products,
     promotedProductsIOS,
     subscriptions,
-    purchaseHistories,
+    purchaseHistory,
     availablePurchases,
     currentPurchase,
     currentPurchaseError,
@@ -123,8 +128,6 @@ export function useIAP(): IAP_STATUS {
     getProducts,
     getSubscriptions,
     getAvailablePurchases,
-    getPurchaseHistories,
-    requestPurchase: iapRequestPurchase,
-    requestSubscription: iapRequestSubscription,
+    getPurchaseHistory,
   };
 }

--- a/src/hooks/withIAPContext.tsx
+++ b/src/hooks/withIAPContext.tsx
@@ -1,17 +1,16 @@
 import React, {useContext, useEffect, useMemo, useState} from 'react';
 
 import {
-  getPromotedProductIOS,
-  initConnection,
   promotedProductListener,
   purchaseErrorListener,
   purchaseUpdatedListener,
-} from '../iap';
+} from '../eventEmitter';
+import {getPromotedProductIOS, initConnection} from '../iap';
+import type {PurchaseError} from '../purchaseError';
 import type {
-  InAppPurchase,
   Product,
+  ProductPurchase,
   Purchase,
-  PurchaseError,
   Subscription,
   SubscriptionPurchase,
 } from '../types';
@@ -21,14 +20,14 @@ type IAPContextType = {
   products: Product[];
   promotedProductsIOS: Product[];
   subscriptions: Subscription[];
-  purchaseHistories: Purchase[];
+  purchaseHistory: Purchase[];
   availablePurchases: Purchase[];
   currentPurchase?: Purchase;
   currentPurchaseError?: PurchaseError;
   initConnectionError?: Error;
   setProducts: (products: Product[]) => void;
   setSubscriptions: (subscriptions: Subscription[]) => void;
-  setPurchaseHistories: (purchaseHistories: Purchase[]) => void;
+  setPurchaseHistory: (purchaseHistory: Purchase[]) => void;
   setAvailablePurchases: (availablePurchases: Purchase[]) => void;
   setCurrentPurchase: (currentPurchase: Purchase | undefined) => void;
   setCurrentPurchaseError: (
@@ -58,7 +57,7 @@ export function withIAPContext<T>(Component: React.ComponentType<T>) {
       [],
     );
     const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
-    const [purchaseHistories, setPurchaseHistories] = useState<Purchase[]>([]);
+    const [purchaseHistory, setPurchaseHistory] = useState<Purchase[]>([]);
 
     const [availablePurchases, setAvailablePurchases] = useState<Purchase[]>(
       [],
@@ -76,14 +75,14 @@ export function withIAPContext<T>(Component: React.ComponentType<T>) {
         products,
         subscriptions,
         promotedProductsIOS,
-        purchaseHistories,
+        purchaseHistory,
         availablePurchases,
         currentPurchase,
         currentPurchaseError,
         initConnectionError,
         setProducts,
         setSubscriptions,
-        setPurchaseHistories,
+        setPurchaseHistory,
         setAvailablePurchases,
         setCurrentPurchase,
         setCurrentPurchaseError,
@@ -93,14 +92,14 @@ export function withIAPContext<T>(Component: React.ComponentType<T>) {
         products,
         subscriptions,
         promotedProductsIOS,
-        purchaseHistories,
+        purchaseHistory,
         availablePurchases,
         currentPurchase,
         currentPurchaseError,
         initConnectionError,
         setProducts,
         setSubscriptions,
-        setPurchaseHistories,
+        setPurchaseHistory,
         setAvailablePurchases,
         setCurrentPurchase,
         setCurrentPurchaseError,
@@ -122,7 +121,7 @@ export function withIAPContext<T>(Component: React.ComponentType<T>) {
       }
 
       const purchaseUpdateSubscription = purchaseUpdatedListener(
-        async (purchase: InAppPurchase | SubscriptionPurchase) => {
+        async (purchase: ProductPurchase | SubscriptionPurchase) => {
           setCurrentPurchaseError(undefined);
           setCurrentPurchase(purchase);
         },

--- a/src/iap.ts
+++ b/src/iap.ts
@@ -1,46 +1,30 @@
-import {
-  EmitterSubscription,
-  Linking,
-  NativeEventEmitter,
-  NativeModules,
-  Platform,
-} from 'react-native';
+import {Linking, NativeModules, Platform} from 'react-native';
 
 import type * as Amazon from './types/amazon';
 import type * as Android from './types/android';
 import type * as Apple from './types/apple';
 import {ReceiptValidationStatus} from './types/apple';
+import {
+  enhancedFetch,
+  fillProductsWithAdditionalData,
+  isAmazon,
+  isAndroid,
+} from './internal';
 import type {
-  InAppPurchase,
   Product,
-  ProductCommon,
   ProductPurchase,
-  PurchaseError,
+  ProrationModesAndroid,
   PurchaseResult,
-  RequestPurchase,
-  RequestSubscription,
+  Sku,
   Subscription,
+  SubscriptionOffer,
   SubscriptionPurchase,
 } from './types';
-import {
-  IAPErrorCode,
-  InstallSourceAndroid,
-  PurchaseStateAndroid,
-} from './types';
+import {InstallSourceAndroid, PurchaseStateAndroid} from './types';
 
 const {RNIapIos, RNIapModule, RNIapAmazonModule} = NativeModules;
-const isAndroid = Platform.OS === 'android';
-const isAmazon = isAndroid && !!RNIapAmazonModule;
-const isIos = Platform.OS === 'ios';
 const ANDROID_ITEM_TYPE_SUBSCRIPTION = 'subs';
 const ANDROID_ITEM_TYPE_IAP = 'inapp';
-
-export class IapError implements PurchaseError {
-  constructor(public code?: string, public message?: string) {
-    this.code = code;
-    this.message = message;
-  }
-}
 
 export const getInstallSourceAndroid = (): InstallSourceAndroid => {
   return RNIapModule
@@ -58,11 +42,13 @@ export const setAndroidNativeModule = (
 
 const checkNativeAndroidAvailable = (): void => {
   if (!RNIapModule && !RNIapAmazonModule) {
-    throw new Error(IAPErrorCode.E_IAP_NOT_AVAILABLE);
+    throw new Error('IAP_NOT_AVAILABLE');
   }
 };
 
-const getAndroidModule = (): typeof RNIapModule | typeof RNIapAmazonModule => {
+export const getAndroidModule = ():
+  | typeof RNIapModule
+  | typeof RNIapAmazonModule => {
   checkNativeAndroidAvailable();
 
   return androidNativeModule
@@ -74,17 +60,17 @@ const getAndroidModule = (): typeof RNIapModule | typeof RNIapAmazonModule => {
 
 const checkNativeIOSAvailable = (): void => {
   if (!RNIapIos) {
-    throw new Error(IAPErrorCode.E_IAP_NOT_AVAILABLE);
+    throw new Error('IAP_NOT_AVAILABLE');
   }
 };
 
-const getIosModule = (): typeof RNIapIos => {
+export const getIosModule = (): typeof RNIapIos => {
   checkNativeIOSAvailable();
 
   return RNIapIos;
 };
 
-const getNativeModule = ():
+export const getNativeModule = ():
   | typeof RNIapModule
   | typeof RNIapAmazonModule
   | typeof RNIapIos => {
@@ -114,51 +100,15 @@ export const flushFailedPurchasesCachedAsPendingAndroid = (): Promise<
 > => getAndroidModule().flushFailedPurchasesCachedAsPending();
 
 /**
- * Fill products with additional data
- * @param {Array<ProductCommon>} products Products
- */
-const fillProductsAdditionalData = async (
-  products: Array<ProductCommon>,
-): Promise<Array<ProductCommon>> => {
-  // Amazon
-  if (RNIapAmazonModule) {
-    // On amazon we must get the user marketplace to detect the currency
-    const user = await RNIapAmazonModule.getUser();
-
-    const currencies = {
-      CA: 'CAD',
-      ES: 'EUR',
-      AU: 'AUD',
-      DE: 'EUR',
-      IN: 'INR',
-      US: 'USD',
-      JP: 'JPY',
-      GB: 'GBP',
-      IT: 'EUR',
-      BR: 'BRL',
-      FR: 'EUR',
-    };
-
-    const currency =
-      currencies[user.userMarketplaceAmazon as keyof typeof currencies];
-
-    // Add currency to products
-    products.forEach((product) => {
-      if (currency) {
-        product.currency = currency;
-      }
-    });
-  }
-
-  return products;
-};
-
-/**
  * Get a list of products (consumable and non-consumable items, but not subscriptions)
  * @param {string[]} skus The item skus
  * @returns {Promise<Product[]>}
  */
-export const getProducts = (skus: string[]): Promise<Array<Product>> =>
+export const getProducts = ({
+  skus,
+}: {
+  skus: string[];
+}): Promise<Array<Product>> =>
   (
     Platform.select({
       ios: async () => {
@@ -175,7 +125,7 @@ export const getProducts = (skus: string[]): Promise<Array<Product>> =>
           skus,
         );
 
-        return fillProductsAdditionalData(products);
+        return fillProductsWithAdditionalData(products);
       },
     }) || Promise.resolve
   )();
@@ -185,7 +135,11 @@ export const getProducts = (skus: string[]): Promise<Array<Product>> =>
  * @param {string[]} skus The item skus
  * @returns {Promise<Subscription[]>}
  */
-export const getSubscriptions = (skus: string[]): Promise<Subscription[]> =>
+export const getSubscriptions = ({
+  skus,
+}: {
+  skus: string[];
+}): Promise<Subscription[]> =>
   (
     Platform.select({
       ios: async () => {
@@ -202,17 +156,17 @@ export const getSubscriptions = (skus: string[]): Promise<Subscription[]> =>
           skus,
         );
 
-        return fillProductsAdditionalData(subscriptions);
+        return fillProductsWithAdditionalData(subscriptions);
       },
     }) || Promise.resolve
   )();
 
 /**
  * Gets an inventory of purchases made by the user regardless of consumption status
- * @returns {Promise<(InAppPurchase | SubscriptionPurchase)[]>}
+ * @returns {Promise<(ProductPurchase | SubscriptionPurchase)[]>}
  */
 export const getPurchaseHistory = (): Promise<
-  (InAppPurchase | SubscriptionPurchase)[]
+  (ProductPurchase | SubscriptionPurchase)[]
 > =>
   (
     Platform.select({
@@ -239,10 +193,10 @@ export const getPurchaseHistory = (): Promise<
 
 /**
  * Get all purchases made by the user (either non-consumable, or haven't been consumed yet)
- * @returns {Promise<(InAppPurchase | SubscriptionPurchase)[]>}
+ * @returns {Promise<(ProductPurchase | SubscriptionPurchase)[]>}
  */
 export const getAvailablePurchases = (): Promise<
-  (InAppPurchase | SubscriptionPurchase)[]
+  (ProductPurchase | SubscriptionPurchase)[]
 > =>
   (
     Platform.select({
@@ -276,18 +230,27 @@ export const getAvailablePurchases = (): Promise<
  * @param {string} [obfuscatedProfileIdAndroid] Specifies an optional obfuscated string that is uniquely associated with the user's profile in your app.
  * @param {string[]} [skus] Product Ids to purchase. Note that this is only for Android. iOS only uses a single SKU. If not provided, it'll default to using [sku] for backward-compatibility
  * @param {boolean} [isOfferPersonalized] Defaults to false, Only for Android V5
- * @returns {Promise<InAppPurchase>}
+ * @returns {Promise<ProductPurchase>}
  */
 
 export const requestPurchase = ({
   sku,
   andDangerouslyFinishTransactionAutomaticallyIOS = false,
+  applicationUsername,
   obfuscatedAccountIdAndroid,
   obfuscatedProfileIdAndroid,
-  applicationUsername,
-  skus, // Android Billing V5
-  isOfferPersonalized = undefined, // Android Billing V5
-}: RequestPurchase): Promise<InAppPurchase> =>
+  skus,
+  isOfferPersonalized,
+}: {
+  sku?: Sku;
+  andDangerouslyFinishTransactionAutomaticallyIOS?: boolean;
+  applicationUsername?: string;
+  obfuscatedAccountIdAndroid?: string;
+  obfuscatedProfileIdAndroid?: string;
+  /** For Google Play Billing Library 5 https://developer.android.com/google/play/billing/integrate#personalized-price */
+  skus?: Sku[];
+  isOfferPersonalized?: boolean;
+}): Promise<ProductPurchase> =>
   (
     Platform.select({
       ios: async () => {
@@ -337,14 +300,26 @@ export const requestPurchase = ({
 export const requestSubscription = ({
   sku,
   andDangerouslyFinishTransactionAutomaticallyIOS = false,
+  applicationUsername,
   purchaseTokenAndroid,
   prorationModeAndroid = -1,
+  subscriptionOffers,
   obfuscatedAccountIdAndroid,
   obfuscatedProfileIdAndroid,
-  subscriptionOffers = undefined, // Android Billing V5
-  isOfferPersonalized = undefined, // Android Billing V5
-  applicationUsername,
-}: RequestSubscription): Promise<SubscriptionPurchase | null> =>
+  isOfferPersonalized = undefined,
+}: {
+  sku?: Sku;
+  andDangerouslyFinishTransactionAutomaticallyIOS?: boolean;
+  applicationUsername?: string;
+  purchaseTokenAndroid?: string;
+  prorationModeAndroid?: ProrationModesAndroid;
+  /** For Google Play Billing Library 5 */
+  subscriptionOffers?: SubscriptionOffer[];
+  obfuscatedAccountIdAndroid?: string;
+  obfuscatedProfileIdAndroid?: string;
+  /** For Google Play Billing Library 5 https://developer.android.com/google/play/billing/integrate#personalized-price */
+  isOfferPersonalized?: boolean;
+}): Promise<SubscriptionPurchase | null> =>
   (
     Platform.select({
       ios: async () => {
@@ -390,10 +365,13 @@ export const requestSubscription = ({
  * @param {string} sku The product's sku/ID
  * @returns {Promise<void>}
  */
-export const requestPurchaseWithQuantityIOS = (
-  sku: string,
-  quantity: number,
-): Promise<InAppPurchase> =>
+export const requestPurchaseWithQuantityIOS = ({
+  sku,
+  quantity,
+}: {
+  sku: Sku;
+  quantity: number;
+}): Promise<ProductPurchase> =>
   getIosModule().buyProductWithQuantityIOS(sku, quantity);
 
 /**
@@ -408,11 +386,15 @@ export const requestPurchaseWithQuantityIOS = (
  * @param {string} developerPayloadAndroid Android developerPayload.
  * @returns {Promise<string | void> }
  */
-export const finishTransaction = (
-  purchase: InAppPurchase | ProductPurchase,
-  isConsumable?: boolean,
-  developerPayloadAndroid?: string,
-): Promise<string | void> => {
+export const finishTransaction = ({
+  purchase,
+  isConsumable,
+  developerPayloadAndroid,
+}: {
+  purchase: ProductPurchase | ProductPurchase;
+  isConsumable?: boolean;
+  developerPayloadAndroid?: string;
+}): Promise<string | void> => {
   return (
     Platform.select({
       ios: async () => {
@@ -468,10 +450,13 @@ export const clearProductsIOS = (): Promise<void> =>
  * @param {string} token The product's token (on Android)
  * @returns {Promise<PurchaseResult | void>}
  */
-export const acknowledgePurchaseAndroid = (
-  token: string,
-  developerPayload?: string,
-): Promise<PurchaseResult | void> => {
+export const acknowledgePurchaseAndroid = ({
+  token,
+  developerPayload,
+}: {
+  token: string;
+  developerPayload?: string;
+}): Promise<PurchaseResult | void> => {
   return getAndroidModule().acknowledgePurchase(token, developerPayload);
 };
 
@@ -480,9 +465,11 @@ export const acknowledgePurchaseAndroid = (
  * @param {string} sku The product's SKU (on Android)
  * @returns {Promise<void>}
  */
-export const deepLinkToSubscriptionsAndroid = async (
-  sku: string,
-): Promise<void> => {
+export const deepLinkToSubscriptionsAndroid = async ({
+  sku,
+}: {
+  sku: Sku;
+}): Promise<void> => {
   checkNativeAndroidAvailable();
 
   return Linking.openURL(
@@ -506,42 +493,26 @@ export const getPromotedProductIOS = (): Promise<Product | null> =>
 export const buyPromotedProductIOS = (): Promise<void> =>
   getIosModule().buyPromotedProduct();
 
-const fetchJsonOrThrow = async (
-  url: string,
-  receiptBody: Record<string, unknown>,
-): Promise<Apple.ReceiptValidationResponse | false> => {
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(receiptBody),
-  });
-
-  if (!response.ok) {
-    throw Object.assign(new Error(response.statusText), {
-      statusCode: response.status,
-    });
-  }
-
-  return response.json();
-};
-
 const requestAgnosticReceiptValidationIos = async (
   receiptBody: Record<string, unknown>,
 ): Promise<Apple.ReceiptValidationResponse | false> => {
-  const response = await fetchJsonOrThrow(
+  const response = await enhancedFetch<Apple.ReceiptValidationResponse>(
     'https://buy.itunes.apple.com/verifyReceipt',
-    receiptBody,
+    {
+      method: 'POST',
+      body: receiptBody,
+    },
   );
 
   // Best practice is to check for test receipt and check sandbox instead
   // https://developer.apple.com/documentation/appstorereceipts/verifyreceipt
   if (response && response.status === ReceiptValidationStatus.TEST_RECEIPT) {
-    const testResponse = await fetchJsonOrThrow(
+    const testResponse = await enhancedFetch<Apple.ReceiptValidationResponse>(
       'https://sandbox.itunes.apple.com/verifyReceipt',
-      receiptBody,
+      {
+        method: 'POST',
+        body: receiptBody,
+      },
     );
 
     return testResponse;
@@ -565,11 +536,16 @@ const requestAgnosticReceiptValidationIos = async (
  * @param {number} withOffer.timestamp The timestamp of the signature
  * @returns {Promise<void>}
  */
-export const requestPurchaseWithOfferIOS = (
-  sku: string,
-  forUser: string,
-  withOffer: Apple.PaymentDiscount,
-): Promise<void> => getIosModule().buyProductWithOffer(sku, forUser, withOffer);
+export const requestPurchaseWithOfferIOS = ({
+  sku,
+  forUser,
+  withOffer,
+}: {
+  sku: Sku;
+  forUser: string;
+  withOffer: Apple.PaymentDiscount;
+}): Promise<void> =>
+  getIosModule().buyProductWithOffer(sku, forUser, withOffer);
 
 /**
  * Validate receipt for iOS.
@@ -577,10 +553,13 @@ export const requestPurchaseWithOfferIOS = (
  * @param {boolean} isTest whether this is in test environment which is sandbox.
  * @returns {Promise<Apple.ReceiptValidationResponse | false>}
  */
-export const validateReceiptIos = async (
-  receiptBody: Record<string, unknown>,
-  isTest?: boolean,
-): Promise<Apple.ReceiptValidationResponse | false> => {
+export const validateReceiptIos = async ({
+  receiptBody,
+  isTest,
+}: {
+  receiptBody: Record<string, unknown>;
+  isTest?: boolean;
+}): Promise<Apple.ReceiptValidationResponse | false> => {
   if (isTest == null) {
     return await requestAgnosticReceiptValidationIos(receiptBody);
   }
@@ -589,9 +568,7 @@ export const validateReceiptIos = async (
     ? 'https://sandbox.itunes.apple.com/verifyReceipt'
     : 'https://buy.itunes.apple.com/verifyReceipt';
 
-  const response = await fetchJsonOrThrow(url, receiptBody);
-
-  return response;
+  return await enhancedFetch<Apple.ReceiptValidationResponse>(url);
 };
 
 /**
@@ -605,13 +582,19 @@ export const validateReceiptIos = async (
  * @param {boolean} isSub whether this is subscription or inapp. `true` for subscription.
  * @returns {Promise<object>}
  */
-export const validateReceiptAndroid = async (
-  packageName: string,
-  productId: string,
-  productToken: string,
-  accessToken: string,
-  isSub?: boolean,
-): Promise<Android.ReceiptType> => {
+export const validateReceiptAndroid = async ({
+  packageName,
+  productId,
+  productToken,
+  accessToken,
+  isSub,
+}: {
+  packageName: string;
+  productId: string;
+  productToken: string;
+  accessToken: string;
+  isSub?: boolean;
+}): Promise<Android.ReceiptType> => {
   const type = isSub ? 'subscriptions' : 'products';
 
   const url =
@@ -619,20 +602,7 @@ export const validateReceiptAndroid = async (
     `/${packageName}/purchases/${type}/${productId}` +
     `/tokens/${productToken}?access_token=${accessToken}`;
 
-  const response = await fetch(url, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
-
-  if (!response.ok) {
-    throw Object.assign(new Error(response.statusText), {
-      statusCode: response.status,
-    });
-  }
-
-  return response.json();
+  return await enhancedFetch<Android.ReceiptType>(url);
 };
 
 /**
@@ -645,75 +615,21 @@ export const validateReceiptAndroid = async (
  * @param {boolean} useSandbox Defaults to true, use sandbox environment or production.
  * @returns {Promise<object>}
  */
-export const validateReceiptAmazon = async (
-  developerSecret: string,
-  userId: string,
-  receiptId: string,
-  useSandbox: boolean = true,
-): Promise<Amazon.ReceiptType> => {
+export const validateReceiptAmazon = async ({
+  developerSecret,
+  userId,
+  receiptId,
+  useSandbox = true,
+}: {
+  developerSecret: string;
+  userId: string;
+  receiptId: string;
+  useSandbox: boolean;
+}): Promise<Amazon.ReceiptType> => {
   const sandBoxUrl = useSandbox ? 'sandbox/' : '';
   const url = `https://appstore-sdk.amazon.com/${sandBoxUrl}version/1.0/verifyReceiptId/developer/${developerSecret}/user/${userId}/receiptId/${receiptId}`;
 
-  const response = await fetch(url, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
-
-  if (!response.ok) {
-    throw Object.assign(new Error(response.statusText), {
-      statusCode: response.status,
-    });
-  }
-
-  return response.json();
-};
-
-/**
- * Add IAP purchase event
- * @returns {callback(e: InAppPurchase | ProductPurchase)}
- */
-export const purchaseUpdatedListener = (
-  listener: (event: InAppPurchase | SubscriptionPurchase) => void,
-): EmitterSubscription => {
-  const emitterSubscription = new NativeEventEmitter(
-    getNativeModule(),
-  ).addListener('purchase-updated', listener);
-
-  if (isAndroid) {
-    getAndroidModule().startListening();
-  }
-
-  return emitterSubscription;
-};
-
-/**
- * Add IAP purchase error event
- * @returns {callback(e: PurchaseError)}
- */
-export const purchaseErrorListener = (
-  listener: (errorEvent: PurchaseError) => void,
-): EmitterSubscription =>
-  new NativeEventEmitter(getNativeModule()).addListener(
-    'purchase-error',
-    listener,
-  );
-
-/**
- * Add IAP promoted subscription event
- * Only available on iOS
- */
-export const promotedProductListener = (
-  listener: (productId?: string) => void,
-): EmitterSubscription | null => {
-  if (isIos) {
-    return new NativeEventEmitter(getIosModule()).addListener(
-      'iap-promoted-product',
-      listener,
-    );
-  }
-  return null;
+  return await enhancedFetch<Amazon.ReceiptType>(url);
 };
 
 /**
@@ -729,8 +645,11 @@ export const getPendingPurchasesIOS = async (): Promise<ProductPurchase[]> =>
  * @param {forceRefresh?:boolean}
  * @returns {Promise<string>}
  */
-export const getReceiptIOS = async (forceRefresh?: boolean): Promise<string> =>
-  getIosModule().requestReceipt(forceRefresh ?? false);
+export const getReceiptIOS = async ({
+  forceRefresh,
+}: {
+  forceRefresh?: boolean;
+}): Promise<string> => getIosModule().requestReceipt(forceRefresh ?? false);
 
 /**
  * Launches a modal to register the redeem offer code in IOS.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,6 @@
-import * as iap from './iap';
-
 export * from './iap';
 export * from './types';
+export * from './eventEmitter';
 export * from './hooks/useIAP';
 export * from './hooks/withIAPContext';
-
-export default iap;
+export * from './purchaseError';

--- a/src/internal/enhancedFetch.ts
+++ b/src/internal/enhancedFetch.ts
@@ -1,0 +1,25 @@
+interface OverwrittenRequestInit extends Omit<RequestInit, 'body'> {
+  body: Record<string, any>;
+}
+
+export const enhancedFetch = async <T = any>(
+  url: string,
+  init?: OverwrittenRequestInit,
+) => {
+  const response = await fetch(url, {
+    method: init?.method ?? 'GET',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    ...(init?.body ? {body: JSON.stringify(init.body)} : {}),
+  });
+
+  if (!response.ok) {
+    throw Object.assign(new Error(response.statusText), {
+      statusCode: response.status,
+    });
+  }
+
+  return response.json() as Promise<T>;
+};

--- a/src/internal/fillProductsWithAdditionalData.ts
+++ b/src/internal/fillProductsWithAdditionalData.ts
@@ -1,0 +1,43 @@
+import {NativeModules} from 'react-native';
+
+import type {ProductCommon} from '../types';
+
+const {RNIapAmazonModule} = NativeModules;
+
+/**
+ * Fill products with additional data
+ */
+export const fillProductsWithAdditionalData = async <T extends ProductCommon>(
+  items: T[],
+) => {
+  if (RNIapAmazonModule) {
+    // On amazon we must get the user marketplace to detect the currency
+    const user = await RNIapAmazonModule.getUser();
+
+    const currencies = {
+      CA: 'CAD',
+      ES: 'EUR',
+      AU: 'AUD',
+      DE: 'EUR',
+      IN: 'INR',
+      US: 'USD',
+      JP: 'JPY',
+      GB: 'GBP',
+      IT: 'EUR',
+      BR: 'BRL',
+      FR: 'EUR',
+    };
+
+    const currency =
+      currencies[user.userMarketplaceAmazon as keyof typeof currencies];
+
+    // Add currency to items
+    items.forEach((item) => {
+      if (currency) {
+        item.currency = currency;
+      }
+    });
+  }
+
+  return items;
+};

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -1,0 +1,3 @@
+export * from './enhancedFetch';
+export * from './fillProductsWithAdditionalData';
+export * from './platform';

--- a/src/internal/platform.ts
+++ b/src/internal/platform.ts
@@ -1,0 +1,7 @@
+import {NativeModules, Platform} from 'react-native';
+
+const {RNIapAmazonModule} = NativeModules;
+
+export const isIos = Platform.OS === 'ios';
+export const isAndroid = Platform.OS === 'android';
+export const isAmazon = isAndroid && !!RNIapAmazonModule;

--- a/src/purchaseError.ts
+++ b/src/purchaseError.ts
@@ -1,0 +1,35 @@
+export enum ErrorCode {
+  E_UNKNOWN = 'E_UNKNOWN',
+  E_USER_CANCELLED = 'E_USER_CANCELLED',
+  E_USER_ERROR = 'E_USER_ERROR',
+  E_ITEM_UNAVAILABLE = 'E_ITEM_UNAVAILABLE',
+  E_REMOTE_ERROR = 'E_REMOTE_ERROR',
+  E_NETWORK_ERROR = 'E_NETWORK_ERROR',
+  E_SERVICE_ERROR = 'E_SERVICE_ERROR',
+  E_RECEIPT_FAILED = 'E_RECEIPT_FAILED',
+  E_RECEIPT_FINISHED_FAILED = 'E_RECEIPT_FINISHED_FAILED',
+  E_NOT_PREPARED = 'E_NOT_PREPARED',
+  E_NOT_ENDED = 'E_NOT_ENDED',
+  E_ALREADY_OWNED = 'E_ALREADY_OWNED',
+  E_DEVELOPER_ERROR = 'E_DEVELOPER_ERROR',
+  E_BILLING_RESPONSE_JSON_PARSE_ERROR = 'E_BILLING_RESPONSE_JSON_PARSE_ERROR',
+  E_DEFERRED_PAYMENT = 'E_DEFERRED_PAYMENT',
+}
+
+export class PurchaseError implements Error {
+  constructor(
+    public name: string,
+    public message: string,
+    public responseCode?: number,
+    public debugMessage?: string,
+    public code?: ErrorCode,
+    public productId?: string,
+  ) {
+    this.name = '[react-native-iap]: PurchaseError';
+    this.message = message;
+    this.responseCode = responseCode;
+    this.debugMessage = debugMessage;
+    this.code = code;
+    this.productId = productId;
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,24 +1,5 @@
 export type Sku = string;
 
-export enum IAPErrorCode {
-  E_IAP_NOT_AVAILABLE = 'E_IAP_NOT_AVAILABLE',
-  E_UNKNOWN = 'E_UNKNOWN',
-  E_USER_CANCELLED = 'E_USER_CANCELLED',
-  E_USER_ERROR = 'E_USER_ERROR',
-  E_ITEM_UNAVAILABLE = 'E_ITEM_UNAVAILABLE',
-  E_REMOTE_ERROR = 'E_REMOTE_ERROR',
-  E_NETWORK_ERROR = 'E_NETWORK_ERROR',
-  E_SERVICE_ERROR = 'E_SERVICE_ERROR',
-  E_RECEIPT_FAILED = 'E_RECEIPT_FAILED',
-  E_RECEIPT_FINISHED_FAILED = 'E_RECEIPT_FINISHED_FAILED',
-  E_NOT_PREPARED = 'E_NOT_PREPARED',
-  E_NOT_ENDED = 'E_NOT_ENDED',
-  E_ALREADY_OWNED = 'E_ALREADY_OWNED',
-  E_DEVELOPER_ERROR = 'E_DEVELOPER_ERROR',
-  E_BILLING_RESPONSE_JSON_PARSE_ERROR = 'E_BILLING_RESPONSE_JSON_PARSE_ERROR',
-  E_DEFERRED_PAYMENT = 'E_DEFERRED_PAYMENT',
-}
-
 export enum ProrationModesAndroid {
   IMMEDIATE_WITH_TIME_PRORATION = 1,
   IMMEDIATE_AND_CHARGE_PRORATED_PRICE = 2,
@@ -89,23 +70,13 @@ export interface PurchaseResult {
   message?: string;
 }
 
-export interface PurchaseError {
-  responseCode?: number;
-  debugMessage?: string;
-  code?: string;
-  message?: string;
-  productId?: string;
-}
-
-export type InAppPurchase = ProductPurchase;
-
 export interface SubscriptionPurchase extends ProductPurchase {
   autoRenewingAndroid?: boolean;
   originalTransactionDateIOS?: string;
   originalTransactionIdentifierIOS?: string;
 }
 
-export type Purchase = InAppPurchase | SubscriptionPurchase;
+export type Purchase = ProductPurchase | SubscriptionPurchase;
 
 export interface Discount {
   identifier: string;
@@ -176,24 +147,6 @@ export interface SubscriptionIOS extends ProductCommon {
 
 export type Subscription = SubscriptionAndroid & SubscriptionIOS;
 
-export interface RequestPurchaseBaseAndroid {
-  obfuscatedAccountIdAndroid?: string;
-  obfuscatedProfileIdAndroid?: string;
-  isOfferPersonalized?: boolean; // For AndroidBilling V5 https://developer.android.com/google/play/billing/integrate#personalized-price
-}
-
-export interface RequestPurchaseAndroid extends RequestPurchaseBaseAndroid {
-  skus?: Sku[];
-}
-
-export interface RequestPurchaseIOS {
-  sku?: Sku;
-  andDangerouslyFinishTransactionAutomaticallyIOS?: boolean;
-  applicationUsername?: string;
-}
-
-export type RequestPurchase = RequestPurchaseAndroid & RequestPurchaseIOS;
-
 /**
  * In order to purchase a new subscription, every sku must have a selected offerToken
  * @see SubscriptionAndroid.subscriptionOfferDetails.offerToken
@@ -202,14 +155,3 @@ export interface SubscriptionOffer {
   sku: Sku;
   offerToken: string;
 }
-
-export interface RequestSubscriptionAndroid extends RequestPurchaseBaseAndroid {
-  purchaseTokenAndroid?: string;
-  prorationModeAndroid?: ProrationModesAndroid;
-  subscriptionOffers?: SubscriptionOffer[]; // For AndroidBilling V5
-}
-
-export type RequestSubscriptionIOS = RequestPurchaseIOS;
-
-export type RequestSubscription = RequestSubscriptionAndroid &
-  RequestSubscriptionIOS;


### PR DESCRIPTION
- ci: replace publication for next branch
- refactor!: create a PurchaseError class (#1866)
- refactor!: remove support for default export (#1864)
- chore: clean up non existing errors (#1868)
- chore: move some logic into internal files (#1871)
- refactor: extract event-emitter to specific file (#1872)
- refactor!: make all methods take an object of params (#1873)
