### PR TITLE
docs: Fixed getProducts signature

### DIFF
--- a/docs/docs/usage_instructions/retrieve_available.md
+++ b/docs/docs/usage_instructions/retrieve_available.md
@@ -26,7 +26,7 @@ import * as RNIap from 'react-native-iap';
 
   async componentDidMount() {
     try {
-      const products: Product[] = await RNIap.getProducts(productIds);
+      const products: Product[] = await RNIap.getProducts({skus: productIds});
       this.setState({ products });
     } catch(err) {
       console.warn(err); // standardized err.code and err.message available


### PR DESCRIPTION
In the source code, we have an object with one attribute: `skus`

```
export declare const getProducts: ({ skus, }: {
    skus: string[];
}) => Promise<Array<Product>>;
```