### PR TITLE
fix: modified the type of timestamp in the paymentDiscount from number to string

### DIFF
--- a/src/iap.ts
+++ b/src/iap.ts
@@ -858,7 +858,7 @@ const requestAgnosticReceiptValidationIos = async (
  * @param {string} withOffer.keyIdentifier Key identifier that it uses to generate the signature
  * @param {string} withOffer.nonce An UUID returned from the server
  * @param {string} withOffer.signature The actual signature returned from the server
- * @param {number} withOffer.timestamp The timestamp of the signature
+ * @param {string} withOffer.timestamp The timestamp of the signature
  * @returns {Promise<void>}
  */
 export const requestPurchaseWithOfferIOS = ({

--- a/src/types/apple.ts
+++ b/src/types/apple.ts
@@ -25,5 +25,5 @@ export interface PaymentDiscount {
   /**
    * The date and time of the signature's creation in milliseconds, formatted in Unix epoch time.
    */
-  timestamp: number;
+  timestamp: string;
 }


### PR DESCRIPTION
- modified the type of `timestamp` in the `paymentDiscount` from number to string.

- I modified this way because the timestamp property, which is a number type, causes a type casting error in the iOS environment.

- If it is better to fix the `buyProductWithOffer` in the `RNIapIos.swift` file than to fix the type like this, you can reject this PR.