### PR TITLE
onlyIncludeActiveItems ios sk2

### DIFF
--- a/ios/RNIapIosSk2.m
+++ b/ios/RNIapIosSk2.m
@@ -36,6 +36,7 @@ RCT_EXTERN_METHOD(getItems:
 
 RCT_EXTERN_METHOD(getAvailableItems:
                   (BOOL)alsoPublishToEventListener
+                  (BOOL)onlyIncludeActiveItems
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject)
 

--- a/ios/RNIapIosSk2.swift
+++ b/ios/RNIapIosSk2.swift
@@ -317,7 +317,7 @@ class RNIapIosSk2: RCTEventEmitter, Sk2Delegate {
         resolve: @escaping RCTPromiseResolveBlock = { _ in },
         reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
     ) {
-        delegate.getAvailableItems(alsoPublishToEventListener,onlyIncludeActiveItems: onlyIncludeActiveItems, resolve: resolve, reject: reject)
+        delegate.getAvailableItems(alsoPublishToEventListener, onlyIncludeActiveItems: onlyIncludeActiveItems, resolve: resolve, reject: reject)
     }
 
     @objc public func buyProduct(
@@ -603,8 +603,12 @@ class RNIapIosSk2iOS15: Sk2Delegate {
                         if products[transaction.productID] != nil {
                             addTransaction(transaction: transaction)
                         }
+
                     case .consumable:
-                        addTransaction(transaction: transaction)
+                        if products[transaction.productID] != nil {
+                            addTransaction(transaction: transaction)
+                        }
+
                     default:
                         break
                     }

--- a/ios/RNIapIosSk2.swift
+++ b/ios/RNIapIosSk2.swift
@@ -26,6 +26,7 @@ protocol Sk2Delegate {
 
     func getAvailableItems(
         _ alsoPublishToEventListener: Bool,
+        onlyIncludeActiveItems: Bool,
         resolve: @escaping RCTPromiseResolveBlock,
         reject: @escaping RCTPromiseRejectBlock
     )
@@ -140,6 +141,7 @@ class DummySk2: Sk2Delegate {
 
     func getAvailableItems(
         _ alsoPublishToEventListener: Bool,
+        onlyIncludeActiveItems: Bool,
         resolve: @escaping RCTPromiseResolveBlock,
         reject: @escaping RCTPromiseRejectBlock
     ) {
@@ -311,10 +313,11 @@ class RNIapIosSk2: RCTEventEmitter, Sk2Delegate {
 
     @objc public func getAvailableItems(
         _ alsoPublishToEventListener: Bool,
+        onlyIncludeActiveItems: Bool,
         resolve: @escaping RCTPromiseResolveBlock = { _ in },
         reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
     ) {
-        delegate.getAvailableItems(alsoPublishToEventListener, resolve: resolve, reject: reject)
+        delegate.getAvailableItems(alsoPublishToEventListener,onlyIncludeActiveItems: onlyIncludeActiveItems, resolve: resolve, reject: reject)
     }
 
     @objc public func buyProduct(
@@ -506,14 +509,14 @@ class RNIapIosSk2iOS15: Sk2Delegate {
         hasListeners = false
     }
 
-    @objc public func initConnection(
+    public func initConnection(
         _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
         reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
     ) {
         addTransactionObserver()
         resolve(AppStore.canMakePayments)
     }
-    @objc public func endConnection(
+    public func endConnection(
         _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
         reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
     ) {
@@ -524,7 +527,7 @@ class RNIapIosSk2iOS15: Sk2Delegate {
         resolve(nil)
     }
 
-    @objc public func getItems(
+    public func getItems(
         _ skus: [String],
         resolve: @escaping RCTPromiseResolveBlock = { _ in },
         reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
@@ -544,15 +547,16 @@ class RNIapIosSk2iOS15: Sk2Delegate {
         }
     }
 
-    @objc public func getAvailableItems(
+    public func getAvailableItems(
         _ alsoPublishToEventListener: Bool,
+        onlyIncludeActiveItems: Bool,
         resolve: @escaping RCTPromiseResolveBlock = { _ in },
         reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
     ) {
         Task {
             var purchasedItems: [Transaction] = []
 
-            func addPurchase(transaction: Transaction, product: Product) {
+            func addTransaction(transaction: Transaction) {
                 purchasedItems.append( transaction)
                 if alsoPublishToEventListener {
                     self.sendEvent?("purchase-update", serialize(transaction))
@@ -569,14 +573,18 @@ class RNIapIosSk2iOS15: Sk2Delegate {
                     // Check whether the transaction is verified. If it isn’t, catch `failedVerification` error.
                     let transaction = try checkVerified(result)
                     // Check the `productType` of the transaction and get the corresponding product from the store.
+                    if !onlyIncludeActiveItems {
+                        addTransaction(transaction: transaction)
+                        continue
+                    }
                     switch transaction.productType {
                     case .nonConsumable:
-                        if let product = products[transaction.productID] {
-                            addPurchase(transaction: transaction, product: product)
+                        if products[transaction.productID] != nil {
+                            addTransaction(transaction: transaction)
                         }
 
                     case .nonRenewable:
-                        if let nonRenewable = products[transaction.productID] {
+                        if products[transaction.productID] != nil {
                             // Non-renewing subscriptions have no inherent expiration date, so they're always
                             // contained in `Transaction.currentEntitlements` after the user purchases them.
                             // This app defines this non-renewing subscription's expiration date to be one year after purchase.
@@ -587,15 +595,16 @@ class RNIapIosSk2iOS15: Sk2Delegate {
                                                                                        to: transaction.purchaseDate)!
 
                             if currentDate < expirationDate {
-                                addPurchase(transaction: transaction, product: nonRenewable)
+                                addTransaction(transaction: transaction)
                             }
                         }
 
                     case .autoRenewable:
-                        if let subscription = products[transaction.productID] {
-                            addPurchase(transaction: transaction, product: subscription)
+                        if products[transaction.productID] != nil {
+                            addTransaction(transaction: transaction)
                         }
-
+                    case .consumable:
+                        addTransaction(transaction: transaction)
                     default:
                         break
                     }
@@ -627,7 +636,7 @@ class RNIapIosSk2iOS15: Sk2Delegate {
         }
     }
 
-    @objc public func buyProduct(
+    public func buyProduct(
         _ sku: String,
         andDangerouslyFinishTransactionAutomatically: Bool,
         appAccountToken: String?,
@@ -728,7 +737,7 @@ class RNIapIosSk2iOS15: Sk2Delegate {
         }
     }
 
-    @objc public func isEligibleForIntroOffer(
+    public func isEligibleForIntroOffer(
         _ groupID: String,
         resolve: @escaping RCTPromiseResolveBlock = { _ in },
         reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
@@ -739,7 +748,7 @@ class RNIapIosSk2iOS15: Sk2Delegate {
         }
     }
 
-    @objc public func subscriptionStatus(
+    public func subscriptionStatus(
         _ sku: String,
         resolve: @escaping RCTPromiseResolveBlock = { _ in },
         reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
@@ -758,7 +767,7 @@ class RNIapIosSk2iOS15: Sk2Delegate {
         }
     }
 
-    @objc public func currentEntitlement(
+    public func currentEntitlement(
         _ sku: String,
         resolve: @escaping RCTPromiseResolveBlock = { _ in },
         reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
@@ -785,7 +794,7 @@ class RNIapIosSk2iOS15: Sk2Delegate {
         }
     }
 
-    @objc public func latestTransaction(
+    public func latestTransaction(
         _ sku: String,
         resolve: @escaping RCTPromiseResolveBlock = { _ in },
         reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
@@ -812,7 +821,7 @@ class RNIapIosSk2iOS15: Sk2Delegate {
         }
     }
 
-    @objc public func  finishTransaction(
+    public func  finishTransaction(
         _ transactionIdentifier: String,
         resolve: @escaping RCTPromiseResolveBlock = { _ in },
         reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
@@ -830,14 +839,14 @@ class RNIapIosSk2iOS15: Sk2Delegate {
         }
     }
 
-    @objc public func getPendingTransactions (
+    public func getPendingTransactions (
         _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
         reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
     ) {
         resolve(transactions.values.map({(t: Transaction) in serialize(t)}))
     }
 
-    @objc public func sync(
+    public func sync(
         _ resolve: @escaping RCTPromiseResolveBlock = { _ in},
         reject: @escaping RCTPromiseRejectBlock = {_, _, _ in}
     ) {
@@ -855,7 +864,7 @@ class RNIapIosSk2iOS15: Sk2Delegate {
      Should remain the same according to:
      https://stackoverflow.com/a/72789651/570612
      */
-    @objc public func  presentCodeRedemptionSheet(
+    public func  presentCodeRedemptionSheet(
         _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
         reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
     ) {
@@ -867,7 +876,7 @@ class RNIapIosSk2iOS15: Sk2Delegate {
         #endif
     }
 
-    @objc public func showManageSubscriptions(
+    public func showManageSubscriptions(
         _ resolve: @escaping RCTPromiseResolveBlock = { _ in },
         reject: @escaping RCTPromiseRejectBlock = { _, _, _ in }
     ) {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "lint:eslint": "eslint --fix '**/*.{ts,tsx}'",
     "lint:ci": "yarn lint:tsc && yarn lint:eslint -f ./node_modules/@firmnav/eslint-github-actions-formatter/dist/formatter.js && yarn lint:prettier",
     "lint:prettier": "prettier --write \"**/*.{md,js,jsx,ts,tsx}\"",
+    "lint:swift": "swiftlint lint --fix --format --path ios/*.swift --config .swiftlint.yml",
     "format": "git ls-files -m | xargs yarn prettier --write --ignore-unknown --no-error-on-unmatched-pattern",
     "bootstrap": "yarn example && yarn && yarn example pods",
     "gen:doc": "typedoc"

--- a/src/iap.ts
+++ b/src/iap.ts
@@ -326,13 +326,17 @@ Note that this is only for backaward compatiblity. It won't publish to transacti
 @param {automaticallyFinishRestoredTransactions}:boolean. (IOS Sk1 only) When `true`, all the transactions that are returned are automatically
 finished. This means that if you call this method again you won't get the same result on the same device. On the other hand, if `false` you'd
 have to manually finish the returned transaction once you have delivered the content to your user.
+@param {onlyIncludeActiveItems}:boolean. (IOS Sk2 only). Defaults to false, meaning that it will return one transaction per item purchased. 
+@See https://developer.apple.com/documentation/storekit/transaction/3851204-currententitlements for details
  */
 export const getPurchaseHistory = ({
   alsoPublishToEventListener = false,
   automaticallyFinishRestoredTransactions = true,
+  onlyIncludeActiveItems = false,
 }: {
   alsoPublishToEventListener?: boolean;
   automaticallyFinishRestoredTransactions?: boolean;
+  onlyIncludeActiveItems?: boolean;
 } = {}): Promise<(ProductPurchase | SubscriptionPurchase)[]> =>
   (
     Platform.select({
@@ -340,7 +344,10 @@ export const getPurchaseHistory = ({
         if (isIosStorekit2()) {
           return Promise.resolve(
             (
-              await RNIapIosSk2.getAvailableItems(alsoPublishToEventListener)
+              await RNIapIosSk2.getAvailableItems(
+                alsoPublishToEventListener,
+                onlyIncludeActiveItems,
+              )
             ).map(transactionSk2Map),
           );
         } else {
@@ -445,14 +452,18 @@ const App = () => {
 ```
 @param {alsoPublishToEventListener}:boolean When `true`, every element will also be pushed to the purchaseUpdated listener.
 Note that this is only for backaward compatiblity. It won't publish to transactionUpdated (Storekit2) Defaults to `false`
+@param {onlyIncludeActiveItems}:boolean. (IOS Sk2 only). Defaults to true, meaning that it will return the transaction if suscription has not expired. 
+@See https://developer.apple.com/documentation/storekit/transaction/3851204-currententitlements for details
  *
  */
 export const getAvailablePurchases = ({
   alsoPublishToEventListener = false,
   automaticallyFinishRestoredTransactions = false,
+  onlyIncludeActiveItems = true,
 }: {
   alsoPublishToEventListener?: boolean;
   automaticallyFinishRestoredTransactions?: boolean;
+  onlyIncludeActiveItems?: boolean;
 } = {}): Promise<(ProductPurchase | SubscriptionPurchase)[]> =>
   (
     Platform.select({
@@ -460,7 +471,10 @@ export const getAvailablePurchases = ({
         if (isIosStorekit2()) {
           return Promise.resolve(
             (
-              await RNIapIosSk2.getAvailableItems(alsoPublishToEventListener)
+              await RNIapIosSk2.getAvailableItems(
+                alsoPublishToEventListener,
+                onlyIncludeActiveItems,
+              )
             ).map(transactionSk2Map),
           );
         } else {

--- a/src/modules/iosSk2.ts
+++ b/src/modules/iosSk2.ts
@@ -16,6 +16,7 @@ type getItems = (skus: Sku[]) => Promise<ProductSk2[]>;
 
 type getAvailableItems = (
   alsoPublishToEventListener?: boolean,
+  onlyIncludeActiveItems?: boolean,
 ) => Promise<TransactionSk2[]>;
 
 export type BuyProduct = (


### PR DESCRIPTION
Adds the `onlyIncludeActiveItems` parameter to `getAvailablePurchases` (defaults to true) and `getPurchaseHistory` (defaults to false). It allows to skip the validation of the item being active that caused empty array being returned in `getPurchaseHistory` 

- Implementation of onlyIncludeActiveItems
- lint fix
