### PR TITLE
Fix compatibility with babel-plugin-module-resolver

### DIFF
--- a/src/types/appleSk2.ts
+++ b/src/types/appleSk2.ts
@@ -5,9 +5,9 @@ import type {
   Purchase,
   SubscriptionIOS,
   SubscriptionIosPeriod,
-} from '.';
+} from './';
 import type * as Apple from './apple';
-import {SubscriptionPlatform} from '.';
+import {SubscriptionPlatform} from './';
 
 export type SubscriptionPeriod = {
   unit: 'day' | 'week' | 'month' | 'year';


### PR DESCRIPTION
Hey,

I'm using `babel-plugin-module-resolver` for import aliases, but doing so is breaking compatibility with this package.

It's failing when trying to import from `'.'` (Metro is trying to import from `../../../../(rootDir)`) – changing this to `'./'` has fixed the issue for me.

Thanks!