### PR TITLE
integrate ios storekit 2

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,34 @@
+name: Publish main package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          cache: 'yarn'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Remove example code
+        run: rm -rf IapExample
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Run lint scripts
+        run: yarn lint:ci
+
+      - name: Verify no files have changed after auto-fix
+        run: git diff -- ":(exclude)IapExample/*" --exit-code HEAD
+
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,6 +6,5 @@ opt_in_rules:
   - operator_usage_whitespace
   - redundant_type_annotation
 
-indentation: 2
 vertical_whitespace_closing_braces: true
 vertical_whitespace_opening_braces: true

--- a/IapExample/ios/Podfile
+++ b/IapExample/ios/Podfile
@@ -1,7 +1,7 @@
 require_relative '../node_modules/react-native/scripts/react_native_pods'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
-platform :ios, '12.4'
+platform :ios, '15.0'
 install! 'cocoapods', :deterministic_uuids => false
 
 target 'IapExample' do

--- a/IapExample/ios/Podfile.lock
+++ b/IapExample/ios/Podfile.lock
@@ -360,7 +360,7 @@ PODS:
     - React-Core
   - RNGestureHandler (2.5.0):
     - React-Core
-  - RNIap (8.6.5):
+  - RNIap (9.0.0):
     - React-Core
   - RNScreens (3.15.0):
     - React-Core
@@ -575,12 +575,12 @@ SPEC CHECKSUMS:
   ReactCommon: e30ec17dfb1d4c4f3419eac254350d6abca6d5a2
   RNCMaskedView: cb9670ea9239998340eaab21df13fa12a1f9de15
   RNGestureHandler: bad495418bcbd3ab47017a38d93d290ebd406f50
-  RNIap: e9f648d00e693913f80bbe5b661a5257fb72fe93
+  RNIap: 95084640290f4d68559dc37f1c8424b3f7dbf5d8
   RNScreens: 4a1af06327774490d97342c00aee0c2bafb497b7
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: 7ab6e3ee4ce47d7b789d1cb520163833e515f452
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: cfed50b11ea421296640e72457dcf62114e957f6
+PODFILE CHECKSUM: 47f330ba4aa0808e88cd2a085debf346af3dc659
 
 COCOAPODS: 1.11.3

--- a/RNIap.podspec
+++ b/RNIap.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "10.0" , :tvos => "10.0"}
+  s.platforms    = { :ios => "15.0" , :tvos => "15.0"}
   s.source       = { :git => "https://github.com/dooboolab/react-native-iap.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/*.{h,m,mm,swift}"

--- a/docs/docs/usage_instructions/receipt_validation.md
+++ b/docs/docs/usage_instructions/receipt_validation.md
@@ -57,28 +57,6 @@ flow) or unstable internet connections.
 For these cases we have a convenience method `getReceiptIOS()` which gets
 the latest receipt for the app at any given time. The response is base64 encoded.
 
