### PR TITLE
Remove onSyncError option from useIAP hook

### DIFF
--- a/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
+++ b/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
@@ -126,7 +126,7 @@ class HybridRnIap : HybridRnIapSpec() {
                         openIap.initConnection()
                     }
                 } catch (err: Throwable) {
-                    val error = OpenIAPError.InitConnection()
+                    val error = OpenIAPError.InitConnection
                     RnIapLog.failure("initConnection.native", err)
                     throw Exception(
                         toErrorJson(
@@ -137,7 +137,7 @@ class HybridRnIap : HybridRnIapSpec() {
                     )
                 }
                 if (!ok) {
-                    val error = OpenIAPError.InitConnection()
+                    val error = OpenIAPError.InitConnection
                     RnIapLog.failure("initConnection.native", Exception(error.message))
                     throw Exception(
                         toErrorJson(
@@ -279,7 +279,7 @@ class HybridRnIap : HybridRnIapSpec() {
                         }
                         fetched.firstOrNull()?.let { productTypeBySku[it.id] = it.type.rawValue }
                         if (!productTypeBySku.containsKey(sku)) {
-                            sendPurchaseError(toErrorResult(OpenIAPError.SkuNotFound(sku), sku))
+                            sendPurchaseError(toErrorResult(OpenIAPError.SkuNotFound(sku)))
                             return@async defaultResult
                         }
                     }
@@ -363,7 +363,7 @@ class HybridRnIap : HybridRnIapSpec() {
                 RnIapLog.failure("requestPurchase", e)
                 sendPurchaseError(
                     toErrorResult(
-                        error = OpenIAPError.PurchaseFailed(),
+                        error = OpenIAPError.PurchaseFailed,
                         debugMessage = e.message,
                         messageOverride = e.message
                     )
@@ -446,7 +446,7 @@ class HybridRnIap : HybridRnIapSpec() {
             try {
                 initConnection().await()
             } catch (e: Exception) {
-                val err = OpenIAPError.InitConnection()
+                val err = OpenIAPError.InitConnection
                 return@async Variant_Boolean_NitroPurchaseResult.Second(
                     NitroPurchaseResult(
                         responseCode = -1.0,
@@ -476,7 +476,7 @@ class HybridRnIap : HybridRnIapSpec() {
                 RnIapLog.result("finishTransaction", mapOf("success" to true))
                 result
             } catch (e: Exception) {
-                val err = OpenIAPError.BillingError()
+                val err = OpenIAPError.BillingError
                 RnIapLog.failure("finishTransaction", e)
                 Variant_Boolean_NitroPurchaseResult.Second(
                     NitroPurchaseResult(
@@ -909,7 +909,7 @@ class HybridRnIap : HybridRnIapSpec() {
                 
             } catch (e: Exception) {
                 val debugMessage = e.message
-                val error = OpenIAPError.InvalidReceipt()
+                val error = OpenIAPError.InvalidReceipt
                 throw Exception(
                     toErrorJson(
                         error = error,

--- a/docs/docs/api/use-iap.md
+++ b/docs/docs/api/use-iap.md
@@ -48,9 +48,6 @@ const {
   onPurchaseError: (error) => {
     console.error('Purchase failed:', error);
   },
-  onSyncError: (error) => {
-    console.warn('Sync error:', error);
-  },
 });
 ```
 
@@ -68,7 +65,6 @@ const {
 interface UseIAPOptions {
   onPurchaseSuccess?: (purchase: Purchase) => void;
   onPurchaseError?: (error: PurchaseError) => void;
-  onSyncError?: (error: Error) => void;
   shouldAutoSyncPurchases?: boolean; // Controls auto sync behavior inside the hook
   onPromotedProductIOS?: (product: Product) => void; // iOS promoted products
 }
@@ -100,18 +96,6 @@ interface UseIAPOptions {
     if (error.code !== ErrorCode.UserCancelled) {
       Alert.alert('Purchase Failed', error.message);
     }
-  };
-  ```
-
-#### onSyncError
-
-- **Type**: `(error: Error) => void`
-- **Description**: Called when there's an error syncing with the store
-- **Example**:
-
-  ```tsx
-  onSyncError: (error) => {
-    console.warn('Store sync error:', error.message);
   };
   ```
 

--- a/docs/versioned_docs/version-14.1/api/use-iap.md
+++ b/docs/versioned_docs/version-14.1/api/use-iap.md
@@ -171,7 +171,6 @@ export default function MyStore() {
 interface UseIAPOptions {
   onPurchaseSuccess?: (purchase: Purchase) => void;
   onPurchaseError?: (error: PurchaseError) => void;
-  onSyncError?: (error: Error) => void;
   autoFinishTransactions?: boolean; // Default: true
 }
 ```
@@ -202,18 +201,6 @@ interface UseIAPOptions {
     if (error.code !== ErrorCode.UserCancelled) {
       Alert.alert('Purchase Failed', error.message);
     }
-  };
-  ```
-
-#### onSyncError
-
-- **Type**: `(error: Error) => void`
-- **Description**: Called when there's an error syncing with the store
-- **Example**:
-
-  ```tsx
-  onSyncError: (error) => {
-    console.warn('Store sync error:', error.message);
   };
   ```
 

--- a/docs/versioned_docs/version-14.2/api/use-iap.md
+++ b/docs/versioned_docs/version-14.2/api/use-iap.md
@@ -173,7 +173,6 @@ export default function MyStore() {
 interface UseIAPOptions {
   onPurchaseSuccess?: (purchase: Purchase) => void;
   onPurchaseError?: (error: PurchaseError) => void;
-  onSyncError?: (error: Error) => void;
   autoFinishTransactions?: boolean; // Default: true
 }
 ```
@@ -204,18 +203,6 @@ interface UseIAPOptions {
     if (error.code !== ErrorCode.UserCancelled) {
       Alert.alert('Purchase Failed', error.message);
     }
-  };
-  ```
-
-#### onSyncError
-
-- **Type**: `(error: Error) => void`
-- **Description**: Called when there's an error syncing with the store
-- **Example**:
-
-  ```tsx
-  onSyncError: (error) => {
-    console.warn('Store sync error:', error.message);
   };
   ```
 

--- a/docs/versioned_docs/version-14.3/api/use-iap.md
+++ b/docs/versioned_docs/version-14.3/api/use-iap.md
@@ -174,7 +174,6 @@ export default function MyStore() {
 interface UseIAPOptions {
   onPurchaseSuccess?: (purchase: Purchase) => void;
   onPurchaseError?: (error: PurchaseError) => void;
-  onSyncError?: (error: Error) => void;
   autoFinishTransactions?: boolean; // Default: true
 }
 ```
@@ -205,18 +204,6 @@ interface UseIAPOptions {
     if (error.code !== ErrorCode.UserCancelled) {
       Alert.alert('Purchase Failed', error.message);
     }
-  };
-  ```
-
-#### onSyncError
-
-- **Type**: `(error: Error) => void`
-- **Description**: Called when there's an error syncing with the store
-- **Example**:
-
-  ```tsx
-  onSyncError: (error) => {
-    console.warn('Store sync error:', error.message);
   };
   ```
 

--- a/example-expo/app/purchase-flow.tsx
+++ b/example-expo/app/purchase-flow.tsx
@@ -565,10 +565,6 @@ function PurchaseFlowContainer() {
       setIsProcessing(false);
       setPurchaseResult(`Purchase failed: ${error.message}`);
     },
-    onSyncError: (error: Error) => {
-      console.warn('Sync error:', error);
-      Alert.alert('Sync Error', `Failed to sync purchases: ${error.message}`);
-    },
   });
 
   const didFetchRef = useRef(false);

--- a/example-expo/app/subscription-flow.tsx
+++ b/example-expo/app/subscription-flow.tsx
@@ -637,13 +637,6 @@ function SubscriptionFlowContainer() {
       setPurchaseResult(`❌ Subscription failed: ${error.message}`);
       Alert.alert('Subscription Failed', error.message);
     },
-    onSyncError: (error: Error) => {
-      console.warn('Sync error:', error);
-      Alert.alert(
-        'Sync Error',
-        `Failed to sync subscriptions: ${error.message}`,
-      );
-    },
   });
 
   useEffect(() => {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.81.1):
     - hermes-engine/Pre-built (= 0.81.1)
   - hermes-engine/Pre-built (0.81.1)
-  - NitroIap (14.4.0):
+  - NitroIap (14.4.3):
     - boost
     - DoubleConversion
     - fast_float
@@ -2747,8 +2747,8 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  NitroIap: 23ebd959866247ef8e8308e0108dd044a152a1d0
-  NitroModules: 7d693306799405ca141ef5c24efc0936f20a09c0
+  NitroIap: 0334bb6a2379907b20ba556d6ec49f0f94dc3e96
+  NitroModules: d9c969e83c30ec1e7efc95e0ae58c21db1585c14
   openiap: 92c66923a5aa128777da7dc6283a06b331eeab37
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077
@@ -2756,69 +2756,69 @@ SPEC CHECKSUMS:
   RCTTypeSafety: 720403058b7c1380c6a3ae5706981d6362962c89
   React: f1486d005993b0af01943af1850d3d4f3b597545
   React-callinvoker: 133f69368c8559e744efa345223625d412f5dfbe
-  React-Core: 559823921b4f294c2840fa8238ca958a29ddc211
-  React-CoreModules: c41e7bbfabbc420783bb926f45837a0d5e53341e
-  React-cxxreact: 9cb9fa738274a1b36b97ede09c8a6717dec1a20b
+  React-Core: d6d8c1fd33697cec596d33b820456505ee305686
+  React-CoreModules: 81ab751a7668ba161440f9623b994e1a6a3019fe
+  React-cxxreact: 16f2a2751d0dce8b569f23c1914edc90f655b01b
   React-debug: e01581e1589f329e61c95b332bf7f4969b10564b
-  React-defaultsnativemodule: bbb39447caa6b6cf9405fa0099f828c083640faa
-  React-domnativemodule: 03744d12b6d56d098531a933730bf1d4cb79bdfb
-  React-Fabric: 530b3993a12a96e8a7cdb9f0ef48e605277b572e
-  React-FabricComponents: 271ec2a9b2c00ac66fd6d1fd24e9e964d907751d
-  React-FabricImage: d0af66e976dbab7f8b81e36dd369fc70727d2695
-  React-featureflags: 269704c8eff86e0485c9d384e286350fcda6eb70
-  React-featureflagsnativemodule: db1e5d88a912fb08a5ece33fcf64e1b732da8467
-  React-graphics: b19d03a01b0722b4dc82f47acb56dc3ed41937e7
-  React-hermes: 811606c0aca5a3f9c6fa8e4994e02ca8f677e68e
-  React-idlecallbacksnativemodule: 3a3df629cd50046c7e4354f9025aefe8f2c84601
-  React-ImageManager: 0d53866c63132791e37bb2373f93044fdef14aa3
-  React-jserrorhandler: d5700d6ab7162fd575287502a3c5d601d98e7f09
-  React-jsi: ece95417fedbed0e7153a855cb8342b7c72ab75e
-  React-jsiexecutor: 2b0bb644b533df2f5c0cd6ade9a4560d0bf1dd84
-  React-jsinspector: 0c160f8510a8852bdf2dac12f0b1949efc18200b
-  React-jsinspectorcdp: f4b84409f453f61ddd8614ad45139bc594ec6bb5
-  React-jsinspectornetwork: 8f2f0ca8c871ca19b571f426002c0012e7fb2aee
-  React-jsinspectortracing: 33f6b977eb8a4bc1e3d1a4b948809aca083143f9
-  React-jsitooling: 2c61529b589e17229a9f0a4a4fc35aa7ad495850
-  React-jsitracing: 838a7b0c013c4aff7d382d7fdc78cf442013ba1d
-  React-logger: 7aef4d74123e5e3d267e5af1fbf5135b5a0d8381
-  React-Mapbuffer: 91e0eab42a6ae7f3e34091a126d70fc53bd3823e
-  React-microtasksnativemodule: 1ead4fe154df3b1ba34b5a9e35ef3c4bdfa72ccb
-  react-native-safe-area-context: c6e2edd1c1da07bdce287fa9d9e60c5f7b514616
-  React-NativeModulesApple: eff2eba56030eb0d107b1642b8f853bc36a833ac
+  React-defaultsnativemodule: e956b1d8fe15cc79d23061db229bf88170565f2f
+  React-domnativemodule: a18b0f7a31b9c75f12fa369baece5542d1265b36
+  React-Fabric: c0237a32c3c0dbea2d2b294c8e95605e1dfe2f57
+  React-FabricComponents: 65b03884bd5d9f24c79a631d7d26f0fa079bc4aa
+  React-FabricImage: de1ea2f2a0b32ad02e5cbb64827d1eec0439cf0d
+  React-featureflags: 02de9c35256cc624269b01d670d99e1fd706ea8d
+  React-featureflagsnativemodule: 8b84e67edbaa7b9318390c5bd3ae19790a74f356
+  React-graphics: 004b40c1b236ea3bb8de6693439bef9797922ba9
+  React-hermes: 2179a018b2f86652f6f33ef23efd9e5ac284b247
+  React-idlecallbacksnativemodule: f54ea68f984b12e42feed1e7110623b2c38df4d1
+  React-ImageManager: 9dd04b7b62bc5397f876ca5fb1b712e700ce390c
+  React-jserrorhandler: 2f90bf50fffea1d012e7f3d717c6adf748b1813d
+  React-jsi: b27208f8866e53238534f65f304903e4eff25e05
+  React-jsiexecutor: 1d3e827797f592c393860dea91aaa6d53c7715e7
+  React-jsinspector: bda319277ae779bc476b736fe3a497c6aed304cd
+  React-jsinspectorcdp: 69e1736edfd5420037680b7b4557fa748c3c8216
+  React-jsinspectornetwork: 7aa707b057c6129b4af59e0c9160436bbab25022
+  React-jsinspectortracing: b4a8a328ad2697f9638daa4b7cc054e0303fa47f
+  React-jsitooling: a6c7e2829437b28665e97a398b3374d443125e24
+  React-jsitracing: d87ae17dd0eef7844e605945da926c5433fe2b51
+  React-logger: d27dd2000f520bf891d24f6e141cde34df41f0ee
+  React-Mapbuffer: 0746ffab5ac0f49b7c9347338e3d0c1d9dd634c8
+  React-microtasksnativemodule: b0fb3f97372df39bda3e657536039f1af227cc29
+  react-native-safe-area-context: 6d8a7b750e496e37bda47c938320bf2c734d441f
+  React-NativeModulesApple: 9ec9240159974c94886ebbe4caec18e3395f6aef
   React-oscompat: b12c633e9c00f1f99467b1e0e0b8038895dae436
-  React-perflogger: 58d12c4e5df1403030c97b9c621375c312cca454
-  React-performancetimeline: 0ee0a3236c77a4ee6d8a6189089e41e4003d292e
+  React-perflogger: ccf4fd2664b00818645e588623c7531a8b32d114
+  React-performancetimeline: a866ba759d8e06e9ba174b4421677edcae487baf
   React-RCTActionSheet: 3f741a3712653611a6bfc5abceb8260af9d0b218
-  React-RCTAnimation: 408ad69ea136e99a463dd33eadecc29e586b3d72
-  React-RCTAppDelegate: f03b46e80b8a3dbfa84b35abfe123e02f3ceef83
-  React-RCTBlob: bd42e92a00ad22eaab92ffe5c137e7a2f725887a
-  React-RCTFabric: b99ab638c73cf2d57b886eafdbfb2e4909b0eb9a
-  React-RCTFBReactNativeSpec: 7ad9aba0e0655e3f29be0a1c3fd4a888fab04dcf
-  React-RCTImage: 0f1c74f7cd20027f8c34976a211b35d4263a0add
-  React-RCTLinking: 6d7dfc3a74110df56c3a73cc7626bf4415656542
-  React-RCTNetwork: 6a25d8645a80d5b86098675ca39bf8fcf1afa08b
-  React-RCTRuntime: 38bfe9766565ae3293ca230bc51c9c020a8bc98a
-  React-RCTSettings: 651d9ae2cdd32f547ad0d225a2c13886d6ad2358
-  React-RCTText: 9bc66cd288478e23195e01f5cb45eba79986b2b4
-  React-RCTVibration: 371226f5667a00c76d792dcdb5c2e0fcbcde0c3b
+  React-RCTAnimation: 2edeebfba175cc2e937e2752209ab605d3c48f21
+  React-RCTAppDelegate: e292321e83ee966897244a032216a70930b758d6
+  React-RCTBlob: 8dfb24b6dd4a5af45e1e59e2fd925b2df1e44d08
+  React-RCTFabric: b25b02a2016f5cb15926a60c77a8d75865aa3558
+  React-RCTFBReactNativeSpec: 20338571a1ed853d01da6c68576aa6e8e107b6f6
+  React-RCTImage: c7fe8c2f2ae8bad98ab4d944d5d50a889da4b652
+  React-RCTLinking: 9ac21ce9f1af914bb01c06af3752db2ec840d0ee
+  React-RCTNetwork: 09a5de71d757dbad4b3fe3615839290200b932aa
+  React-RCTRuntime: da3f1e0ce088c20350044cdf1efcd7f8d9b9b40c
+  React-RCTSettings: fee112652ac7569ea9abe910206e1685f5f9adba
+  React-RCTText: 7ee9d0bc16b3a8149f8df6d70c48e724d0db1d89
+  React-RCTVibration: 619d613abaeb05f6fbc2b2e5e33f724f05df8eb8
   React-rendererconsistency: a05f6c37f9389c53213d1e28798e441fa6fbdbcd
-  React-renderercss: 6e4febfa014b0f53bc171a62b0f713ddbdbb9860
-  React-rendererdebug: e94bf27b9d55ef2795caa8e43aa92abc4a373b8b
-  React-RuntimeApple: 723be5159519eba1cd92449acb29436d21571b82
-  React-RuntimeCore: f58eb0f01065c9d27d91de10b2e4ab4c76d83b0e
-  React-runtimeexecutor: f615ec8742d0b5820170f7c8b4d2c7cb75d93ac9
-  React-RuntimeHermes: fddb258e03d330d1132bb19e78fe51ac2f3f41ac
-  React-runtimescheduler: e92a31460e654ced8587debeec37553315e1b6a5
-  React-timing: 97ada2c47b4c5932e7f773c7d239c52b90d6ca68
-  React-utils: f0949d247a46b4c09f03e5a3cb1167602d0b729a
-  ReactAppDependencyProvider: 3eb9096cb139eb433965693bbe541d96eb3d3ec9
-  ReactCodegen: 4d203eddf6f977caa324640a20f92e70408d648b
-  ReactCommon: ce5d4226dfaf9d5dacbef57b4528819e39d3a120
-  RNCClipboard: 4b58c780f63676367640f23c8e114e9bd0cf86ac
-  RNScreens: 0bbf16c074ae6bb1058a7bf2d1ae017f4306797c
+  React-renderercss: 3decb27a81648fcdee837c59994b51fff5be5a67
+  React-rendererdebug: 3b9a92d36932af52e1b473f2a89ea4b05dbdecdf
+  React-RuntimeApple: 4e35fb74be4b721c2e1fd6d54ec66456fa7043e9
+  React-RuntimeCore: 0fd7ac6e3e9dd20cb47e87c6b9f35832dd445d5e
+  React-runtimeexecutor: 7680156c9f3a5a49c688bc33f9ec5ea1b00527f5
+  React-RuntimeHermes: 435b7104a3c749af6251353dcb7317a8e53cbd73
+  React-runtimescheduler: 8056b916168e446ea44531883928034e62e76a81
+  React-timing: 36da85e32e53008ce73f87528818191e7f2508ba
+  React-utils: 71e53d55ce778c6e7c7c9db4b1b9d63ef8f55289
+  ReactAppDependencyProvider: 448b422f8af1dedf81374eacc90a15439a0ed7f5
+  ReactCodegen: 3baedb0c33f963250c866151b825a3c5194b12f1
+  ReactCommon: e897f9a1b4afab370cfefaaf5fb3c80371bc3937
+  RNCClipboard: 962296f7af77f6c039b683e21c2e2255af9c05df
+  RNScreens: 74985ca8e102294a60cec7513fa84c936fa0b20b
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 11c9686a21e2cd82a094a723649d9f4507200fb0
+  Yoga: fa23995c18b65978347b096d0836f4f5093df545
 
 PODFILE CHECKSUM: 68a7c2afe0ade1366edc9327417ab94a1539b9b1
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/example/screens/PurchaseFlow.tsx
+++ b/example/screens/PurchaseFlow.tsx
@@ -561,10 +561,6 @@ function PurchaseFlowContainer() {
       setIsProcessing(false);
       setPurchaseResult(`Purchase failed: ${error.message}`);
     },
-    onSyncError: (error: Error) => {
-      console.warn('Sync error:', error);
-      Alert.alert('Sync Error', `Failed to sync purchases: ${error.message}`);
-    },
   });
 
   const didFetchRef = useRef(false);

--- a/example/screens/SubscriptionFlow.tsx
+++ b/example/screens/SubscriptionFlow.tsx
@@ -633,13 +633,6 @@ function SubscriptionFlowContainer() {
       setPurchaseResult(`❌ Subscription failed: ${error.message}`);
       Alert.alert('Subscription Failed', error.message);
     },
-    onSyncError: (error: Error) => {
-      console.warn('Sync error:', error);
-      Alert.alert(
-        'Sync Error',
-        `Failed to sync subscriptions: ${error.message}`,
-      );
-    },
   });
 
   useEffect(() => {

--- a/src/hooks/useIAP.ts
+++ b/src/hooks/useIAP.ts
@@ -79,8 +79,6 @@ type UseIap = {
 export interface UseIapOptions {
   onPurchaseSuccess?: (purchase: Purchase) => void;
   onPurchaseError?: (error: PurchaseError) => void;
-  onSyncError?: (error: Error) => void;
-  shouldAutoSyncPurchases?: boolean; // New option to control auto-syncing
   onPromotedProductIOS?: (product: Product) => void;
 }
 


### PR DESCRIPTION
This PR removes the onSyncError and shouldAutoSyncPurchases options from the useIAP hook as they were deemed unnecessary.

## Changes
- Remove onSyncError from UseIapOptions interface
- Remove shouldAutoSyncPurchases from UseIapOptions interface
- Remove onSyncError callbacks from example apps
- Update documentation to remove onSyncError references
- Clean up TypeScript definitions

## Breaking Changes
- The onSyncError option is no longer available in useIAP hook options
- The shouldAutoSyncPurchases option is no longer available in useIAP hook options