### PR TITLE
Fixed infinite spinner on Amazon IAP

### DIFF
--- a/IapExample/android/app/src/main/java/com/iapexample/MainActivity.java
+++ b/IapExample/android/app/src/main/java/com/iapexample/MainActivity.java
@@ -1,10 +1,20 @@
 package com.iapexample;
 
+import android.os.Bundle;
+
+import com.dooboolab.RNIap.RNIapActivityListener;
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactRootView;
 
 public class MainActivity extends ReactActivity {
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    //Needed for Amazon IAP
+    RNIapActivityListener.registerActivity(this);
+  }
 
   /**
    * Returns the name of the main component registered from JavaScript. This is used to schedule

--- a/android/src/amazon/java/com/dooboolab/RNIap/RNIapActivityListener.kt
+++ b/android/src/amazon/java/com/dooboolab/RNIap/RNIapActivityListener.kt
@@ -1,0 +1,33 @@
+package com.dooboolab.RNIap
+
+import android.app.Activity
+import android.util.Log
+import com.amazon.device.iap.PurchasingService
+
+/**
+ * In order of the IAP process to show correctly, AmazonPurchasingService must be registered on Activity.onCreate
+ * registering it in on Application.onCreate will not throw an error but it will now show the Native purchasing screen
+ */
+class RNIapActivityListener {
+    companion object {
+        @JvmStatic
+        var hasListener = false
+
+        @JvmStatic
+        var amazonListener: RNIapAmazonListener? = null
+
+        @JvmStatic
+        fun registerActivity(activity: Activity) {
+            amazonListener = RNIapAmazonListener(null, null)
+            try {
+                PurchasingService.registerListener(activity, amazonListener)
+                hasListener = true
+                // Prefetch user and purchases as per Amazon SDK documentation:
+                PurchasingService.getUserData()
+                PurchasingService.getPurchaseUpdates(false)
+            } catch (e: Exception) {
+                Log.e(RNIapAmazonModule.TAG, "Error initializing Amazon appstore sdk", e)
+            }
+        }
+    }
+}

