### PR TITLE
Added support for showManageSubscriptions on Storekit 2

### DIFF
--- a/ios/RNIapIosSk2.m
+++ b/ios/RNIapIosSk2.m
@@ -85,6 +85,10 @@ RCT_EXTERN_METHOD(presentCodeRedemptionSheet:
                   (RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(showManageSubscriptions:
+                  (RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(clearTransaction:
                   (RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)

--- a/src/modules/iosSk2.ts
+++ b/src/modules/iosSk2.ts
@@ -35,6 +35,7 @@ type finishTransaction = (transactionIdentifier: string) => Promise<boolean>;
 
 type getPendingTransactions = () => Promise<ProductPurchase[]>;
 type presentCodeRedemptionSheet = () => Promise<null>;
+type showManageSubscriptions = () => Promise<null>;
 
 export interface IosModulePropsSk2 extends NativeModuleProps {
   isAvailable(): number;
@@ -53,6 +54,7 @@ export interface IosModulePropsSk2 extends NativeModuleProps {
   finishTransaction: finishTransaction;
   getPendingTransactions: getPendingTransactions;
   presentCodeRedemptionSheet: presentCodeRedemptionSheet;
+  showManageSubscriptions: showManageSubscriptions;
   disable: () => Promise<null>;
   beginRefundRequest: (sku: string) => Promise<RefundRequestStatus>;
 }


### PR DESCRIPTION
This PR adds support for showManageSubscriptions: https://developer.apple.com/documentation/storekit/appstore/3803198-showmanagesubscriptions

- This panel is very useful for testing where one can cancel the subscription and avoid waiting for expire and additional renewals.
- This panel is very user friendly allowing users to cancel or change their subscription without going to the App Store or Settings app to find their subscription.