### PR TITLE
Fix place of addTransactionObserver

### DIFF
--- a/ios/RNIapIosSk2.swift
+++ b/ios/RNIapIosSk2.swift
@@ -433,7 +433,6 @@ class RNIapIosSk2iOS15: Sk2Delegate {
         self.sendEvent = sendEvent
         products = [String: Product]()
         transactions = [String: Transaction]()
-        addTransactionObserver()
     }
 
     deinit {


### PR DESCRIPTION
Starting transaction listener at constructor causes unfinished transactions to be missed. This improvement allows developers to start listening transactions right time (when JS Thread bootstraps and then IAP module initialized)