-### iOS Purchasing process right way.
-
-Issue regarding `valid products`
-
-- In iOS, generally you are fetching valid products at App launching process.
-
-  If you fetch again, or fetch valid subscription, the products are added to
-  the array object in iOS side (Objective-C `NSMutableArray`).
-
-  This makes unexpected behavior when you fetch with a part of product lists.
-
-  For example, if you have products of `[A, B, C]`, and you call fetch function
-  with only `[A]`, this module returns `[A, B, C]`).
-
-  This is weird, but it works.
-
-- But, weird result is weird, so we made a new method which remove all valid products.
-
-  If you need to clear all products, subscriptions in that array, just call
-  `clearProductsIOS()`, and do the fetching job again, and you will receive what
-  you expected.
-
 ### Example backend (Node.js)
 
 [Here](https://github.com/mifi/in-app-subscription-example) you can find an example backend for idempotent validating of receipts on both iOS/Android and storing and serving subscription state to the client.

--- a/ios/IapSerializationUtils.swift
+++ b/ios/IapSerializationUtils.swift
@@ -1,0 +1,112 @@
+//
+//  IapSerializationUtils.swift
+//  RNIap
+//
+//  Created by Aguilar Andres on 8/18/22.
+//
+
+import Foundation
+import StoreKit
+
+func serialize(_ p: Product) -> [String: Any?] {
+    return ["displayName": p.displayName,
+            "description": p.description,
+            "id": p.id,
+            "displayPrice": p.displayPrice,
+            "price": p.price,
+            "isFamilyShareable": p.isFamilyShareable,
+            "subscription": p.subscription?.subscriptionGroupID,
+            "jsonRepresentation": p.jsonRepresentation,
+            "debugDescription": p.debugDescription,
+            "subscription": serialize(p.subscription),
+            "type": serialize(p.type)
+    ]
+}
+
+func serialize(_ e: Error?) -> [String: Any?]? {
+    guard let e = e else {return nil}
+    return ["localizedDescription": e.localizedDescription]
+}
+
+func serialize(_ si: Product.SubscriptionInfo?) -> [String: Any?]? {
+    guard let si = si else {return nil}
+    return [
+        "subscriptionGroupID": si.subscriptionGroupID,
+        "promotionalOffers": si.promotionalOffers.map {(offer: Product.SubscriptionOffer) in serialize(offer)},
+        "introductoryOffer": serialize(si.introductoryOffer),
+        "subscriptionPeriod": si.subscriptionPeriod
+    ]
+}
+
+func serialize(_ so: Product.SubscriptionOffer?) -> [String: Any?]? {
+    guard let so = so else {return nil}
+    return [
+        "id": so.id,
+        "price": so.price,
+        "displayPrice": so.displayPrice,
+        "type": so.type,
+        "paymentMode": so.paymentMode,
+        "period": so.period,
+        "periodCount": so.periodCount
+    ]
+}
+
+// Transaction
+func serialize(_ t: Transaction) -> [String: Any?] {
+    return ["id": t.id,
+            "appBundleID": t.appBundleID,
+            "offerID": t.offerID,
+            "subscriptionGroupID": t.subscriptionGroupID,
+            "appAccountToken": t.appAccountToken,
+            "debugDescription": t.debugDescription,
+            "deviceVerification": t.deviceVerification,
+            "deviceVerificationNonce": t.deviceVerificationNonce,
+            "expirationDate": t.expirationDate,
+            "isUpgraded": t.isUpgraded,
+            "jsonRepresentation": t.jsonRepresentation,
+            "offerType": serialize(t.offerType),
+            "expirationDate": t.expirationDate,
+            "originalID": t.originalID,
+            "originalPurchaseDate": t.originalPurchaseDate,
+            "ownershipType": serialize(t.ownershipType),
+            "productType": serialize(t.productType),
+            "productID": t.productID,
+            "purchasedQuantity": t.purchasedQuantity,
+            "revocationDate": t.revocationDate,
+            "revocationReason": t.revocationReason,
+            "purchaseDate": t.purchaseDate,
+            "signedDate": t.signedDate,
+            "webOrderLineItemID": t.webOrderLineItemID
+    ]
+}
+
+func serialize(_ ot: Transaction.OfferType?) -> String? {
+    guard let ot = ot else {return nil}
+    switch ot {
+    case .promotional: return "promotional"
+    case .introductory: return "introductory"
+    case .code: return "code"
+    default:
+        return nil
+    }
+}
+func serialize(_ ot: Transaction.OwnershipType?) -> String? {
+    guard let ot = ot else {return nil}
+    switch ot {
+    case .purchased: return "purchased"
+    case .familyShared: return "familyShared"
+    default:
+        return nil
+    }
+}
+func serialize(_ pt: Product.ProductType?) -> String? {
+    guard let pt = pt else {return nil}
+    switch pt {
+    case .autoRenewable: return "autoRenewable"
+    case .consumable: return "consumable"
+    case .nonConsumable: return "nonConsumable"
+    case .nonRenewable: return "nonRenewable"
+    default:
+        return nil
+    }
+}

--- a/ios/IapTypes.swift
+++ b/ios/IapTypes.swift
@@ -1,0 +1,39 @@
+//
+//  IapTypes.swift
+//  RNIap
+//
+//  Created by Aguilar Andres on 8/18/22.
+//
+
+import Foundation
+import StoreKit
+
+typealias RNIapIosPromise = (RCTPromiseResolveBlock, RCTPromiseRejectBlock)
+
+struct ProductOrError {
+    let product: Product?
+    let error: Error?
+}
+
+public enum StoreError: Error {
+    case failedVerification
+}
+
+enum IapErrors: String, CaseIterable {
+    case E_UNKNOWN = "E_UNKNOWN"
+    case E_SERVICE_ERROR = "E_SERVICE_ERROR"
+    case E_USER_CANCELLED = "E_USER_CANCELLED"
+    case E_USER_ERROR = "E_USER_ERROR"
+    case E_ITEM_UNAVAILABLE = "E_ITEM_UNAVAILABLE"
+    case E_REMOTE_ERROR = "E_REMOTE_ERROR"
+    case E_NETWORK_ERROR = "E_NETWORK_ERROR"
+    case E_RECEIPT_FAILED = "E_RECEIPT_FAILED"
+    case E_RECEIPT_FINISHED_FAILED = "E_RECEIPT_FINISHED_FAILED"
+    case E_DEVELOPER_ERROR = "E_DEVELOPER_ERROR"
+    case E_PURCHASE_ERROR = "E_PURCHASE_ERROR"
+    case E_SYNC_ERROR = "E_SYNC_ERROR"
+    case E_DEFERRED_PAYMENT = "E_DEFERRED_PAYMENT"
+    func asInt() -> Int {
+        return IapErrors.allCases.firstIndex(of: self)!
+    }
+}

--- a/ios/IapUtils.swift
+++ b/ios/IapUtils.swift
@@ -1,0 +1,30 @@
+//
+//  IapUtils.swift
+//  RNIap
+//
+//  Created by Aguilar Andres on 8/15/22.
+//
+
+import Foundation
+import StoreKit
+
+public func debugMessage(_ object: Any...) {
+    #if DEBUG
+    for item in object {
+        print("[react-native-iap] \(item)")
+    }
+    #endif
+}
+
+func checkVerified<T>(_ result: VerificationResult<T>) throws -> T {
+    // Check whether the JWS passes StoreKit verification.
+    switch result {
+    case .unverified:
+        // StoreKit parses the JWS, but it fails verification.
+        throw StoreError.failedVerification
+
+    case .verified(let safe):
+        // The result is verified. Return the unwrapped value.
+        return safe
+    }
+}

--- a/ios/RNIapIos.m
+++ b/ios/RNIapIos.m
@@ -12,58 +12,49 @@ RCT_EXTERN_METHOD(endConnection:
                   (RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(getItems:
+RCT_EXTERN_METHOD(products:
                   (NSArray*)skus
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(getAvailableItems:
+RCT_EXTERN_METHOD(currentEntitlements:
                   (RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(buyProduct:
+RCT_EXTERN_METHOD(purchase:
                   (NSString*)sku
                   andDangerouslyFinishTransactionAutomatically:(BOOL)andDangerouslyFinishTransactionAutomatically
-                  applicationUsername:(NSString*)applicationUsername
-                  resolve:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
-RCT_EXTERN_METHOD(buyProductWithOffer:
-                  (NSString*)sku
-                  forUser:(NSString*)usernameHash
+                  appAccountToken:(NSString*)appAccountToken
+                  quantity:(NSInteger)quantity
                   withOffer:(NSDictionary*)discountOffer
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
-RCT_EXTERN_METHOD(buyProductWithQuantityIOS:
+
+RCT_EXTERN_METHOD(isEligibleForIntroOffer:
+                  (NSString*)groupID
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(currentEntitlement:
                   (NSString*)sku
-                  quantity:(NSInteger)quantity
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(clearTransaction:
-                  (RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
-
-RCT_EXTERN_METHOD(clearProducts:
-                  (RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
-
-RCT_EXTERN_METHOD(promotedProduct:
-                  (RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
-
-RCT_EXTERN_METHOD(buyPromotedProduct:(RCTPromiseResolveBlock)resolve
-                  reject:(RCTPromiseRejectBlock)reject)
-
-RCT_EXTERN_METHOD(requestReceipt:
-                  (BOOL)refresh
+RCT_EXTERN_METHOD(latestTransaction:
+                  (NSString*)sku
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(finishTransaction:
                   (NSString*)transactionIdentifier
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
-RCT_EXTERN_METHOD(getPendingTransactions:
+RCT_EXTERN_METHOD(pendingTransactions:
+                  (RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
+RCT_EXTERN_METHOD(sync:
                   (RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 

--- a/ios/RNIapIos.swift
+++ b/ios/RNIapIos.swift
@@ -1,970 +1,398 @@
+import Foundation
 import React
 import StoreKit
 
-typealias RNIapIosPromise = (RCTPromiseResolveBlock, RCTPromiseRejectBlock)
-
-public func debugMessage(_ object: Any...) {
-  #if DEBUG
-  for item in object {
-    print("[react-native-iap] \(item)")
-  }
-  #endif
-}
-
-// Based on https://stackoverflow.com/a/40135192/570612
-extension Date {
-  var millisecondsSince1970: Int64 {
-    return Int64((self.timeIntervalSince1970 * 1000.0).rounded())
-  }
-
-  var millisecondsSince1970String: String {
-    return String((self.timeIntervalSince1970 * 1000.0).rounded())
-  }
-
-  init(milliseconds: Int64) {
-    self = Date(timeIntervalSince1970: TimeInterval(milliseconds) / 1000)
-  }
-}
-
 extension SKProductsRequest {
-  var key: String {
-    return String(self.hashValue)
-  }
+    var key: String {
+        return String(self.hashValue)
+    }
 }
 
 @objc(RNIapIos)
-class RNIapIos: RCTEventEmitter, SKRequestDelegate, SKPaymentTransactionObserver, SKProductsRequestDelegate {
-  private var promisesByKey: [String: [RNIapIosPromise]]
-  private var myQueue: DispatchQueue
-  private var hasListeners = false
-  private var pendingTransactionWithAutoFinish = false
-  private var receiptBlock: ((Data?, Error?) -> Void)? // Block to handle request the receipt async from delegate
-  private var validProducts: [SKProduct]
-  private var promotedPayment: SKPayment?
-  private var promotedProduct: SKProduct?
-  private var productsRequest: SKProductsRequest?
-  private var countPendingTransaction: Int = 0
-  private var hasTransactionObserver = false
+class RNIapIos: RCTEventEmitter, SKRequestDelegate {
+    private var hasListeners = false
+    private var products: [String: Product]
+    private var transactions: [String: Transaction]
+    private var updateListenerTask: Task<Void, Error>?
 
-  override init() {
-    promisesByKey = [String: [RNIapIosPromise]]()
-    pendingTransactionWithAutoFinish = false
-    myQueue = DispatchQueue(label: "reject")
-    validProducts = [SKProduct]()
-    super.init()
-    addTransactionObserver()
-  }
-
-  deinit {
-    removeTransactionObserver()
-  }
-
-  override class func requiresMainQueueSetup() -> Bool {
-    return true
-  }
-
-  func addTransactionObserver() {
-    if !hasTransactionObserver {
-      hasTransactionObserver = true
-      SKPaymentQueue.default().add(self)
-    }
-  }
-
-  func removeTransactionObserver() {
-    if hasTransactionObserver {
-      hasTransactionObserver = false
-      SKPaymentQueue.default().remove(self)
-    }
-  }
-
-  func flushUnheardEvents() {
-    paymentQueue(SKPaymentQueue.default(), updatedTransactions: SKPaymentQueue.default().transactions)
-  }
-
-  override func startObserving() {
-    hasListeners = true
-    flushUnheardEvents()
-  }
-
-  override func stopObserving() {
-    hasListeners = false
-  }
-
-  override func addListener(_ eventName: String?) {
-    super.addListener(eventName)
-
-    if (eventName == "iap-promoted-product") && promotedPayment != nil {
-      sendEvent(withName: "iap-promoted-product", body: promotedPayment?.productIdentifier)
-    }
-  }
-
-  func addPromise(forKey key: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-    var promises: [RNIapIosPromise]? = promisesByKey[key]
-
-    if promises == nil {
-      promises = []
+    override init() {
+        products = [String: Product]()
+        transactions = [String: Transaction]()
+        super.init()
+        addTransactionObserver()
     }
 
-    promises?.append((resolve, reject))
-    promisesByKey[key] = promises
-  }
-
-  func resolvePromises(forKey key: String?, value: Any?) {
-    let promises: [RNIapIosPromise]? = promisesByKey[key ?? ""]
-
-    if let promises = promises {
-      for tuple in promises {
-        let resolveBlck = tuple.0
-        resolveBlck(value)
-      }
-      promisesByKey[key ?? ""] = nil
+    deinit {
+        removeTransactionObserver()
     }
-  }
 
-  func rejectPromises(forKey key: String, code: String?, message: String?, error: Error?) {
-    let promises = promisesByKey[key]
-
-    if let promises = promises {
-      for tuple in promises {
-        let reject = tuple.1
-        reject(code, message, error)
-      }
-      promisesByKey[key] = nil
+    override class func requiresMainQueueSetup() -> Bool {
+        return true
     }
-  }
-
-  func paymentQueue(_ queue: SKPaymentQueue, shouldAddStorePayment payment: SKPayment, for product: SKProduct) -> Bool {
-    promotedProduct = product
-    promotedPayment = payment
-
-    if hasListeners {
-      sendEvent(withName: "iap-promoted-product", body: product.productIdentifier)
-    }
-    return false
-  }
-
-  override func supportedEvents() -> [String]? {
-    return ["iap-promoted-product", "purchase-updated", "purchase-error"]
-  }
-
-  @objc public func initConnection(
-    _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
-    reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
-  ) {
-    addTransactionObserver()
-    let canMakePayments = SKPaymentQueue.canMakePayments()
-    resolve(NSNumber(value: canMakePayments))
-  }
-  @objc public func endConnection(
-    _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
-    reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
-  ) {
-    removeTransactionObserver()
-    resolve(nil)
-  }
-  @objc public func getItems(
-    _ skus: [String],
-    resolve: @escaping RCTPromiseResolveBlock = { _ in },
-    reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
-  ) {
-    let productIdentifiers = Set<AnyHashable>(skus)
-    if let productIdentifiers = productIdentifiers as? Set<String> {
-      productsRequest = SKProductsRequest(productIdentifiers: productIdentifiers)
-      if let productsRequest = productsRequest {
-        productsRequest.delegate = self
-        let key: String = productsRequest.key
-        addPromise(forKey: key, resolve: resolve, reject: reject)
-        productsRequest.start()
-      }
-    }
-  }
-  @objc public func getAvailableItems(
-    _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
-    reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
-  ) {
-    addPromise(forKey: "availableItems", resolve: resolve, reject: reject)
-    SKPaymentQueue.default().restoreCompletedTransactions()
-  }
-
-  @objc public func buyProduct(
-    _ sku: String,
-    andDangerouslyFinishTransactionAutomatically: Bool,
-    applicationUsername: String?,
-    resolve: @escaping RCTPromiseResolveBlock = { _ in },
-    reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
-  ) {
-    pendingTransactionWithAutoFinish = andDangerouslyFinishTransactionAutomatically
-    var product: SKProduct?
-    let lockQueue = DispatchQueue(label: "validProducts")
-    lockQueue.sync {
-      for p in validProducts {
-        if sku == p.productIdentifier {
-          product = p
-          break
+    func addTransactionObserver() {
+        if updateListenerTask == nil {
+            updateListenerTask = listenForTransactions()
         }
-      }
     }
-    if let prod = product {
-      addPromise(forKey: prod.productIdentifier, resolve: resolve, reject: reject)
 
-      let payment = SKMutablePayment(product: prod)
-
-      if let applicationUsername = applicationUsername {
-        payment.applicationUsername = applicationUsername
-      }
-      SKPaymentQueue.default().add(payment)
-    } else {
-      if hasListeners {
-        let err = [
-          "debugMessage": "Invalid product ID.",
-          "code": "E_DEVELOPER_ERROR",
-          "message": "Invalid product ID.",
-          "productId": sku
-        ]
-
-        sendEvent(withName: "purchase-error", body: err)
-      }
-
-      reject("E_DEVELOPER_ERROR", "Invalid product ID.", nil)
+    func removeTransactionObserver() {
+        updateListenerTask?.cancel()
+        updateListenerTask = nil
     }
-  }
 
-  @objc public func buyProductWithOffer(
-    _ sku: String,
-    forUser usernameHash: String,
-    withOffer discountOffer: [String: String],
-    resolve: @escaping RCTPromiseResolveBlock = { _ in },
-    reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
-  ) {
-    var product: SKProduct?
-    let lockQueue = DispatchQueue(label: "validProducts")
-    lockQueue.sync {
-      for p in validProducts {
-        if sku == p.productIdentifier {
-          product = p
-          break
+    func addTransaction(_ transaction: Transaction) {
+        let transactionId = String(transaction.id)
+        self.transactions[transactionId] = transaction
+    }
+
+    func listenForTransactions() -> Task<Void, Error> {
+        return Task.detached {
+            // Iterate through any transactions that don't come from a direct call to `purchase()`.
+            for await result in Transaction.updates {
+                do {
+                    let transaction = try checkVerified(result)
+                    self.addTransaction(transaction)
+                    // Deliver products to the user.
+                    // await self.updateCustomerProductStatus()
+
+                    if self.hasListeners {
+                        self.sendEvent(withName: "transaction-updated", body: ["transaction": serialize(transaction)])
+                    }
+                    // Always finish a transaction.
+                    // await transaction.finish() //TODO: Document
+                } catch {
+                    // StoreKit has a transaction that fails verification. Don't deliver content to the user.
+                    debugMessage("Transaction failed verification")
+                    if self.hasListeners {
+                        let err = [
+                            "responseCode": "-1",
+                            "debugMessage": error.localizedDescription,
+                            "code": "E_RECEIPT_FINISHED_FAILED",
+                            "message": error.localizedDescription
+                        ]
+
+                        self.sendEvent(withName: "transaction-updated", body: ["error": err])
+                    }
+                }
+            }
         }
-      }
     }
 
-    if let prod = product {
-      addPromise(forKey: prod.productIdentifier, resolve: resolve, reject: reject)
-
-      let payment = SKMutablePayment(product: prod)
-
-      if #available(iOS 12.2, tvOS 12.2, *) {
-        let discount = SKPaymentDiscount(
-          identifier: discountOffer["identifier"]!,
-          keyIdentifier: discountOffer["keyIdentifier"]!,
-          nonce: UUID(uuidString: discountOffer["nonce"]!)!,
-          signature: discountOffer["signature"]!,
-          timestamp: NSNumber(value: Int(discountOffer["timestamp"]!)!))
-        payment.paymentDiscount = discount
-      }
-      payment.applicationUsername = usernameHash
-      SKPaymentQueue.default().add(payment)
-    } else {
-      if hasListeners {
-        let err = [
-          "debugMessage": "Invalid product ID.",
-          "message": "Invalid product ID.",
-          "code": "E_DEVELOPER_ERROR",
-          "productId": sku
-        ]
-        sendEvent(withName: "purchase-error", body: err)
-      }
-      reject("E_DEVELOPER_ERROR", "Invalid product ID.", nil)
+    override func startObserving() {
+        hasListeners = true
     }
-  }
 
-  @objc public func buyProductWithQuantityIOS(
-    _ sku: String,
-    quantity: Int,
-    resolve: @escaping RCTPromiseResolveBlock = { _ in },
-    reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
-  ) {
-    debugMessage("buyProductWithQuantityIOS")
-    var product: SKProduct?
-    let lockQueue = DispatchQueue(label: "validProducts")
-    lockQueue.sync {
-      for p in validProducts {
-        if sku == p.productIdentifier {
-          product = p
-          break
+    override func stopObserving() {
+        hasListeners = false
+    }
+    override func addListener(_ eventName: String?) {
+        super.addListener(eventName)
+    }
+
+    override func supportedEvents() -> [String]? {
+        return [ "transaction-updated"]
+    }
+
+    @objc public func initConnection(
+        _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
+        reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
+    ) {
+        addTransactionObserver()
+        resolve(AppStore.canMakePayments)
+    }
+    @objc public func endConnection(
+        _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
+        reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
+    ) {
+        updateListenerTask?.cancel()
+        updateListenerTask = nil
+        resolve(nil)
+    }
+
+    @objc public func products( // TODO: renamed from getItems
+        _ skus: [String],
+        resolve: @escaping RCTPromiseResolveBlock = { _ in },
+        reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
+    ) async {
+        do {
+            let products: [[String: Any?]] = try await Product.products(for: skus).map({ (prod: Product) -> [String: Any?]? in
+                return serialize(prod)
+            }).compactMap({$0})
+            resolve(products)
+        } catch {
+            reject(IapErrors.E_UNKNOWN.rawValue, "Error fetching items", error)
         }
-      }
-    }
-    if let prod = product {
-      let payment = SKMutablePayment(product: prod)
-      payment.quantity = quantity
-      SKPaymentQueue.default().add(payment)
-    } else {
-      if hasListeners {
-        let err = [
-          "debugMessage": "Invalid product ID.",
-          "message": "Invalid product ID.",
-          "code": "E_DEVELOPER_ERROR",
-          "productId": sku
-        ]
-        sendEvent(withName: "purchase-error", body: err)
-      }
-      reject("E_DEVELOPER_ERROR", "Invalid product ID.", nil)
-    }
-  }
-
-  @objc public func clearTransaction(
-    _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
-    reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
-  ) {
-    let pendingTrans = SKPaymentQueue.default().transactions
-    countPendingTransaction = pendingTrans.count
-
-    debugMessage("clear remaining Transactions (\(countPendingTransaction)). Call this before make a new transaction")
-
-    if countPendingTransaction > 0 {
-      addPromise(forKey: "cleaningTransactions", resolve: resolve, reject: reject)
-      for transaction in pendingTrans {
-        SKPaymentQueue.default().finishTransaction(transaction)
-      }
-    } else {
-      resolve(nil)
-    }
-  }
-
-  @objc public func clearProducts(
-    _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
-    reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
-  ) {
-    debugMessage("clear valid products")
-
-    let lockQueue = DispatchQueue(label: "validProducts")
-
-    lockQueue.sync {
-      validProducts.removeAll()
     }
 
-    resolve(nil)
-  }
+    @objc public func currentEntitlements( // TODO: renamed from getAvailableItems
+        _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
+        reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
+    ) async {
+        var purchasedItems: [ProductOrError] = []
+        // Iterate through all of the user's purchased products.
+        for await result in Transaction.currentEntitlements {
+            do {
+                // Check whether the transaction is verified. If it isn’t, catch `failedVerification` error.
+                let transaction = try checkVerified(result)
+                // Check the `productType` of the transaction and get the corresponding product from the store.
+                switch transaction.productType {
+                case .nonConsumable:
+                    if let product = products[transaction.productID] {
+                        purchasedItems.append(ProductOrError(product: product, error: nil))
+                    }
 
-  @objc public func  promotedProduct(
-    _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
-    reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
-  ) {
-    debugMessage("get promoted product")
-    resolve((promotedProduct != nil) ? getProductObject(promotedProduct!) : nil)
-  }
+                case .nonRenewable:
+                    if let nonRenewable = products[transaction.productID] {
+                        // Non-renewing subscriptions have no inherent expiration date, so they're always
+                        // contained in `Transaction.currentEntitlements` after the user purchases them.
+                        // This app defines this non-renewing subscription's expiration date to be one year after purchase.
+                        // If the current date is within one year of the `purchaseDate`, the user is still entitled to this
+                        // product.
+                        let currentDate = Date()
+                        let expirationDate = Calendar(identifier: .gregorian).date(byAdding: DateComponents(year: 1),
+                                                                                   to: transaction.purchaseDate)!
 
-  @objc public func  buyPromotedProduct(
-    _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
-    reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
-  ) {
-    if let promoPayment = promotedPayment {
-      debugMessage("buy promoted product")
-      SKPaymentQueue.default().add(promoPayment)
-    } else {
-      reject("E_DEVELOPER_ERROR", "Invalid product ID.", nil)
-    }
-  }
+                        if currentDate < expirationDate {
+                            purchasedItems.append(ProductOrError(product: nonRenewable, error: nil))
+                        }
+                    }
 
-  @objc public func  requestReceipt(
-    _ refresh: Bool,
-    resolve: @escaping RCTPromiseResolveBlock = { _ in },
-    reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
-  ) {
-    requestReceiptData(withBlock: refresh) { [self] receiptData, error in
-      if error == nil {
-        resolve(receiptData?.base64EncodedString(options: []))
-      } else {
-        reject(standardErrorCode(9), "Invalid receipt", nil)
-      }
-    }
-  }
+                case .autoRenewable:
+                    if let subscription = products[transaction.productID] {
+                        purchasedItems.append(ProductOrError(product: subscription, error: nil))
+                    }
 
-  @objc public func  finishTransaction(
-    _ transactionIdentifier: String,
-    resolve: @escaping RCTPromiseResolveBlock = { _ in },
-    reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
-  ) {
-    finishTransaction(withIdentifier: transactionIdentifier)
-    resolve(nil)
-  }
-
-  @objc public func getPendingTransactions (
-    _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
-    reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
-  ) {
-    requestReceiptData(withBlock: false) { receiptData, _ in
-      var output: [AnyHashable] = []
-
-      if let receipt = receiptData {
-        let transactions = SKPaymentQueue.default().transactions
-
-        for item in transactions {
-          let timestamp = item.transactionDate?.millisecondsSince1970 == nil ? nil : String(item.transactionDate!.millisecondsSince1970)
-          let purchase = [
-            "transactionDate": timestamp,
-            "transactionId": item.transactionIdentifier,
-            "productId": item.payment.productIdentifier,
-            "quantity": "\(item.payment.quantity)",
-            "transactionReceipt": receipt.base64EncodedString(options: [])
-          ]
-
-          output.append(purchase)
-        }
-      }
-
-      resolve(output)
-    }
-  }
-
-  @objc public func  presentCodeRedemptionSheet(
-    _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
-    reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
-  ) {
-    #if !os(tvOS)
-    if #available(iOS 14.0, tvOS 14.0, *) {
-      SKPaymentQueue.default().presentCodeRedemptionSheet()
-      resolve(nil)
-    } else {
-      reject(standardErrorCode(2), "This method only available above iOS 14", nil)
-    }
-    #else
-    reject(standardErrorCode(2), "This method is not available on tvOS", nil)
-    #endif
-  }
-
-  // StoreKitDelegate
-  func productsRequest(_ request: SKProductsRequest, didReceive response: SKProductsResponse) {
-    for prod in response.products {
-      add(prod)
-    }
-
-    var items: [[String: Any?]] = [[:]]
-    let lockQueue = DispatchQueue(label: "validProducts")
-
-    lockQueue.sync {
-      for product in validProducts {
-        items.append(getProductObject(product))
-      }
-    }
-
-    resolvePromises(forKey: request.key, value: items)
-  }
-
-  // Add to valid products from Apple server response. Allowing getProducts, getSubscriptions call several times.
-  // Doesn't allow duplication. Replace new product.
-  func add(_ aProd: SKProduct) {
-    let lockQueue = DispatchQueue(label: "validProducts")
-
-    lockQueue.sync {
-      debugMessage("Add new object: \(aProd.productIdentifier)")
-      var delTar = -1
-
-      for k in 0..<validProducts.count {
-        let cur = validProducts[k]
-        if cur.productIdentifier == aProd.productIdentifier {
-          delTar = k
-        }
-      }
-
-      if delTar >= 0 {
-        validProducts.remove(at: delTar)
-      }
-
-      validProducts.append(aProd)
-    }
-  }
-
-  func request(_ request: SKRequest, didFailWithError error: Error) {
-    let nsError = error as NSError
-
-    if request is SKReceiptRefreshRequest {
-      if let unwrappedReceiptBlock = receiptBlock {
-        let standardError = NSError(domain: nsError.domain, code: 9, userInfo: nsError.userInfo)
-        unwrappedReceiptBlock(nil, standardError)
-        receiptBlock = nil
-        return
-      } else {
-        if let key: String = productsRequest?.key {
-          myQueue.sync(execute: { [self] in
-                        rejectPromises(
-                          forKey: key,
-                          code: standardErrorCode(nsError.code),
-                          message: error.localizedDescription,
-                          error: error)}
-          )
-        }
-      }
-    }
-  }
-
-  func paymentQueue(_ queue: SKPaymentQueue, updatedTransactions transactions: [SKPaymentTransaction]) {
-    for transaction in transactions {
-      switch transaction.transactionState {
-      case .purchasing:
-        debugMessage("Purchase Started")
-        break
-
-      case .purchased:
-        debugMessage("Purchase Successful")
-        purchaseProcess(transaction)
-        break
-
-      case .restored:
-        debugMessage("Restored")
-        SKPaymentQueue.default().finishTransaction(transaction)
-        break
-
-      case .deferred:
-        debugMessage("Deferred (awaiting approval via parental controls, etc.)")
-
-        myQueue.sync(execute: { [self] in
-          if hasListeners {
-            let err = [
-              "debugMessage": "The payment was deferred (awaiting approval via parental controls for instance)",
-              "code": "E_DEFERRED_PAYMENT",
-              "message": "The payment was deferred (awaiting approval via parental controls for instance)",
-              "productId": transaction.payment.productIdentifier,
-              "quantity": "\(transaction.payment.quantity)"
-            ]
-
-            sendEvent(withName: "purchase-error", body: err)
-          }
-
-          rejectPromises(
-            forKey: transaction.payment.productIdentifier,
-            code: "E_DEFERRED_PAYMENT",
-            message: "The payment was deferred (awaiting approval via parental controls for instance)",
-            error: nil)
-        })
-
-      case .failed:
-        debugMessage("Purchase Failed")
-
-        SKPaymentQueue.default().finishTransaction(transaction)
-
-        myQueue.sync(execute: { [self] in
-          let nsError = transaction.error as NSError?
-
-          if hasListeners {
-            let code = nsError?.code
-            let responseCode = String(code ?? 0)
-            let err = [
-              "responseCode": responseCode,
-              "debugMessage": transaction.error?.localizedDescription,
-              "code": standardErrorCode(code),
-              "message": transaction.error?.localizedDescription,
-              "productId": transaction.payment.productIdentifier
-            ]
-
-            sendEvent(withName: "purchase-error", body: err)
-          }
-
-          rejectPromises(
-            forKey: transaction.payment.productIdentifier,
-            code: standardErrorCode(nsError?.code),
-            message: nsError?.localizedDescription,
-            error: nsError)
-        })
-
-        break
-      }
-    }
-  }
-
-  func finishTransaction(withIdentifier transactionIdentifier: String?) {
-    let queue = SKPaymentQueue.default()
-
-    for transaction in queue.transactions {
-      if transaction.transactionIdentifier == transactionIdentifier {
-        SKPaymentQueue.default().finishTransaction(transaction)
-      }
-    }
-  }
-
-  func paymentQueueRestoreCompletedTransactionsFinished(_ queue: SKPaymentQueue) {
-    debugMessage("PaymentQueueRestoreCompletedTransactionsFinished")
-    var items = [[String: Any?]]()
-
-    for transaction in queue.transactions {
-      if transaction.transactionState == .restored || transaction.transactionState == .purchased {
-        getPurchaseData(transaction) { restored in
-          if let restored = restored {
-            items.append(restored)
-          }
-
-          SKPaymentQueue.default().finishTransaction(transaction)
-        }
-      }
-    }
-
-    resolvePromises(forKey: "availableItems", value: items)
-  }
-
-  func paymentQueue(_ queue: SKPaymentQueue, restoreCompletedTransactionsFailedWithError error: Error) {
-    myQueue.sync(execute: { [self] in
-      rejectPromises(
-        forKey: "availableItems",
-        code: standardErrorCode((error as NSError).code),
-        message: error.localizedDescription,
-        error: error)
-    })
-
-    debugMessage("restoreCompletedTransactionsFailedWithError")
-  }
-
-  func purchaseProcess(_ transaction: SKPaymentTransaction) {
-    if pendingTransactionWithAutoFinish {
-      SKPaymentQueue.default().finishTransaction(transaction)
-      pendingTransactionWithAutoFinish = false
-    }
-
-    getPurchaseData(transaction) { [self] purchase in
-      resolvePromises(forKey: transaction.payment.productIdentifier, value: purchase)
-
-      // additionally send event
-      if hasListeners {
-        sendEvent(withName: "purchase-updated", body: purchase)
-      }
-    }
-  }
-
-  func standardErrorCode(_ code: Int?) -> String? {
-    let descriptions = [
-      "E_UNKNOWN",
-      "E_SERVICE_ERROR",
-      "E_USER_CANCELLED",
-      "E_USER_ERROR",
-      "E_USER_ERROR",
-      "E_ITEM_UNAVAILABLE",
-      "E_REMOTE_ERROR",
-      "E_NETWORK_ERROR",
-      "E_SERVICE_ERROR",
-      "E_RECEIPT_FAILED",
-      "E_RECEIPT_FINISHED_FAILED"
-    ]
-
-    guard let code = code else {
-      return descriptions[0]
-    }
-
-    if code > descriptions.count - 1 || code < 0 { // Fix crash app without internet connection
-      return descriptions[0]
-    }
-
-    return descriptions[code]
-  }
-
-  func getProductObject(_ product: SKProduct) -> [String: Any?] {
-    let formatter = NumberFormatter()
-    formatter.numberStyle = .currency
-    formatter.locale = product.priceLocale
-
-    let localizedPrice = formatter.string(from: product.price)
-    var introductoryPrice = localizedPrice
-    var introductoryPriceAsAmountIOS = "\(product.price)"
-
-    var introductoryPricePaymentMode = ""
-    var introductoryPriceNumberOfPeriods = ""
-
-    var introductoryPriceSubscriptionPeriod = ""
-
-    var currencyCode: String? = ""
-    var countryCode: String? = ""
-    var periodNumberIOS = "0"
-    var periodUnitIOS = ""
-    var itemType = "iap"
-
-    if #available(iOS 11.2, tvOS 11.2, *) {
-      let numOfUnits = UInt(product.subscriptionPeriod?.numberOfUnits ?? 0)
-      let unit = product.subscriptionPeriod?.unit
-
-      if unit == .year {
-        periodUnitIOS = "YEAR"
-      } else if unit == .month {
-        periodUnitIOS = "MONTH"
-      } else if unit == .week {
-        periodUnitIOS = "WEEK"
-      } else if unit == .day {
-        periodUnitIOS = "DAY"
-      }
-
-      periodNumberIOS = String(format: "%lu", numOfUnits)
-      if numOfUnits != 0 {
-        itemType = "subs"
-      }
-
-      // subscriptionPeriod = product.subscriptionPeriod ? [product.subscriptionPeriod stringValue] : @"";
-      // introductoryPrice = product.introductoryPrice != nil ? [NSString stringWithFormat:@"%@", product.introductoryPrice] : @"";
-      if product.introductoryPrice != nil {
-        formatter.locale = product.introductoryPrice?.priceLocale
-
-        if let price = product.introductoryPrice?.price {
-          introductoryPrice = formatter.string(from: price)
+                default:
+                    break
+                }
+            } catch StoreError.failedVerification {
+                purchasedItems.append(ProductOrError(product: nil, error: StoreError.failedVerification))
+            } catch {
+                debugMessage(error)
+                purchasedItems.append(ProductOrError(product: nil, error: error))
+            }
         }
 
-        introductoryPriceAsAmountIOS = product.introductoryPrice?.price.stringValue ?? ""
+        // Check the `subscriptionGroupStatus` to learn the auto-renewable subscription state to determine whether the customer
+        // is new (never subscribed), active, or inactive (expired subscription). This app has only one subscription
+        // group, so products in the subscriptions array all belong to the same group. The statuses that
+        // `product.subscription.status` returns apply to the entire subscription group.
+        // subscriptionGroupStatus = try? await subscriptions.first?.subscription?.status.first?.state
+        resolve(purchasedItems.map({(p: ProductOrError) in ["product": p.product.flatMap { serialize($0)}, "error": serialize(p.error)]}))
+    }
 
-        switch product.introductoryPrice?.paymentMode {
-        case .freeTrial:
-          introductoryPricePaymentMode = "FREETRIAL"
-          introductoryPriceNumberOfPeriods = NSNumber(value: product.introductoryPrice?.subscriptionPeriod.numberOfUnits ?? 0).stringValue
+    @objc public func purchase( // TODO: renamed from buyProduct
+        _ sku: String,
+        andDangerouslyFinishTransactionAutomatically: Bool,
+        appAccountToken: String?,
+        quantity: Int,
+        withOffer discountOffer: [String: String],
+        resolve: @escaping RCTPromiseResolveBlock = { _ in },
+        reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
+    ) async {
+        let product: Product? = products[sku]
 
-        case .payAsYouGo:
-          introductoryPricePaymentMode = "PAYASYOUGO"
-          introductoryPriceNumberOfPeriods = NSNumber(value: product.introductoryPrice?.numberOfPeriods ?? 0).stringValue
+        if let product = product {
+            do {
+                var options: Set<Product.PurchaseOption> = []
+                if quantity > -1 {
+                    options.insert(.quantity(quantity))
+                }
 
-        case .payUpFront:
-          introductoryPricePaymentMode = "PAYUPFRONT"
-          introductoryPriceNumberOfPeriods = NSNumber(value: product.introductoryPrice?.subscriptionPeriod.numberOfUnits ?? 0).stringValue
+                let offerID = discountOffer["offerID"] // TODO: Adjust JS to match these new names
+                let keyID = discountOffer["keyID"]
+                let nonce = discountOffer["nonce"]
+                let signature = discountOffer["signature"]
+                let timestamp = discountOffer["timestamp"]
 
-        default:
-          introductoryPricePaymentMode = ""
-          introductoryPriceNumberOfPeriods = "0"
-        }
+                if let offerID = offerID, let keyID = keyID, let nonce = nonce, let nonce = UUID(uuidString: nonce), let signature = signature, let signature = signature.data(using: .utf8), let timestamp = timestamp, let timestamp = Int(timestamp) {
+                    options.insert(.promotionalOffer(offerID: offerID, keyID: keyID, nonce: nonce, signature: signature, timestamp: timestamp ))
+                }
+                if let appAccountToken = appAccountToken, let appAccountToken = UUID(uuidString: appAccountToken) {
+                    options.insert(.appAccountToken(appAccountToken))
+                }
+                debugMessage("Purchase Started")
 
-        if product.introductoryPrice?.subscriptionPeriod.unit == .day {
-          introductoryPriceSubscriptionPeriod = "DAY"
-        } else if product.introductoryPrice?.subscriptionPeriod.unit == .week {
-          introductoryPriceSubscriptionPeriod = "WEEK"
-        } else if product.introductoryPrice?.subscriptionPeriod.unit == .month {
-          introductoryPriceSubscriptionPeriod = "MONTH"
-        } else if product.introductoryPrice?.subscriptionPeriod.unit == .year {
-          introductoryPriceSubscriptionPeriod = "YEAR"
+                let result = try await product.purchase(options: options)
+                switch result {
+                case .success(let verification):
+                    debugMessage("Purchase Successful")
+
+                    // Check whether the transaction is verified. If it isn't,
+                    // this function rethrows the verification error.
+                    let transaction = try checkVerified(verification)
+
+                    // The transaction is verified. Deliver content to the user.
+                    // Do on JS :await updateCustomerProductStatus()
+
+                    // Always finish a transaction.
+                    if andDangerouslyFinishTransactionAutomatically {
+                        await transaction.finish()
+                        resolve(nil)
+                    } else {
+                        self.addTransaction(transaction)
+                        resolve(serialize(transaction))
+                    }
+                    return
+
+                case .userCancelled, .pending:
+                    debugMessage("Deferred (awaiting approval via parental controls, etc.)")
+
+                    let err = [
+                        "debugMessage": "The payment was deferred (awaiting approval via parental controls for instance)",
+                        "code": IapErrors.E_DEFERRED_PAYMENT.rawValue,
+                        "message": "The payment was deferred (awaiting approval via parental controls for instance)",
+                        "productId": sku,
+                        "quantity": "\(quantity)"
+                    ]
+                    debugMessage(err)
+
+                    reject(
+                        IapErrors.E_DEFERRED_PAYMENT.rawValue,
+                        "The payment was deferred for \(sku) (awaiting approval via parental controls for instance)",
+                        nil)
+
+                    return
+
+                default:
+                    reject(IapErrors.E_UNKNOWN.rawValue, "Unknown response from purchase", nil)
+                    return
+                }
+            } catch {
+                debugMessage("Purchase Failed")
+
+                let err = [
+                    "responseCode": IapErrors.E_PURCHASE_ERROR.rawValue,
+                    "debugMessage": error.localizedDescription,
+                    "message": error.localizedDescription,
+                    "productId": sku
+                ]
+                print(err)
+
+                reject(
+                    IapErrors.E_UNKNOWN.rawValue,
+                    "Purchased failed for sku:\(sku): \(error.localizedDescription)",
+                    error)
+            }
         } else {
-          introductoryPriceSubscriptionPeriod = ""
+            reject("E_DEVELOPER_ERROR", "Invalid product ID.", nil)
         }
-      } else {
-        introductoryPrice = ""
-        introductoryPriceAsAmountIOS = ""
-        introductoryPricePaymentMode = ""
-        introductoryPriceNumberOfPeriods = ""
-        introductoryPriceSubscriptionPeriod = ""
-      }
     }
 
-    if #available(iOS 10.0, tvOS 10.0, *) {
-      currencyCode = product.priceLocale.currencyCode
+    @objc public func isEligibleForIntroOffer( // TODO: new method
+        _ groupID: String,
+        resolve: @escaping RCTPromiseResolveBlock = { _ in },
+        reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
+    ) async {
+        let isEligibleForIntroOffer = await Product.SubscriptionInfo.isEligibleForIntroOffer(for: groupID)
+        resolve(isEligibleForIntroOffer)
     }
 
-    if #available(iOS 13.0, tvOS 13.0, *) {
-      countryCode = SKPaymentQueue.default().storefront?.countryCode
-    } else if #available(iOS 10.0, tvOS 10.0, *) {
-      countryCode = product.priceLocale.regionCode
-    }
-
-    var discounts: [[String: String?]]?
-
-    if #available(iOS 12.2, tvOS 12.2, *) {
-      discounts = getDiscountData(product)
-    }
-
-    let obj: [String: Any?] = [
-      "productId": product.productIdentifier,
-      "price": "\(product.price)",
-      "currency": currencyCode,
-      "countryCode": countryCode ?? "",
-      "type": itemType,
-      "title": product.localizedTitle != "" ? product.localizedTitle : "",
-      "description": product.localizedDescription != "" ? product.localizedDescription : "",
-      "localizedPrice": localizedPrice,
-      "subscriptionPeriodNumberIOS": periodNumberIOS,
-      "subscriptionPeriodUnitIOS": periodUnitIOS,
-      "introductoryPrice": introductoryPrice,
-      "introductoryPriceAsAmountIOS": introductoryPriceAsAmountIOS,
-      "introductoryPricePaymentModeIOS": introductoryPricePaymentMode,
-      "introductoryPriceNumberOfPeriodsIOS": introductoryPriceNumberOfPeriods,
-      "introductoryPriceSubscriptionPeriodIOS": introductoryPriceSubscriptionPeriod,
-      "discounts": discounts
-    ]
-
-    return obj
-  }
-
-  func getDiscountData(_ product: SKProduct) -> [[String: String?]]? {
-    if #available(iOS 12.2, tvOS 12.2, *) {
-      var mappedDiscounts: [[String: String?]] = []
-      var localizedPrice: String?
-      var paymendMode: String?
-      var subscriptionPeriods: String?
-      var discountType: String?
-
-      for discount in product.discounts {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .currency
-        let priceLocale: Locale? = discount.priceLocale
-        if let pLocale = priceLocale {
-          formatter.locale = pLocale
+    @objc public func subscriptionStatus( // TODO: new method
+        _ sku: String,
+        resolve: @escaping RCTPromiseResolveBlock = { _ in },
+        reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
+    ) async {
+        do {
+            let status = try await products[sku]?.subscription?.status
+            resolve(status)
+        } catch {
+            reject("", "", error)
         }
-        localizedPrice = formatter.string(from: discount.price)
-        var numberOfPeriods: String?
+    }
 
-        switch discount.paymentMode {
-        case .freeTrial:
-          paymendMode = "FREETRIAL"
-          numberOfPeriods = NSNumber(value: discount.subscriptionPeriod.numberOfUnits ).stringValue
-          break
-
-        case .payAsYouGo:
-          paymendMode = "PAYASYOUGO"
-          numberOfPeriods = NSNumber(value: discount.numberOfPeriods).stringValue
-          break
-
-        case .payUpFront:
-          paymendMode = "PAYUPFRONT"
-          numberOfPeriods = NSNumber(value: discount.subscriptionPeriod.numberOfUnits ).stringValue
-          break
-
-        default:
-          paymendMode = ""
-          numberOfPeriods = "0"
-          break
+    @objc public func currentEntitlement( // TODO: new method
+        _ sku: String,
+        resolve: @escaping RCTPromiseResolveBlock = { _ in },
+        reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
+    ) async {
+        if let product = products[sku] {
+            if let result = await product.currentEntitlement {
+                do {
+                    // Check whether the transaction is verified. If it isn’t, catch `failedVerification` error.
+                    let transaction = try checkVerified(result)
+                    resolve(serialize(transaction))
+                } catch StoreError.failedVerification {
+                    reject(IapErrors.E_UNKNOWN.rawValue, "Failed to verify transaction for sku \(sku)", StoreError.failedVerification)
+                } catch {
+                    debugMessage(error)
+                    reject(IapErrors.E_UNKNOWN.rawValue, "Error fetching entitlement for sku \(sku)", error)
+                }
+            } else {
+                reject(IapErrors.E_DEVELOPER_ERROR.rawValue, "Can't find entitlement for sku \(sku)", nil)
+            }
+        } else {
+            reject(IapErrors.E_DEVELOPER_ERROR.rawValue, "Can't find product for sku \(sku)", nil)
         }
+    }
 
-        switch discount.subscriptionPeriod.unit {
-        case .day:
-          subscriptionPeriods = "DAY"
-
-        case .week:
-          subscriptionPeriods = "WEEK"
-
-        case .month:
-          subscriptionPeriods = "MONTH"
-
-        case .year:
-          subscriptionPeriods = "YEAR"
-
-        default:
-          subscriptionPeriods = ""
+    @objc public func latestTransaction( // TODO: new method
+        _ sku: String,
+        resolve: @escaping RCTPromiseResolveBlock = { _ in },
+        reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
+    ) async {
+        if let product = products[sku] {
+            if let result = await product.latestTransaction {
+                do {
+                    // Check whether the transaction is verified. If it isn’t, catch `failedVerification` error.
+                    let transaction = try checkVerified(result)
+                    resolve(serialize(transaction))
+                } catch StoreError.failedVerification {
+                    reject(IapErrors.E_UNKNOWN.rawValue, "Failed to verify transaction for sku \(sku)", StoreError.failedVerification)
+                } catch {
+                    debugMessage(error)
+                    reject(IapErrors.E_UNKNOWN.rawValue, "Error fetching latest transaction for sku \(sku)", error)
+                }
+            } else {
+                reject(IapErrors.E_DEVELOPER_ERROR.rawValue, "Can't find latest transaction for sku \(sku)", nil)
+            }
+        } else {
+            reject(IapErrors.E_DEVELOPER_ERROR.rawValue, "Can't find product for sku \(sku)", nil)
         }
+    }
 
-        let discountIdentifier = discount.identifier
-        switch discount.type {
-        case SKProductDiscount.Type.introductory:
-          discountType = "INTRODUCTORY"
-          break
+    @objc public func  finishTransaction(
+        _ transactionIdentifier: String,
+        resolve: @escaping RCTPromiseResolveBlock = { _ in },
+        reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
+    ) async {
+        await transactions[transactionIdentifier]?.finish()
+        transactions.removeValue(forKey: transactionIdentifier)
+        resolve(nil)
+    }
 
-        case SKProductDiscount.Type.subscription:
-          discountType = "SUBSCRIPTION"
-          break
+    @objc public func pendingTransactions (
+        _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
+        reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
+    ) {
+        resolve(transactions.values.map({(t: Transaction) in serialize(t)}))
+    }
 
-        default:
-          discountType = ""
-          break
+    // TODO: New method
+    @objc public func sync(
+        _ resolve: @escaping RCTPromiseResolveBlock = { _ in},
+        reject: @escaping RCTPromiseRejectBlock = {_, _, _ in}
+    ) async {
+        do {
+            try await AppStore.sync()
+        } catch {
+            reject(IapErrors.E_SYNC_ERROR.rawValue, "Error synchronizing with the AppStore", error)
         }
-
-        let discountObj = [
-          "identifier": discountIdentifier,
-          "type": discountType,
-          "numberOfPeriods": numberOfPeriods,
-          "price": "\(discount.price)",
-          "localizedPrice": localizedPrice,
-          "paymentMode": paymendMode,
-          "subscriptionPeriod": subscriptionPeriods
-        ]
-
-        mappedDiscounts.append(discountObj)
-      }
-
-      return mappedDiscounts
     }
 
-    return nil
-  }
-
-  func getPurchaseData(_ transaction: SKPaymentTransaction, withBlock block: @escaping (_ transactionDict: [String: Any]?) -> Void) {
-    requestReceiptData(withBlock: false) { receiptData, _ in
-      if receiptData == nil {
-        block(nil)
-      } else {
-        var purchase = [
-          "transactionDate": transaction.transactionDate?.millisecondsSince1970String,
-          "transactionId": transaction.transactionIdentifier,
-          "productId": transaction.payment.productIdentifier,
-          "transactionReceipt": receiptData?.base64EncodedString(options: [])
-        ]
-
-        // originalTransaction is available for restore purchase and purchase of cancelled/expired subscriptions
-        if let originalTransaction = transaction.original {
-          purchase["originalTransactionDateIOS"] = originalTransaction.transactionDate?.millisecondsSince1970String
-          purchase["originalTransactionIdentifierIOS"] = originalTransaction.transactionIdentifier
-        }
-
-        block(purchase as [String: Any])
-      }
+    /**
+     Should remain the same according to:
+     https://stackoverflow.com/a/72789651/570612
+     */
+    @objc public func  presentCodeRedemptionSheet(
+        _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
+        reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
+    ) {
+        #if !os(tvOS)
+        SKPaymentQueue.default().presentCodeRedemptionSheet()
+        resolve(nil)
+        #else
+        reject(standardErrorCode(2), "This method is not available on tvOS", nil)
+        #endif
     }
-  }
-
-  func requestReceiptData(withBlock forceRefresh: Bool, withBlock block: @escaping (_ data: Data?, _ error: Error?) -> Void) {
-    debugMessage("requestReceiptDataWithBlock with force refresh: \(forceRefresh ? "YES" : "NO")")
-
-    if forceRefresh || isReceiptPresent() == false {
-      let refreshRequest = SKReceiptRefreshRequest()
-      refreshRequest.delegate = self
-      refreshRequest.start()
-      receiptBlock = block
-    } else {
-      receiptBlock = nil
-      block(receiptData(), nil)
-    }
-  }
-
-  func isReceiptPresent() -> Bool {
-    let receiptURL = Bundle.main.appStoreReceiptURL
-    var canReachError: Error?
-
-    do {
-      try _ = receiptURL?.checkResourceIsReachable()
-    } catch let error {
-      canReachError = error
-    }
-
-    return canReachError == nil
-  }
-
-  func receiptData() -> Data? {
-    let receiptURL = Bundle.main.appStoreReceiptURL
-    var receiptData: Data?
-
-    if let receiptURL = receiptURL {
-      do {
-        try receiptData = Data(contentsOf: receiptURL)
-      } catch _ {
-      }
-    }
-
-    return receiptData
-  }
-
-  func requestDidFinish(_ request: SKRequest) {
-    if request is SKReceiptRefreshRequest {
-      if isReceiptPresent() == true {
-        debugMessage("Receipt refreshed success")
-
-        if let receiptBlock = receiptBlock {
-          receiptBlock(receiptData(), nil)
-        }
-      } else if let receiptBlock = receiptBlock {
-        debugMessage("Finished but receipt refreshed failed")
-
-        let error = NSError(domain: "Receipt request finished but it failed!", code: 10, userInfo: nil)
-        receiptBlock(nil, error)
-      }
-
-      receiptBlock = nil
-    }
-  }
-
-  func paymentQueue(_ queue: SKPaymentQueue, removedTransactions transactions: [SKPaymentTransaction]) {
-    debugMessage("removedTransactions - countPendingTransactions \(countPendingTransaction)")
-
-    if countPendingTransaction > 0 {
-      countPendingTransaction -= transactions.count
-
-      if countPendingTransaction <= 0 {
-        resolvePromises(forKey: "cleaningTransactions", value: nil)
-        countPendingTransaction = 0
-      }
-    }
-  }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
+import type * as Apple from './apple';
 export type Sku = string;
 
 export enum ProrationModesAndroid {
@@ -146,6 +147,28 @@ export interface SubscriptionIOS extends ProductCommon {
 }
 
 export type Subscription = SubscriptionAndroid & SubscriptionIOS;
+export interface RequestPurchaseBaseAndroid {
+  obfuscatedAccountIdAndroid?: string;
+  obfuscatedProfileIdAndroid?: string;
+  isOfferPersonalized?: boolean; // For AndroidBilling V5 https://developer.android.com/google/play/billing/integrate#personalized-price
+}
+
+export interface RequestPurchaseAndroid extends RequestPurchaseBaseAndroid {
+  skus?: Sku[];
+}
+
+export interface RequestPurchaseIOS {
+  sku?: Sku;
+  andDangerouslyFinishTransactionAutomaticallyIOS?: boolean;
+  /**
+   * UUID representing user account
+   */
+  appAccountToken?: string;
+  quantity?: number;
+  withOffer?: Apple.PaymentDiscount;
+}
+
+export type RequestPurchase = RequestPurchaseAndroid & RequestPurchaseIOS;
 
 /**
  * In order to purchase a new subscription, every sku must have a selected offerToken
@@ -155,3 +178,14 @@ export interface SubscriptionOffer {
   sku: Sku;
   offerToken: string;
 }
+
+export interface RequestSubscriptionAndroid extends RequestPurchaseBaseAndroid {
+  purchaseTokenAndroid?: string;
+  prorationModeAndroid?: ProrationModesAndroid;
+  subscriptionOffers?: SubscriptionOffer[]; // For AndroidBilling V5
+}
+
+export type RequestSubscriptionIOS = RequestPurchaseIOS;
+
+export type RequestSubscription = RequestSubscriptionAndroid &
+  RequestSubscriptionIOS;


### PR DESCRIPTION
- set min ios version to 15
- consolidated buy methods
- removed checks for older versions of ios
- cleared most errors
- swiftlint
- continue migration, purchases
- return promises to class
- moved utils to ios
- clean up promises and error codes
- serialized Transactions
- removed remaining old methods, added serialization
- default to Xcode 4 spaces
- Split files
- Added more transaction methods
- removed global autofinish
- fix lint on doc
