### PR TITLE
Fix subscriptionOffers promise rejected

### DIFF
--- a/src/iap.ts
+++ b/src/iap.ts
@@ -340,10 +340,9 @@ export const requestSubscription = ({
           return RNIapAmazonModule.buyItemByType(sku);
         } else {
           if (!subscriptionOffers?.length) {
-            Promise.reject(
+            return Promise.reject(
               'subscriptionOffers are required for Google Play Subscriptions',
             );
-            return;
           }
           return RNIapModule.buyItemByType(
             ANDROID_ITEM_TYPE_SUBSCRIPTION,


### PR DESCRIPTION
The return was invalid.

Promise rejected was called without being returned, thus it didn't trigger the catch and it was handled inside finally statement. 