### PR TITLE
Clean up on disconnect

### DIFF
--- a/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonListener.kt
+++ b/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonListener.kt
@@ -333,6 +333,10 @@ class RNIapAmazonListener(private val reactContext: ReactContext) : PurchasingLi
                     )
         }
     }
+    fun clear(){
+        skus.clear()
+
+    }
 
     private fun sendEvent(
         reactContext: ReactContext,

--- a/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonModule.kt
+++ b/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonModule.kt
@@ -15,6 +15,7 @@ import java.util.HashSet
 class RNIapAmazonModule(reactContext: ReactApplicationContext) :
     ReactContextBaseJavaModule(reactContext) {
     var hasListener = false
+    private var amazonListener: RNIapAmazonListener? = null
     override fun getName(): String {
         return TAG
     }
@@ -22,7 +23,9 @@ class RNIapAmazonModule(reactContext: ReactApplicationContext) :
     @ReactMethod
     fun initConnection(promise: Promise) {
         val context = reactApplicationContext
-        PurchasingService.registerListener(context, RNIapAmazonListener(context))
+        val amazonListener = RNIapAmazonListener(context)
+        this.amazonListener = amazonListener
+        PurchasingService.registerListener(context, amazonListener)
         hasListener = true
         // Prefetch user and purchases as per Amazon SDK documentation:
         PurchasingService.getUserData()
@@ -32,6 +35,9 @@ class RNIapAmazonModule(reactContext: ReactApplicationContext) :
 
     @ReactMethod
     fun endConnection(promise: Promise) {
+        DoobooUtils.instance.rejectAllPendingPromises()
+        amazonListener?.clear()
+        hasListener = false
         promise.resolve(true)
     }
 

--- a/android/src/main/java/com/dooboolab/RNIap/DoobooUtils.kt
+++ b/android/src/main/java/com/dooboolab/RNIap/DoobooUtils.kt
@@ -49,6 +49,13 @@ class DoobooUtils {
         }
     }
 
+    fun rejectAllPendingPromises() {
+        promises.flatMap { it.value }.forEach { promise ->
+            promise.safeReject(E_CONNECTION_CLOSED, "Connection has been closed", null)
+        }
+        promises.clear()
+    }
+
     fun rejectPromisesForKey(
         key: String,
         code: String?,
@@ -175,6 +182,7 @@ class DoobooUtils {
         const val E_USER_ERROR = "E_USER_ERROR"
         const val E_DEVELOPER_ERROR = "E_DEVELOPER_ERROR"
         const val E_BILLING_RESPONSE_JSON_PARSE_ERROR = "E_BILLING_RESPONSE_JSON_PARSE_ERROR"
+        const val E_CONNECTION_CLOSED = "E_CONNECTION_CLOSED"
         val instance = DoobooUtils()
     }
 }

--- a/android/src/main/java/com/dooboolab/RNIap/PromiseUtlis.kt
+++ b/android/src/main/java/com/dooboolab/RNIap/PromiseUtlis.kt
@@ -9,11 +9,13 @@ import com.facebook.react.bridge.Promise
  * want to crash in the case of it being resolved/rejected more than once
  */
 
+const val TAG = "IapPromises"
+
 fun Promise.safeResolve(value: Any) {
     try {
         this.resolve(value)
     } catch (oce: ObjectAlreadyConsumedException) {
-        Log.d(RNIapModule.TAG, "Already consumed ${oce.message}")
+        Log.d(TAG, "Already consumed ${oce.message}")
     }
 }
 
@@ -28,6 +30,6 @@ fun Promise.safeReject(code: String?, message: String?, throwable: Throwable?) {
     try {
         this.reject(code, message, throwable)
     } catch (oce: ObjectAlreadyConsumedException) {
-        Log.d(RNIapModule.TAG, "Already consumed ${oce.message}")
+        Log.d(TAG, "Already consumed ${oce.message}")
     }
 }

--- a/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
@@ -127,6 +127,8 @@ class RNIapModule(
     fun endConnection(promise: Promise) {
         billingClientCache?.endConnection()
         billingClientCache = null
+        skus.clear()
+        DoobooUtils.instance.rejectAllPendingPromises()
         promise.safeResolve(true)
     }
 

--- a/ios/RNIapIos.swift
+++ b/ios/RNIapIos.swift
@@ -133,6 +133,14 @@ class RNIapIos: RCTEventEmitter, SKRequestDelegate, SKPaymentTransactionObserver
         }
     }
 
+    func rejectAllPendingPromises() {
+        promisesByKey.values.reduce([], +).forEach({tuple in
+            let reject = tuple.1
+            reject("E_CONNECTION_CLOSED", "Connection has been closed", nil)
+        })
+        promisesByKey.removeAll()
+    }
+
     func paymentQueue(_ queue: SKPaymentQueue, shouldAddStorePayment payment: SKPayment, for product: SKProduct) -> Bool {
         promotedProduct = product
         promotedPayment = payment
@@ -160,6 +168,14 @@ class RNIapIos: RCTEventEmitter, SKRequestDelegate, SKPaymentTransactionObserver
         reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
     ) {
         removeTransactionObserver()
+        stopObserving()
+        rejectAllPendingPromises()
+        receiptBlock = nil
+        validProducts.removeAll()
+        promotedPayment = nil
+        promotedProduct = nil
+        productsRequest = nil
+        countPendingTransaction = 0
         resolve(nil)
     }
     @objc public func getItems(


### PR DESCRIPTION
When opening and closing connections, some pieces of data (particularly promises) were being kept possibly causing memory leaks and duplicate calls