### PR TITLE
Fix missing prorationModeAndroid causing crash

### DIFF
--- a/src/iap.ts
+++ b/src/iap.ts
@@ -772,7 +772,7 @@ export const requestSubscription = (
           const {
             subscriptionOffers,
             purchaseTokenAndroid,
-            prorationModeAndroid,
+            prorationModeAndroid = -1,
             obfuscatedAccountIdAndroid,
             obfuscatedProfileIdAndroid,
             isOfferPersonalized,

--- a/src/modules/android.ts
+++ b/src/modules/android.ts
@@ -35,7 +35,7 @@ export type BuyItemByType = (
   type: string,
   skus: Sku[],
   purchaseToken: string | undefined,
-  prorationMode: ProrationModesAndroid | undefined,
+  prorationMode: ProrationModesAndroid | -1,
   obfuscatedAccountId: string | undefined,
   obfuscatedProfileId: string | undefined,
   subscriptionOffers: string[],


### PR DESCRIPTION
## Motivation

I realized I accidentally removed the default value for `prorationModeAndroid`. This introduces the same crash that's mentioned in #1913

Fixes #1913

## Fix

Restore the default `prorationMode` of -1

## Testing

I introduced this bug because I didn't test thoroughly enough. I did a new round of testing to make sure it works end-to-end.

![Trimmed](https://user-images.githubusercontent.com/2937410/195517084-7e8601c3-6905-41c4-b2eb-9956bf727d48.gif)