### PR TITLE
fix: include expo plugin in package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "android",
     "ios",
     "RNIap.podspec",
+    "plugin/build",
+    "app.plugin.js",
     "!android/.gradle",
     "!android/.idea",
     "!android/build",


### PR DESCRIPTION
Currently, the `plugin/build` and `app.plugin.js` directories are missing from the package installed via npm. I forgot to add them to the `files` array in package.json 🤦‍♂️