### PR TITLE
Add "USER-CANCELLED" alias for UserCancelled error code

### DIFF
--- a/src/utils/errorMapping.ts
+++ b/src/utils/errorMapping.ts
@@ -5,6 +5,7 @@ const ERROR_CODE_ALIASES: Record<string, ErrorCode> = {
   USER_CANCELED: ErrorCode.UserCancelled,
   E_USER_CANCELLED: ErrorCode.UserCancelled,
   USER_CANCELLED: ErrorCode.UserCancelled,
+  'USER-CANCELLED': ErrorCode.UserCancelled,
 };
 
 export const normalizeErrorCodeFromNative = (code: unknown): ErrorCode => {


### PR DESCRIPTION
Before:
`{code: 'UNKNOWN', message: 'User cancelled the purchase flow' ... }`

After:
`{code: 'USER_CANCELLED', message: 'User cancelled the purchase flow' ... }`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improves error-code normalization to recognize the hyphenated “USER-CANCELLED” value from native platforms, aligning it with the existing UserCancelled identifier.
  * Ensures consistent handling and messaging when a user aborts an operation, reducing edge-case inconsistencies across platforms.
  * Guarantees the same standardized error identifier is returned regardless of source formatting (hyphenated, underscored, or uppercase).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->