### PR TITLE
[Android] subscriptionOfferDetails - added "basePlanId" & "offerId" fields

### DIFF
--- a/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
+++ b/android/src/play/java/com/dooboolab/RNIap/RNIapModule.kt
@@ -244,6 +244,14 @@ class RNIapModule(
                         it.forEach { subscriptionOfferDetailsItem ->
                             val offerDetails = Arguments.createMap()
                             offerDetails.putString(
+                                "basePlanId",
+                                subscriptionOfferDetailsItem.basePlanId
+                            )
+                            offerDetails.putString(
+                                "offerId",
+                                subscriptionOfferDetailsItem.offerId
+                            )
+                            offerDetails.putString(
                                 "offerToken",
                                 subscriptionOfferDetailsItem.offerToken
                             )

--- a/android/src/testPlay/java/com/dooboolab/RNIap/RNIapModuleTest.kt
+++ b/android/src/testPlay/java/com/dooboolab/RNIap/RNIapModuleTest.kt
@@ -229,6 +229,8 @@ class RNIapModuleTest {
                         every { subscriptionOfferDetails } returns listOf(
                             mockk {
                                 every { offerToken } returns "sToken"
+                                every { basePlanId } returns "basePlanId"
+                                every { offerId } returns "offerId"
                                 every { offerTags } returns listOf("offerTag1", "offerTag2")
                                 every { pricingPhases } returns mockk {
                                     every { pricingPhaseList } returns listOf(

--- a/src/__tests__/iap.test.ts
+++ b/src/__tests__/iap.test.ts
@@ -42,6 +42,8 @@ describe('Google Play IAP', () => {
           },
           offerTags: [],
           offerToken: 'dGVzdA==',
+          basePlanId: 'basePlanId',
+          offerId: 'offerId',
         },
       ],
       name: 'MyApp Pro: Annual Plan',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -147,6 +147,8 @@ export interface SubscriptionAndroid {
 }
 
 export interface SubscriptionOfferAndroid {
+  basePlanId: string;
+  offerId: string | null;
   offerToken: string;
   pricingPhases: {
     pricingPhaseList: PricingPhaseAndroid[];


### PR DESCRIPTION
At the moment, "basePlanId" and "offerId" fields are missing in subscriptionOfferDetails. Those are very important fields when filtering the offers in complex subscription structures. 

See android docs: https://developer.android.com/reference/com/android/billingclient/api/ProductDetails.SubscriptionOfferDetails

PS:[ react-native-iap docs](https://react-native-iap.dooboolab.com/docs/api/interfaces/SubscriptionOfferAndroid) need to be updated after this change.