### PR TITLE
fix: remove unnecessary try-catch wrapper in useIAP finishTransaction

### DIFF
--- a/src/hooks/useIAP.ts
+++ b/src/hooks/useIAP.ts
@@ -279,8 +279,11 @@ export function useIAP(options?: UseIapOptions): UseIap {
 
   const finishTransaction = useCallback(
     async (args: MutationFinishTransactionArgs): Promise<void> => {
-      // Directly use root API finishTransaction which includes proper error handling
-      // for already-finished transactions (iOS) and other edge cases
+      // Directly delegate to root API finishTransaction without catching errors.
+      // This allows the root API's error handling logic to work correctly, including:
+      // - iOS: treating "Transaction not found" as success (already-finished transactions)
+      // - Proper validation and error messages for required fields
+      // Users should handle errors in their onPurchaseSuccess callback if needed.
       await finishTransactionInternal(args);
     },
     [],


### PR DESCRIPTION
Resolve #3064

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved in-app purchase transaction handling to reduce spurious errors and better recover from edge cases (including already-completed iOS transactions). Users should see more reliable purchase completion, fewer duplicate or confusing error messages, and smoother transaction reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->