### PR TITLE
finish transaction returns true on iOS

### DIFF
--- a/src/iap.ts
+++ b/src/iap.ts
@@ -838,6 +838,7 @@ const App = () => {
   return <Button title="Buy product" onPress={handlePurchase} />;
 };
 ```
+ @returns {Promise<PurchaseResult | boolean>} Android: PurchaseResult, iOS: true
  */
 export const finishTransaction = ({
   purchase,

--- a/src/iap.ts
+++ b/src/iap.ts
@@ -858,7 +858,8 @@ export const finishTransaction = ({
             new Error('transactionId required to finish iOS transaction'),
           );
         }
-        return getIosModule().finishTransaction(transactionId);
+        await getIosModule().finishTransaction(transactionId);
+        return Promise.resolve(true);
       },
       android: async () => {
         if (purchase?.purchaseToken) {


### PR DESCRIPTION
The iOS Native purchase doesn't return anything when finishing transactions. I'm changing the code to always return true for iOS. Note that Android does return the purchase result. I added a quick note in the documentation