### PR TITLE
Decouple reactContext from AmazonListener

### DIFF
--- a/IapExample/android/build.gradle
+++ b/IapExample/android/build.gradle
@@ -34,6 +34,17 @@ buildscript {
 
 allprojects {
     repositories {
+        // Fix to react-native not being found: https://github.com/facebook/react-native/issues/35204#issuecomment-1304740228
+        exclusiveContent {
+           filter {
+               includeGroup "com.facebook.react"
+           }
+           forRepository {
+               maven {
+                   url "$rootDir/../node_modules/react-native/android"
+               }
+           }
+       }
         maven {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url("$rootDir/../node_modules/react-native/android")

--- a/android/src/amazon/java/com/dooboolab/RNIap/EventSender.kt
+++ b/android/src/amazon/java/com/dooboolab/RNIap/EventSender.kt
@@ -1,0 +1,10 @@
+package com.dooboolab.RNIap
+
+import com.facebook.react.bridge.WritableMap
+
+interface EventSender {
+    fun sendEvent(
+        eventName: String,
+        params: WritableMap?
+    )
+}

--- a/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonListener.kt
+++ b/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonListener.kt
@@ -10,11 +10,9 @@ import com.amazon.device.iap.model.Receipt
 import com.amazon.device.iap.model.UserData
 import com.amazon.device.iap.model.UserDataResponse
 import com.facebook.react.bridge.Arguments
-import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
-import com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter
 import java.lang.NumberFormatException
 
 val ProductType.typeString: String
@@ -96,7 +94,7 @@ class RNIapAmazonListener(
                     val item = receiptToMap(userData, receipt)
                     promiseItem = WritableNativeMap()
                     promiseItem.merge(item)
-                    eventSender?.sendEvent( "purchase-updated", item)
+                    eventSender?.sendEvent("purchase-updated", item)
                     availableItems.pushMap(promiseItem)
                 }
                 if (response.hasMore()) {
@@ -129,7 +127,7 @@ class RNIapAmazonListener(
                 error.putString("debugMessage", debugMessage)
                 error.putString("code", errorCode)
                 error.putString("message", debugMessage)
-                eventSender?.sendEvent( "purchase-error", error)
+                eventSender?.sendEvent("purchase-error", error)
                 PromiseUtils
                     .rejectPromisesForKey(
                         RNIapAmazonModule.PROMISE_QUERY_PURCHASES,
@@ -153,7 +151,7 @@ class RNIapAmazonListener(
                 error.putString("debugMessage", debugMessage)
                 error.putString("code", errorCode)
                 error.putString("message", debugMessage)
-                eventSender?.sendEvent( "purchase-error", error)
+                eventSender?.sendEvent("purchase-error", error)
                 PromiseUtils
                     .rejectPromisesForKey(
                         RNIapAmazonModule.PROMISE_QUERY_PURCHASES,
@@ -198,7 +196,7 @@ class RNIapAmazonListener(
                 val item = receiptToMap(userData, receipt)
                 val promiseItem: WritableMap = Arguments.createMap()
                 promiseItem.merge(item)
-                eventSender?.sendEvent( "purchase-updated", item)
+                eventSender?.sendEvent("purchase-updated", item)
                 PromiseUtils
                     .resolvePromisesForKey(
                         RNIapAmazonModule.PROMISE_BUY_ITEM,
@@ -213,7 +211,7 @@ class RNIapAmazonListener(
                 error.putString("debugMessage", debugMessage)
                 error.putString("code", errorCode)
                 error.putString("message", debugMessage)
-                eventSender?.sendEvent( "purchase-error", error)
+                eventSender?.sendEvent("purchase-error", error)
                 PromiseUtils
                     .rejectPromisesForKey(
                         RNIapAmazonModule.PROMISE_BUY_ITEM,
@@ -231,7 +229,7 @@ class RNIapAmazonListener(
                 error.putString("debugMessage", debugMessage)
                 error.putString("code", errorCode)
                 error.putString("message", debugMessage)
-                eventSender?.sendEvent( "purchase-error", error)
+                eventSender?.sendEvent("purchase-error", error)
                 PromiseUtils
                     .rejectPromisesForKey(
                         RNIapAmazonModule.PROMISE_BUY_ITEM,
@@ -248,7 +246,7 @@ class RNIapAmazonListener(
                 error.putString("debugMessage", debugMessage)
                 error.putString("code", errorCode)
                 error.putString("message", debugMessage)
-                eventSender?.sendEvent( "purchase-error", error)
+                eventSender?.sendEvent("purchase-error", error)
                 PromiseUtils
                     .rejectPromisesForKey(
                         RNIapAmazonModule.PROMISE_BUY_ITEM,
@@ -265,7 +263,7 @@ class RNIapAmazonListener(
                 error.putString("debugMessage", debugMessage)
                 error.putString("code", errorCode)
                 error.putString("message", debugMessage)
-                eventSender?.sendEvent( "purchase-error", error)
+                eventSender?.sendEvent("purchase-error", error)
                 PromiseUtils
                     .rejectPromisesForKey(
                         RNIapAmazonModule.PROMISE_BUY_ITEM,
@@ -306,7 +304,6 @@ class RNIapAmazonListener(
                     )
         }
     }
-
 
     companion object {
         private const val E_PRODUCT_DATA_RESPONSE_FAILED = "E_PRODUCT_DATA_RESPONSE_FAILED"

--- a/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonListener.kt
+++ b/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonListener.kt
@@ -21,8 +21,8 @@ val ProductType.typeString: String
     get() = if (this == ProductType.ENTITLED || this == ProductType.CONSUMABLE) "inapp" else "subs"
 
 class RNIapAmazonListener(
-    private val reactContext: ReactContext,
-    private val purchasingService: PurchasingServiceProxy
+    private val eventSender: EventSender?,
+    private val purchasingService: PurchasingServiceProxy?
 ) : PurchasingListener {
 
     override fun onProductDataResponse(response: ProductDataResponse) {
@@ -96,11 +96,11 @@ class RNIapAmazonListener(
                     val item = receiptToMap(userData, receipt)
                     promiseItem = WritableNativeMap()
                     promiseItem.merge(item)
-                    sendEvent(reactContext, "purchase-updated", item)
+                    eventSender?.sendEvent( "purchase-updated", item)
                     availableItems.pushMap(promiseItem)
                 }
                 if (response.hasMore()) {
-                    purchasingService.getPurchaseUpdates(false)
+                    purchasingService?.getPurchaseUpdates(false)
                 } else {
                     if (purchases.size > 0 && promiseItem != null) {
                         PromiseUtils
@@ -129,7 +129,7 @@ class RNIapAmazonListener(
                 error.putString("debugMessage", debugMessage)
                 error.putString("code", errorCode)
                 error.putString("message", debugMessage)
-                sendEvent(reactContext, "purchase-error", error)
+                eventSender?.sendEvent( "purchase-error", error)
                 PromiseUtils
                     .rejectPromisesForKey(
                         RNIapAmazonModule.PROMISE_QUERY_PURCHASES,
@@ -153,7 +153,7 @@ class RNIapAmazonListener(
                 error.putString("debugMessage", debugMessage)
                 error.putString("code", errorCode)
                 error.putString("message", debugMessage)
-                sendEvent(reactContext, "purchase-error", error)
+                eventSender?.sendEvent( "purchase-error", error)
                 PromiseUtils
                     .rejectPromisesForKey(
                         RNIapAmazonModule.PROMISE_QUERY_PURCHASES,
@@ -198,7 +198,7 @@ class RNIapAmazonListener(
                 val item = receiptToMap(userData, receipt)
                 val promiseItem: WritableMap = Arguments.createMap()
                 promiseItem.merge(item)
-                sendEvent(reactContext, "purchase-updated", item)
+                eventSender?.sendEvent( "purchase-updated", item)
                 PromiseUtils
                     .resolvePromisesForKey(
                         RNIapAmazonModule.PROMISE_BUY_ITEM,
@@ -213,7 +213,7 @@ class RNIapAmazonListener(
                 error.putString("debugMessage", debugMessage)
                 error.putString("code", errorCode)
                 error.putString("message", debugMessage)
-                sendEvent(reactContext, "purchase-error", error)
+                eventSender?.sendEvent( "purchase-error", error)
                 PromiseUtils
                     .rejectPromisesForKey(
                         RNIapAmazonModule.PROMISE_BUY_ITEM,
@@ -231,7 +231,7 @@ class RNIapAmazonListener(
                 error.putString("debugMessage", debugMessage)
                 error.putString("code", errorCode)
                 error.putString("message", debugMessage)
-                sendEvent(reactContext, "purchase-error", error)
+                eventSender?.sendEvent( "purchase-error", error)
                 PromiseUtils
                     .rejectPromisesForKey(
                         RNIapAmazonModule.PROMISE_BUY_ITEM,
@@ -248,7 +248,7 @@ class RNIapAmazonListener(
                 error.putString("debugMessage", debugMessage)
                 error.putString("code", errorCode)
                 error.putString("message", debugMessage)
-                sendEvent(reactContext, "purchase-error", error)
+                eventSender?.sendEvent( "purchase-error", error)
                 PromiseUtils
                     .rejectPromisesForKey(
                         RNIapAmazonModule.PROMISE_BUY_ITEM,
@@ -265,7 +265,7 @@ class RNIapAmazonListener(
                 error.putString("debugMessage", debugMessage)
                 error.putString("code", errorCode)
                 error.putString("message", debugMessage)
-                sendEvent(reactContext, "purchase-error", error)
+                eventSender?.sendEvent( "purchase-error", error)
                 PromiseUtils
                     .rejectPromisesForKey(
                         RNIapAmazonModule.PROMISE_BUY_ITEM,
@@ -307,15 +307,6 @@ class RNIapAmazonListener(
         }
     }
 
-    fun sendEvent(
-        reactContext: ReactContext,
-        eventName: String,
-        params: WritableMap?
-    ) {
-        reactContext
-            .getJSModule(RCTDeviceEventEmitter::class.java)
-            .emit(eventName, params)
-    }
 
     companion object {
         private const val E_PRODUCT_DATA_RESPONSE_FAILED = "E_PRODUCT_DATA_RESPONSE_FAILED"

--- a/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonModule.kt
+++ b/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonModule.kt
@@ -13,14 +13,22 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContextBaseJavaModule
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.WritableMap
 import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.modules.core.DeviceEventManagerModule
 
 @ReactModule(name = RNIapAmazonModule.TAG)
 class RNIapAmazonModule(
     reactContext: ReactApplicationContext,
     private val purchasingService: PurchasingServiceProxy = PurchasingServiceProxyAmazonImpl(),
     private val handler: Handler = Handler(Looper.getMainLooper()),
-    private val amazonListener: PurchasingListener = RNIapAmazonListener(reactContext, purchasingService)
+    private val amazonListener: PurchasingListener = RNIapAmazonListener(object : EventSender {
+        override fun sendEvent(eventName: String, params: WritableMap?) {
+            reactContext
+                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+                .emit(eventName, params)
+        }
+    }, purchasingService)
 ) :
     ReactContextBaseJavaModule(reactContext) {
     var hasListener = false

--- a/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonModule.kt
+++ b/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonModule.kt
@@ -22,13 +22,16 @@ class RNIapAmazonModule(
     reactContext: ReactApplicationContext,
     private val purchasingService: PurchasingServiceProxy = PurchasingServiceProxyAmazonImpl(),
     private val handler: Handler = Handler(Looper.getMainLooper()),
-    private val amazonListener: PurchasingListener = RNIapAmazonListener(object : EventSender {
-        override fun sendEvent(eventName: String, params: WritableMap?) {
-            reactContext
-                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
-                .emit(eventName, params)
-        }
-    }, purchasingService)
+    private val amazonListener: PurchasingListener = RNIapAmazonListener(
+        object : EventSender {
+            override fun sendEvent(eventName: String, params: WritableMap?) {
+                reactContext
+                    .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+                    .emit(eventName, params)
+            }
+        },
+        purchasingService
+    )
 ) :
     ReactContextBaseJavaModule(reactContext) {
     var hasListener = false

--- a/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonModule.kt
+++ b/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonModule.kt
@@ -24,9 +24,11 @@ class RNIapAmazonModule(
     private val handler: Handler = Handler(Looper.getMainLooper()),
     private val amazonListener: PurchasingListener = RNIapAmazonListener(
         object : EventSender {
+            private val rctDeviceEventEmitter = reactContext
+                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+
             override fun sendEvent(eventName: String, params: WritableMap?) {
-                reactContext
-                    .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+                rctDeviceEventEmitter
                     .emit(eventName, params)
             }
         },

--- a/android/src/testAmazon/java/com/dooboolab/RNIap/RNIapAmazonModuleTest.kt
+++ b/android/src/testAmazon/java/com/dooboolab/RNIap/RNIapAmazonModuleTest.kt
@@ -36,6 +36,9 @@ class RNIapAmazonModuleTest {
     @MockK
     lateinit var mainThreadHandler: Handler
 
+    @MockK
+    lateinit var eventSender: EventSender
+
     private lateinit var listener: RNIapAmazonListener
 
     private lateinit var module: RNIapAmazonModule
@@ -43,7 +46,7 @@ class RNIapAmazonModuleTest {
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxUnitFun = true)
-        listener = spyk(RNIapAmazonListener(context, purchasingServiceProxy))
+        listener = spyk(RNIapAmazonListener(eventSender, purchasingServiceProxy))
         module = RNIapAmazonModule(context, purchasingServiceProxy, mainThreadHandler, listener)
     }
 
@@ -78,7 +81,7 @@ class RNIapAmazonModuleTest {
             every { userData } returns mUserData
         }
 
-        every { listener.sendEvent(any(), any(), any()) } just Runs
+        every { eventSender.sendEvent(any(), any()) } just Runs
 
         every { purchasingServiceProxy.purchase(any()) } answers {
             listener.onPurchaseResponse(
@@ -100,7 +103,7 @@ class RNIapAmazonModuleTest {
         val response = slot<WritableMap>()
         verify { promise.resolve(capture(response)) }
         assertEquals("mySku", response.captured.getString("productId"))
-        verify { listener.sendEvent(any(), "purchase-updated", any()) }
+        verify { eventSender.sendEvent("purchase-updated", any()) }
         verify(exactly = 0) { purchasingServiceProxy.getPurchaseUpdates(false) }
     }
 


### PR DESCRIPTION
This will make it easier to write unit tests and it's a better practice since the listener doesn't need to know how messages are sent