### PR TITLE
fix: case of user cancelled case

### DIFF
--- a/ios/RNIapIosSk2.swift
+++ b/ios/RNIapIosSk2.swift
@@ -695,8 +695,25 @@ class RNIapIosSk2iOS15: Sk2Delegate {
                             resolve(serialize(transaction))
                         }
                         return
+                    case .userCancelled:
+                        debugMessage("User cancelled the purchase")
+                        
+                        let err = [
+                            "debugMessage": "User cancelled the purchase",
+                            "code": IapErrors.E_USER_CANCELLED.rawValue,
+                            "message": "User cancelled the purchase",
+                            "productId": sku,
+                            "quantity": "\(quantity)"
+                        ]
+                        debugMessage(err)
+                        
+                        reject(
+                            IapErrors.E_USER_CANCELLED.rawValue,
+                            "User cancelled the purchase",
+                            nil)
 
-                    case .userCancelled, .pending:
+                        return
+                    case .pending:
                         debugMessage("Deferred (awaiting approval via parental controls, etc.)")
 
                         let err = [

--- a/ios/RNIapIosSk2.swift
+++ b/ios/RNIapIosSk2.swift
@@ -695,9 +695,10 @@ class RNIapIosSk2iOS15: Sk2Delegate {
                             resolve(serialize(transaction))
                         }
                         return
+
                     case .userCancelled:
                         debugMessage("User cancelled the purchase")
-                        
+
                         let err = [
                             "debugMessage": "User cancelled the purchase",
                             "code": IapErrors.E_USER_CANCELLED.rawValue,
@@ -706,13 +707,14 @@ class RNIapIosSk2iOS15: Sk2Delegate {
                             "quantity": "\(quantity)"
                         ]
                         debugMessage(err)
-                        
+
                         reject(
                             IapErrors.E_USER_CANCELLED.rawValue,
                             "User cancelled the purchase",
                             nil)
 
                         return
+
                     case .pending:
                         debugMessage("Deferred (awaiting approval via parental controls, etc.)")
 


### PR DESCRIPTION
This fix allows developers to know whether user has cancelled the purchase or not when using StoreKit2.