### PR TITLE
chore: use named export in docs for 11.0.0 migration

### DIFF
--- a/docs/docs/migrate_to_11.0.0.md
+++ b/docs/docs/migrate_to_11.0.0.md
@@ -54,7 +54,7 @@ platform :ios, '15.0'
 Call `setup` before you initialize your connection as follows:
 
 ```ts
-import setup from 'react-native-iap'
+import {setup} from 'react-native-iap'
 ...
 setup({storekitMode:'___Selected Mode___'})// See above for available options
 await initConnection()


### PR DESCRIPTION
`setup` seems to be a named export so it must be imported in curlies (`{setup}`)