### PR TITLE
Lint and run tests as part of yarn prepare to improve safety

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
-__tests__
 node_modules
 *.js
 *.d.ts

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ module.exports = {
   clearMocks: true,
   coverageDirectory: 'coverage',
   moduleDirectories: ['node_modules', 'src'],
-  modulePathIgnorePatterns: ['IapExample'],
+  modulePathIgnorePatterns: ['IapExample', 'lib'],
   preset: 'react-native',
   setupFiles: ['<rootDir>/test/mocks/react-native-modules.js'],
   setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "!**/__mocks__"
   ],
   "scripts": {
-    "prepare": "bob build",
+    "prepare": "yarn lint && yarn test && yarn build",
+    "build": "bob build",
     "release": "release-it",
     "example": "yarn --cwd IapExample",
     "test": "jest",

--- a/src/__tests__/iap.test.ts
+++ b/src/__tests__/iap.test.ts
@@ -2,16 +2,15 @@ import {NativeModules} from 'react-native';
 
 import {initConnection} from '../iap';
 
-const rnLib = '../../node_modules/react-native/Libraries';
+jest.mock(
+  '../../node_modules/react-native/Libraries/Utilities/Platform',
+  () => ({
+    OS: 'android',
+    select: (dict: {[x: string]: any}) => dict.android,
+  }),
+);
 
 describe('Google Play IAP', () => {
-  beforeEach(() => {
-    jest.mock(rnLib + '/Utilities/Platform', () => ({
-      OS: 'android',
-      select: (dict: {[x: string]: any}) => dict.android,
-    }));
-  });
-
   it("should call init on Google Play's native module but not on Amazon's", async () => {
     await initConnection();
     expect(NativeModules.RNIapModule.initConnection).toBeCalled();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,6 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "esnext"
-  }
+  },
+  "exclude": ["IapExample", "lib"]
 }


### PR DESCRIPTION
## Motivation

While trying to work on this repository, I realized that the linting and tests were broken. To help ensure the tests and linting isn't broken by any new changes, I think it'd be great to run the linter and tests as part of the `prepare` release process.

## Fix

1. Change `yarn prepare` to also run `yarn lint && yarn test`
   - Create a separate `yarn build` command so we can build while skipping the lint/test process
2. Fix the test by moving the mock to the outermost scope
3. Fix the linting by adding excludes to the typechecker

## Testing

Ran `yarn prepare` and verified that it runs successfully.