### PR TITLE
Fix getSubscriptions Android types; add platform enum and tests

### DIFF
--- a/IapExample/src/screens/Subscriptions.tsx
+++ b/IapExample/src/screens/Subscriptions.tsx
@@ -109,7 +109,10 @@ export const Subscriptions = () => {
                   },
                   {
                     label: 'type',
-                    value: subscription.type,
+                    value:
+                      'type' in subscription
+                        ? subscription.type
+                        : subscription.productType,
                   },
                 ]}
                 isLast={subscriptions.length - 1 === index}
@@ -118,6 +121,7 @@ export const Subscriptions = () => {
                 {!owned &&
                   isPlay &&
                   // On Google Play Billing V5 you might have  multiple offers for a single sku
+                  'subscriptionOfferDetails' in subscription &&
                   subscription?.subscriptionOfferDetails?.map((offer) => (
                     <Button
                       title={`Subscribe ${offer.pricingPhases.pricingPhaseList

--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
     "!**/__mocks__"
   ],
   "scripts": {
-    "prepare": "yarn lint && yarn test && yarn build",
-    "build": "bob build",
+    "prepare": "bob build",
     "release": "release-it",
     "example": "yarn --cwd IapExample",
     "test": "jest",

--- a/src/__tests__/iap.test.ts
+++ b/src/__tests__/iap.test.ts
@@ -1,6 +1,8 @@
 import {NativeModules} from 'react-native';
 
 import {initConnection} from '../iap';
+import type {SubscriptionAndroid} from '../types';
+import {SubscriptionPlatform} from '../types';
 
 jest.mock(
   '../../node_modules/react-native/Libraries/Utilities/Platform',
@@ -15,5 +17,40 @@ describe('Google Play IAP', () => {
     await initConnection();
     expect(NativeModules.RNIapModule.initConnection).toBeCalled();
     expect(NativeModules.RNIapAmazonModule.initConnection).not.toBeCalled();
+  });
+
+  it('has correct typings for an Android subscription', () => {
+    // This actually doesn't test any logic, but just verifies the typings
+    // are correct
+    const subscription: SubscriptionAndroid = {
+      platform: SubscriptionPlatform.android,
+      // The rest of this is pasted in from a `console.log` result of an
+      // Android getSubscriptions call from 2022-10-11.
+      subscriptionOfferDetails: [
+        {
+          pricingPhases: {
+            pricingPhaseList: [
+              {
+                recurrenceMode: 1,
+                priceAmountMicros: '49990000',
+                billingCycleCount: 0,
+                billingPeriod: 'P1Y',
+                priceCurrencyCode: 'USD',
+                formattedPrice: '$49.99',
+              },
+            ],
+          },
+          offerTags: [],
+          offerToken: 'dGVzdA==',
+        },
+      ],
+      name: 'MyApp Pro: Annual Plan',
+      productType: 'subs',
+      description: '',
+      title: 'MyApp Pro: Annual Plan (MyApp - Productivity App)',
+      productId: 'app_4999_1y_1w0',
+    };
+
+    expect(subscription).toBeTruthy();
   });
 });

--- a/src/iap.ts
+++ b/src/iap.ts
@@ -757,7 +757,8 @@ export const requestSubscription = (
           if (!('sku' in request)) {
             throw new Error('sku is required for Amazon subscriptions');
           }
-          return RNIapAmazonModule.buyItemByType(request.sku);
+          const {sku} = request;
+          return RNIapAmazonModule.buyItemByType(sku);
         } else {
           if (
             !('subscriptionOffers' in request) ||

--- a/src/iap.ts
+++ b/src/iap.ts
@@ -15,6 +15,7 @@ import {
 import {
   fillProductsWithAdditionalData,
   getAndroidModule,
+  getAndroidModuleType,
   getIosModule,
   getNativeModule,
   isAmazon,
@@ -28,12 +29,16 @@ import {
   ProductPurchase,
   ProductType,
   PurchaseResult,
+  PurchaseStateAndroid,
   RequestPurchase,
   RequestSubscription,
   Subscription,
+  SubscriptionAmazon,
+  SubscriptionAndroid,
+  SubscriptionIOS,
+  SubscriptionPlatform,
   SubscriptionPurchase,
 } from './types';
-import {PurchaseStateAndroid} from './types';
 
 export {IapAndroid, IapAmazon, IapIos, IapIosSk2, isIosStorekit2};
 
@@ -231,31 +236,68 @@ export const getSubscriptions = ({
 }): Promise<Subscription[]> =>
   (
     Platform.select({
-      ios: async () => {
-        let items: Subscription[];
+      ios: async (): Promise<SubscriptionIOS[]> => {
+        let items: SubscriptionIOS[];
         if (isIosStorekit2()) {
           items = ((await RNIapIosSk2.getItems(skus)) as ProductSk2[]).map(
             subscriptionSk2Map,
           );
         } else {
-          items = (await RNIapIos.getItems(skus)) as Subscription[];
+          items = (await RNIapIos.getItems(skus)) as SubscriptionIOS[];
         }
 
-        return items.filter(
-          (item: Subscription) =>
+        items = items.filter(
+          (item: SubscriptionIOS) =>
             skus.includes(item.productId) && item.type === 'subs',
         );
+
+        return addSubscriptionPlatform(items, SubscriptionPlatform.ios);
       },
-      android: async () => {
-        const subscriptions = (await getAndroidModule().getItemsByType(
+      android: async (): Promise<Subscription[]> => {
+        const androidPlatform = getAndroidModuleType();
+
+        let subscriptions = (await getAndroidModule().getItemsByType(
           ANDROID_ITEM_TYPE_SUBSCRIPTION,
           skus,
-        )) as Subscription[];
+        )) as SubscriptionAndroid[] | SubscriptionAmazon[];
 
-        return fillProductsWithAdditionalData(subscriptions);
+        switch (androidPlatform) {
+          case 'android': {
+            const castSubscriptions = subscriptions as SubscriptionAndroid[];
+            return addSubscriptionPlatform(
+              castSubscriptions,
+              SubscriptionPlatform.android,
+            );
+          }
+          case 'amazon':
+            let castSubscriptions = subscriptions as SubscriptionAmazon[];
+            castSubscriptions = await fillProductsWithAdditionalData(
+              castSubscriptions,
+            );
+            return addSubscriptionPlatform(
+              castSubscriptions,
+              SubscriptionPlatform.amazon,
+            );
+          case null:
+          default:
+            throw new Error(
+              `getSubscriptions received unknown platform ${androidPlatform}. Verify the logic in getAndroidModuleType`,
+            );
+        }
       },
     }) || (() => Promise.reject(new Error('Unsupported Platform')))
   )();
+
+/**
+ * Adds an extra property to subscriptions so we can distinguish the platform
+ * we retrieved them on.
+ */
+const addSubscriptionPlatform = <T>(
+  subscriptions: T[],
+  platform: SubscriptionPlatform,
+): T[] => {
+  return subscriptions.map((subscription) => ({...subscription, platform}));
+};
 
 /**
  * Gets an inventory of purchases made by the user regardless of consumption status
@@ -281,8 +323,8 @@ const App = () => {
 ```
 @param {alsoPublishToEventListener}:boolean. (IOS Sk2 only) When `true`, every element will also be pushed to the purchaseUpdated listener.
 Note that this is only for backaward compatiblity. It won't publish to transactionUpdated (Storekit2) Defaults to `false`
-@param {automaticallyFinishRestoredTransactions}:boolean. (IOS Sk1 only) When `true`, all the transactions that are returned are automatically 
-finished. This means that if you call this method again you won't get the same result on the same device. On the other hand, if `false` you'd 
+@param {automaticallyFinishRestoredTransactions}:boolean. (IOS Sk1 only) When `true`, all the transactions that are returned are automatically
+finished. This means that if you call this method again you won't get the same result on the same device. On the other hand, if `false` you'd
 have to manually finish the returned transaction once you have delivered the content to your user.
  */
 export const getPurchaseHistory = ({
@@ -403,7 +445,7 @@ const App = () => {
 ```
 @param {alsoPublishToEventListener}:boolean When `true`, every element will also be pushed to the purchaseUpdated listener.
 Note that this is only for backaward compatiblity. It won't publish to transactionUpdated (Storekit2) Defaults to `false`
- * 
+ *
  */
 export const getAvailablePurchases = ({
   alsoPublishToEventListener = false,
@@ -460,22 +502,22 @@ always keeping at false, and verifying the transaction receipts on the server-si
 
 ```ts
 requestPurchase(
- The product's sku/ID 
+ The product's sku/ID
   sku,
 
-  
+
    * You should set this to false and call finishTransaction manually when you have delivered the purchased goods to the user.
    * @default false
-   
+
   andDangerouslyFinishTransactionAutomaticallyIOS = false,
 
-  /** Specifies an optional obfuscated string that is uniquely associated with the user's account in your app. 
+  /** Specifies an optional obfuscated string that is uniquely associated with the user's account in your app.
   obfuscatedAccountIdAndroid,
 
-  Specifies an optional obfuscated string that is uniquely associated with the user's profile in your app. 
+  Specifies an optional obfuscated string that is uniquely associated with the user's profile in your app.
   obfuscatedProfileIdAndroid,
 
-   The purchaser's user ID 
+   The purchaser's user ID
   applicationUsername,
 ): Promise<ProductPurchase>;
 ```
@@ -599,7 +641,7 @@ always keeping at false, and verifying the transaction receipts on the server-si
 
 ```ts
 requestSubscription(
-  The product's sku/ID 
+  The product's sku/ID
   sku,
 
 
@@ -608,19 +650,19 @@ requestSubscription(
 
   andDangerouslyFinishTransactionAutomaticallyIOS = false,
 
-   purchaseToken that the user is upgrading or downgrading from (Android). 
+   purchaseToken that the user is upgrading or downgrading from (Android).
   purchaseTokenAndroid,
 
-  UNKNOWN_SUBSCRIPTION_UPGRADE_DOWNGRADE_POLICY, IMMEDIATE_WITH_TIME_PRORATION, IMMEDIATE_AND_CHARGE_PRORATED_PRICE, IMMEDIATE_WITHOUT_PRORATION, DEFERRED 
+  UNKNOWN_SUBSCRIPTION_UPGRADE_DOWNGRADE_POLICY, IMMEDIATE_WITH_TIME_PRORATION, IMMEDIATE_AND_CHARGE_PRORATED_PRICE, IMMEDIATE_WITHOUT_PRORATION, DEFERRED
   prorationModeAndroid = -1,
 
-  /** Specifies an optional obfuscated string that is uniquely associated with the user's account in your app. 
+  /** Specifies an optional obfuscated string that is uniquely associated with the user's account in your app.
   obfuscatedAccountIdAndroid,
 
-  Specifies an optional obfuscated string that is uniquely associated with the user's profile in your app. 
+  Specifies an optional obfuscated string that is uniquely associated with the user's profile in your app.
   obfuscatedProfileIdAndroid,
 
-  The purchaser's user ID 
+  The purchaser's user ID
   applicationUsername,
 ): Promise<SubscriptionPurchase>
 ```
@@ -744,7 +786,7 @@ export const requestSubscription = ({
  *   Call this after you have persisted the purchased state to your server or local data in your app.
  *   `react-native-iap` will continue to deliver the purchase updated events with the successful purchase until you finish the transaction. **Even after the app has relaunched.**
  *   Android: it will consume purchase for consumables and acknowledge purchase for non-consumables.
- *   
+ *
 ```tsx
 import React from 'react';
 import {Button} from 'react-native';
@@ -759,7 +801,7 @@ const App = () => {
 
   return <Button title="Buy product" onPress={handlePurchase} />;
 };
-``` 
+```
  */
 export const finishTransaction = ({
   purchase,

--- a/src/internal/fillProductsWithAdditionalData.ts
+++ b/src/internal/fillProductsWithAdditionalData.ts
@@ -5,11 +5,12 @@ import type {ProductCommon} from '../types';
 const {RNIapAmazonModule} = NativeModules;
 
 /**
- * Fill products with additional data
+ * For Amazon products, we add the currency code from the user's information
+ * since it isn't included in the product information.
  */
 export const fillProductsWithAdditionalData = async <T extends ProductCommon>(
   items: T[],
-) => {
+): Promise<T[]> => {
   if (RNIapAmazonModule) {
     // On amazon we must get the user marketplace to detect the currency
     const user = await RNIapAmazonModule.getUser();

--- a/src/internal/platform.ts
+++ b/src/internal/platform.ts
@@ -25,6 +25,10 @@ export const checkNativeAndroidAvailable = (): void => {
   }
 };
 
+/**
+ * If changing the typings of `getAndroidModule` to accommodate extra modules,
+ * make sure to update `getAndroidModuleType`.
+ */
 export const getAndroidModule = ():
   | typeof RNIapModule
   | typeof RNIapAmazonModule => {
@@ -35,6 +39,22 @@ export const getAndroidModule = ():
     : RNIapModule
     ? RNIapModule
     : RNIapAmazonModule;
+};
+
+/**
+ * Returns whether the Android in-app-purchase code is using the Android,
+ * Amazon, or another store.
+ */
+export const getAndroidModuleType = (): 'android' | 'amazon' | null => {
+  const module = getAndroidModule();
+  switch (module) {
+    case RNIapModule:
+      return 'android';
+    case RNIapAmazonModule:
+      return 'amazon';
+    default:
+      return null;
+  }
 };
 
 export const getNativeModule = ():

--- a/src/modules/android.ts
+++ b/src/modules/android.ts
@@ -35,7 +35,7 @@ export type BuyItemByType = (
   type: string,
   skus: Sku[],
   purchaseToken: string | undefined,
-  prorationMode: ProrationModesAndroid,
+  prorationMode: ProrationModesAndroid | undefined,
   obfuscatedAccountId: string | undefined,
   obfuscatedProfileId: string | undefined,
   subscriptionOffers: string[],

--- a/src/modules/ios.ts
+++ b/src/modules/ios.ts
@@ -2,17 +2,17 @@ import type {ResponseBody as ReceiptValidationResponse} from '@jeremybarbet/appl
 
 import {getIosModule, isIosStorekit2} from '../internal';
 import type {
-  Product,
+  ProductIOS,
   ProductPurchase,
   Purchase,
   Sku,
-  Subscription,
+  SubscriptionIOS,
 } from '../types';
 import type {PaymentDiscount} from '../types/apple';
 
 import type {NativeModuleProps} from './common';
 
-type getItems = (skus: Sku[]) => Promise<Product[] | Subscription[]>;
+type getItems = (skus: Sku[]) => Promise<ProductIOS[] | SubscriptionIOS[]>;
 
 type getAvailableItems = (
   automaticallyFinishRestoredTransactions: boolean,
@@ -28,7 +28,7 @@ export type BuyProduct = (
 
 type clearTransaction = () => Promise<void>;
 type clearProducts = () => Promise<void>;
-type promotedProduct = () => Promise<Product | null>;
+type promotedProduct = () => Promise<ProductIOS | null>;
 type buyPromotedProduct = () => Promise<void>;
 type requestReceipt = (refresh: boolean) => Promise<string>;
 
@@ -83,7 +83,7 @@ export const presentCodeRedemptionSheetIOS = async (): Promise<null> =>
  *   Indicates the the App Store purchase should continue from the app instead of the App Store.
  * @returns {Promise<Product | null>} promoted product
  */
-export const getPromotedProductIOS = (): Promise<Product | null> => {
+export const getPromotedProductIOS = (): Promise<ProductIOS | null> => {
   if (!isIosStorekit2()) {
     return getIosModule().promotedProduct();
   } else {

--- a/src/types/appleSk2.ts
+++ b/src/types/appleSk2.ts
@@ -7,6 +7,7 @@ import type {
   SubscriptionIosPeriod,
 } from '.';
 import type * as Apple from './apple';
+import {SubscriptionPlatform} from '.';
 
 export type SubscriptionPeriod = {
   unit: 'day' | 'week' | 'month' | 'year';
@@ -71,6 +72,7 @@ export const subscriptionSk2Map = ({
   subscription,
 }: ProductSk2): SubscriptionIOS => {
   const prod: SubscriptionIOS = {
+    platform: SubscriptionPlatform.ios,
     title: displayName,
     productId: String(id),
     description,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -209,11 +209,11 @@ export interface RequestPurchaseBaseAndroid {
 }
 
 export interface RequestPurchaseAndroid extends RequestPurchaseBaseAndroid {
-  skus?: Sku[];
+  skus: Sku[];
 }
 
 export interface RequestPurchaseIOS {
-  sku?: Sku;
+  sku: Sku;
   andDangerouslyFinishTransactionAutomaticallyIOS?: boolean;
   /**
    * UUID representing user account
@@ -223,7 +223,13 @@ export interface RequestPurchaseIOS {
   withOffer?: Apple.PaymentDiscount;
 }
 
-export type RequestPurchase = RequestPurchaseAndroid & RequestPurchaseIOS;
+/** As of 2022-10-12, we only use the `sku` field for Amazon purchases */
+export type RequestPurchaseAmazon = RequestPurchaseIOS;
+
+export type RequestPurchase =
+  | RequestPurchaseAndroid
+  | RequestPurchaseAmazon
+  | RequestPurchaseIOS;
 
 /**
  * In order to purchase a new subscription, every sku must have a selected offerToken
@@ -237,13 +243,18 @@ export interface SubscriptionOffer {
 export interface RequestSubscriptionAndroid extends RequestPurchaseBaseAndroid {
   purchaseTokenAndroid?: string;
   prorationModeAndroid?: ProrationModesAndroid;
-  subscriptionOffers?: SubscriptionOffer[]; // For AndroidBilling V5
+  subscriptionOffers: SubscriptionOffer[];
 }
 
 export type RequestSubscriptionIOS = RequestPurchaseIOS;
 
-export type RequestSubscription = RequestSubscriptionAndroid &
-  RequestSubscriptionIOS;
+/** As of 2022-10-12, we only use the `sku` field for Amazon subscriptions */
+export type RequestSubscriptionAmazon = RequestSubscriptionIOS;
+
+export type RequestSubscription =
+  | RequestSubscriptionAndroid
+  | RequestSubscriptionAmazon
+  | RequestSubscriptionIOS;
 
 declare module 'react-native' {
   interface NativeModulesStatic {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -124,7 +124,7 @@ export interface ProductIOS extends ProductCommon {
   type: 'inapp' | 'iap';
 }
 
-export type Product = ProductAndroid | ProductIOS;
+export type Product = ProductAndroid & ProductIOS;
 
 /**
  * Can be used to distinguish the different platforms' subscription information

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -54,10 +54,7 @@ export interface ProductCommon {
   description: string;
   price: string;
   currency: string;
-  /**
-   * For Android use subscription.subscriptionOfferDetails[*].pricingPhases.pricingPhaseList[*].formattedPrice
-   */
-  localizedPrice?: string;
+  localizedPrice: string;
   countryCode?: string;
 }
 
@@ -127,35 +124,63 @@ export interface ProductIOS extends ProductCommon {
   type: 'inapp' | 'iap';
 }
 
-export type Product = ProductAndroid & ProductIOS;
+export type Product = ProductAndroid | ProductIOS;
 
-// Android V5
-export interface SubscriptionAndroid extends ProductCommon {
+/**
+ * Can be used to distinguish the different platforms' subscription information
+ */
+export enum SubscriptionPlatform {
+  android = 'android',
+  amazon = 'amazon',
+  ios = 'ios',
+}
+
+/** Android Billing v5 type */
+export interface SubscriptionAndroid {
+  platform: SubscriptionPlatform.android;
+  productType: 'subs';
+  name: string;
+  title: string;
+  description: string;
+  productId: string;
+  subscriptionOfferDetails: SubscriptionOfferAndroid[];
+}
+
+export interface SubscriptionOfferAndroid {
+  offerToken: string;
+  pricingPhases: {
+    pricingPhaseList: PricingPhaseAndroid[];
+  };
+  offerTags: string[];
+}
+
+export interface PricingPhaseAndroid {
+  formattedPrice: string;
+  priceCurrencyCode: string;
+  /**
+   * P1W, P1M, P1Y
+   */
+  billingPeriod: string;
+  billingCycleCount: number;
+  priceAmountMicros: string;
+  recurrenceMode: number;
+}
+
+/**
+ * TODO: As of 2022-10-10, this typing is not verified against the real
+ * Amazon API. Please update this if you have a more accurate type.
+ */
+export interface SubscriptionAmazon extends ProductCommon {
+  platform: SubscriptionPlatform.amazon;
   type: 'subs';
 
   productType?: string;
   name?: string;
-  subscriptionOfferDetails?: {
-    offerToken: string;
-    pricingPhases: {
-      pricingPhaseList: {
-        formattedPrice: string;
-        priceCurrencyCode: string;
-        /**
-         * P1W, P1M, P1Y
-         */
-        billingPeriod: string;
-        billingCycleCount: number;
-        priceAmountMicros: string;
-        recurrenceMode: number;
-      }[];
-    };
-    offerTags: string[];
-  }[];
 }
 
 export type SubscriptionIosPeriod = 'DAY' | 'WEEK' | 'MONTH' | 'YEAR' | '';
 export interface SubscriptionIOS extends ProductCommon {
+  platform: SubscriptionPlatform.ios;
   type: 'subs';
   discounts?: Discount[];
   introductoryPrice?: string;
@@ -172,7 +197,11 @@ export interface SubscriptionIOS extends ProductCommon {
   subscriptionPeriodUnitIOS?: SubscriptionIosPeriod;
 }
 
-export type Subscription = SubscriptionAndroid & SubscriptionIOS;
+export type Subscription =
+  | SubscriptionAndroid
+  | SubscriptionAmazon
+  | SubscriptionIOS;
+
 export interface RequestPurchaseBaseAndroid {
   obfuscatedAccountIdAndroid?: string;
   obfuscatedProfileIdAndroid?: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
     "strict": true,
     "target": "esnext"
   },
-  "exclude": ["IapExample", "lib"]
+  "exclude": ["lib"]
 }


### PR DESCRIPTION
## Motivation

When I updated `react-native-iap` to 12.0.3 in my project, I realized that `getSubscriptions` on Android no longer returns anything resembling what the typings say they do.

Instead, I got back output that was very different on iOS and Android.

```ts
    const subscription = {
      subscriptionOfferDetails: [
        {
          pricingPhases: {
            pricingPhaseList: [
              {
                recurrenceMode: 1,
                priceAmountMicros: '49990000',
                billingCycleCount: 0,
                billingPeriod: 'P1Y',
                priceCurrencyCode: 'USD',
                formattedPrice: '$49.99',
              },
            ],
          },
          offerTags: [],
          offerToken: 'dGVzdA==',
        },
      ],
      name: 'MyApp Pro: Annual Plan',
      productType: 'subs',
      description: '',
      title: 'MyApp Pro: Annual Plan (MyApp - Productivity App)',
      productId: 'app_4999_1y_1w0',
    };
```

## Fix

1. Update the Typescript `Subscription` typings to use Union types
2. Since the subscription types are now very different between the different platforms, I updated the logic to add a new additional `platform: SubscriptionPlatform` field to the returned subscriptions. This allows calling code to switch based on them more easily
3. For the RequestPurchase and RequestSubscription types, I also used Union types, and then used ['in' operator narrowing](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#the-in-operator-narrowing) to make the app more type-safe

## Testing

1. Added an automated test to test the typings
2. Created an installable branch with the lib and installed it in my own project using `yarn add wanderlog/react-native-iap#12.0.3-wanderlog.1`
4. Tested fetching subscriptions on a real Android phone