### PR TITLE
fix: added the offerTags property to the SubscriptionAndroid

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -146,6 +146,7 @@ export interface SubscriptionAndroid extends ProductCommon {
         recurrenceMode: number;
       }[];
     };
+    offerTags: string[];
   }[];
 }
 


### PR DESCRIPTION
- added the `offerTags` property to the `SubscriptionAndroid`

- There is no the `offerTags` property in the `SubscriptionAndroid` interface, so a lint error occurs when using the `offerTags`. So I added the `offerTags` property like this, but if it's unnecessary, you can reject it.