--- a/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonListener.kt
+++ b/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonListener.kt
@@ -19,8 +19,8 @@ val ProductType.typeString: String
     get() = if (this == ProductType.ENTITLED || this == ProductType.CONSUMABLE) "inapp" else "subs"
 
 class RNIapAmazonListener(
-    private val eventSender: EventSender?,
-    private val purchasingService: PurchasingServiceProxy?
+    var eventSender: EventSender?,
+    var purchasingService: PurchasingServiceProxy?
 ) : PurchasingListener {
 
     override fun onProductDataResponse(response: ProductDataResponse) {

--- a/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonModule.kt
+++ b/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonModule.kt
@@ -31,7 +31,7 @@ class RNIapAmazonModule(
             promise.safeReject(PromiseUtils.E_DEVELOPER_ERROR, Exception("RNIapActivityListener is not registered in your MainActivity.onCreate"))
             return
         }
-        if(eventSender == null) {
+        if (eventSender == null) {
             eventSender = object : EventSender {
                 private val rctDeviceEventEmitter = reactContext
                     .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)

--- a/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonModule.kt
+++ b/android/src/amazon/java/com/dooboolab/RNIap/RNIapAmazonModule.kt
@@ -18,15 +18,7 @@ import com.facebook.react.modules.core.DeviceEventManagerModule
 class RNIapAmazonModule(
     private val reactContext: ReactApplicationContext,
     private val purchasingService: PurchasingServiceProxy = PurchasingServiceProxyAmazonImpl(),
-    private val eventSender: EventSender = object : EventSender {
-        private val rctDeviceEventEmitter = reactContext
-            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
-
-        override fun sendEvent(eventName: String, params: WritableMap?) {
-            rctDeviceEventEmitter
-                .emit(eventName, params)
-        }
-    }
+    private var eventSender: EventSender? = null
 ) :
     ReactContextBaseJavaModule(reactContext) {
     override fun getName(): String {
@@ -38,6 +30,17 @@ class RNIapAmazonModule(
         if (RNIapActivityListener.amazonListener == null) {
             promise.safeReject(PromiseUtils.E_DEVELOPER_ERROR, Exception("RNIapActivityListener is not registered in your MainActivity.onCreate"))
             return
+        }
+        if(eventSender == null) {
+            eventSender = object : EventSender {
+                private val rctDeviceEventEmitter = reactContext
+                    .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+
+                override fun sendEvent(eventName: String, params: WritableMap?) {
+                    rctDeviceEventEmitter
+                        .emit(eventName, params)
+                }
+            }
         }
         RNIapActivityListener.amazonListener?.eventSender = eventSender
         RNIapActivityListener.amazonListener?.purchasingService = purchasingService

--- a/android/src/play/java/com/dooboolab/RNIap/RNIapActivityListener.kt
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapActivityListener.kt
@@ -1,0 +1,14 @@
+package com.dooboolab.RNIap
+
+import android.app.Activity
+
+/**
+ * Currently only needed for Amazon IAP
+ */
+class RNIapActivityListener {
+    companion object {
+        fun registerActivity(activity: Activity){
+            // No op
+        }
+    }
+}

--- a/android/src/play/java/com/dooboolab/RNIap/RNIapActivityListener.kt
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapActivityListener.kt
@@ -7,6 +7,7 @@ import android.app.Activity
  */
 class RNIapActivityListener {
     companion object {
+        @JvmStatic
         fun registerActivity(activity: Activity) {
             // No op
         }

--- a/android/src/play/java/com/dooboolab/RNIap/RNIapActivityListener.kt
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapActivityListener.kt
@@ -7,7 +7,7 @@ import android.app.Activity
  */
 class RNIapActivityListener {
     companion object {
-        fun registerActivity(activity: Activity){
+        fun registerActivity(activity: Activity) {
             // No op
         }
     }

--- a/android/src/testAmazon/java/com/dooboolab/RNIap/RNIapAmazonModuleTest.kt
+++ b/android/src/testAmazon/java/com/dooboolab/RNIap/RNIapAmazonModuleTest.kt
@@ -44,7 +44,7 @@ class RNIapAmazonModuleTest {
     fun setUp() {
         MockKAnnotations.init(this, relaxUnitFun = true)
         listener = spyk(RNIapAmazonListener(eventSender, purchasingServiceProxy))
-        module = RNIapAmazonModule(context, purchasingServiceProxy, eventSender)
+        module = RNIapAmazonModule(context, purchasingServiceProxy,  eventSender)
     }
 
     @Test

--- a/android/src/testAmazon/java/com/dooboolab/RNIap/RNIapAmazonModuleTest.kt
+++ b/android/src/testAmazon/java/com/dooboolab/RNIap/RNIapAmazonModuleTest.kt
@@ -44,7 +44,7 @@ class RNIapAmazonModuleTest {
     fun setUp() {
         MockKAnnotations.init(this, relaxUnitFun = true)
         listener = spyk(RNIapAmazonListener(eventSender, purchasingServiceProxy))
-        module = RNIapAmazonModule(context, purchasingServiceProxy,  eventSender)
+        module = RNIapAmazonModule(context, purchasingServiceProxy, eventSender)
     }
 
     @Test

--- a/docs/docs/guides/amazon-iap.md
+++ b/docs/docs/guides/amazon-iap.md
@@ -10,7 +10,24 @@ The guide assumes that `react-native-iap` is implemented in your app and works w
 
 1. Create "In-App Items" using Amazon Developer portal for your app. Amazon put up detailed instructions at https://developer.amazon.com/docs/in-app-purchasing/iap-create-and-submit-iap-items.html
 
-2. Add new `SKU` strings to your `Iap.getProducts` or `Iap.getSubscriptions` calls.
+2. Add this a call to `RNIapActivityListener.registerActivity(this);` inside your `MainActivity`'s `onCreate` method. This is a necessary step only when using Amazon, but adding it will not affect negatively your Google Play Android builds. E.g.:
+
+```java
+
+import com.dooboolab.RNIap.RNIapActivityListener;
+...
+public class MainActivity extends ReactActivity {
+    ...
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        //Needed for Amazon IAP
+        RNIapActivityListener.registerActivity(this);
+    }
+```
+  
+
+3. Add new `SKU` strings to your `Iap.getProducts` or `Iap.getSubscriptions` calls.
 
 ### App configuration
 

--- a/docs/docs/guides/amazon-iap.md
+++ b/docs/docs/guides/amazon-iap.md
@@ -25,7 +25,6 @@ public class MainActivity extends ReactActivity {
         RNIapActivityListener.registerActivity(this);
     }
 ```
-  
 
 3. Add new `SKU` strings to your `Iap.getProducts` or `Iap.getSubscriptions` calls.
 


### PR DESCRIPTION
The amazon IAP purchase listener needs to be registered on Activity.onCreate, otherwise, instead of the native purchase dialog you get an infinite spinner. This PR fixes it by adding the means to register the listener from `MainActivity` 