### PR TITLE
fix(android): ensure error.code accessible

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -194,6 +194,11 @@ dependencies {
     // Use standard Google Play Billing
     implementation "io.github.hyochan.openiap:openiap-google:${googleVersionString}"
   }
+
+  // Test dependencies
+  testImplementation 'junit:junit:4.13.2'
+  testImplementation 'org.jetbrains.kotlin:kotlin-test'
+  testImplementation 'org.jetbrains.kotlin:kotlin-test-junit'
 }
 
 configurations.all {

--- a/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
+++ b/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
@@ -37,6 +37,22 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.util.Locale
 
+/**
+ * Custom exception for OpenIAP errors that only includes the error JSON without stack traces.
+ * This ensures clean error messages are passed to JavaScript without Java/Kotlin stack traces.
+ */
+class OpenIapException(private val errorJson: String) : Exception() {
+    override val message: String
+        get() = errorJson
+
+    override fun toString(): String = errorJson
+
+    override fun fillInStackTrace(): Throwable {
+        // Don't fill in stack trace to avoid it being serialized
+        return this
+    }
+}
+
 class HybridRnIap : HybridRnIapSpec() {
     
     // Get ReactApplicationContext lazily from NitroModules
@@ -167,7 +183,7 @@ class HybridRnIap : HybridRnIapSpec() {
                 } catch (err: Throwable) {
                     val error = OpenIAPError.InitConnection
                     RnIapLog.failure("initConnection.native", err)
-                    throw Exception(
+                    throw OpenIapException(
                         toErrorJson(
                             error = error,
                             debugMessage = err.message,
@@ -178,7 +194,7 @@ class HybridRnIap : HybridRnIapSpec() {
                 if (!ok) {
                     val error = OpenIAPError.InitConnection
                     RnIapLog.failure("initConnection.native", Exception(error.message))
-                    throw Exception(
+                    throw OpenIapException(
                         toErrorJson(
                             error = error,
                             messageOverride = "Failed to initialize connection"
@@ -225,7 +241,7 @@ class HybridRnIap : HybridRnIapSpec() {
             )
 
             if (skus.isEmpty()) {
-                throw Exception(toErrorJson(OpenIAPError.EmptySkuList))
+                throw OpenIapException(toErrorJson(OpenIAPError.EmptySkuList))
             }
 
             initConnection(null).await()
@@ -528,7 +544,7 @@ class HybridRnIap : HybridRnIapSpec() {
             } catch (e: Exception) {
                 RnIapLog.failure("getActiveSubscriptions", e)
                 val error = OpenIAPError.ServiceUnavailable
-                throw Exception(
+                throw OpenIapException(
                     toErrorJson(
                         error = error,
                         debugMessage = e.message,
@@ -937,14 +953,14 @@ class HybridRnIap : HybridRnIapSpec() {
     // iOS-specific method - not supported on Android
     override fun getStorefrontIOS(): Promise<String> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIAPError.FeatureNotSupported))
+            throw OpenIapException(toErrorJson(OpenIAPError.FeatureNotSupported))
         }
     }
 
     // iOS-specific method - not supported on Android
     override fun getAppTransactionIOS(): Promise<String?> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIAPError.FeatureNotSupported))
+            throw OpenIapException(toErrorJson(OpenIAPError.FeatureNotSupported))
         }
     }
 
@@ -1031,7 +1047,7 @@ class HybridRnIap : HybridRnIapSpec() {
             try {
                 // For Android, we need the androidOptions to be provided
                 val androidOptions = params.androidOptions
-                    ?: throw Exception(toErrorJson(OpenIAPError.DeveloperError))
+                    ?: throw OpenIapException(toErrorJson(OpenIAPError.DeveloperError))
 
                 // Android receipt validation would typically involve server-side validation
                 // using Google Play Developer API. Here we provide a simplified implementation
@@ -1070,7 +1086,7 @@ class HybridRnIap : HybridRnIapSpec() {
             } catch (e: Exception) {
                 val debugMessage = e.message
                 val error = OpenIAPError.InvalidReceipt
-                throw Exception(
+                throw OpenIapException(
                     toErrorJson(
                         error = error,
                         debugMessage = debugMessage,
@@ -1084,31 +1100,31 @@ class HybridRnIap : HybridRnIapSpec() {
     // iOS-specific methods - Not applicable on Android, return appropriate defaults
     override fun subscriptionStatusIOS(sku: String): Promise<Array<NitroSubscriptionStatus>?> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIAPError.FeatureNotSupported))
+            throw OpenIapException(toErrorJson(OpenIAPError.FeatureNotSupported))
         }
     }
     
     override fun currentEntitlementIOS(sku: String): Promise<NitroPurchase?> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIAPError.FeatureNotSupported))
+            throw OpenIapException(toErrorJson(OpenIAPError.FeatureNotSupported))
         }
     }
     
     override fun latestTransactionIOS(sku: String): Promise<NitroPurchase?> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIAPError.FeatureNotSupported))
+            throw OpenIapException(toErrorJson(OpenIAPError.FeatureNotSupported))
         }
     }
     
     override fun getPendingTransactionsIOS(): Promise<Array<NitroPurchase>> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIAPError.FeatureNotSupported))
+            throw OpenIapException(toErrorJson(OpenIAPError.FeatureNotSupported))
         }
     }
     
     override fun syncIOS(): Promise<Boolean> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIAPError.FeatureNotSupported))
+            throw OpenIapException(toErrorJson(OpenIAPError.FeatureNotSupported))
         }
     }
     
@@ -1116,37 +1132,37 @@ class HybridRnIap : HybridRnIapSpec() {
     
     override fun isEligibleForIntroOfferIOS(groupID: String): Promise<Boolean> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIAPError.FeatureNotSupported))
+            throw OpenIapException(toErrorJson(OpenIAPError.FeatureNotSupported))
         }
     }
     
     override fun getReceiptDataIOS(): Promise<String> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIAPError.FeatureNotSupported))
+            throw OpenIapException(toErrorJson(OpenIAPError.FeatureNotSupported))
         }
     }
 
     override fun getReceiptIOS(): Promise<String> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIAPError.FeatureNotSupported))
+            throw OpenIapException(toErrorJson(OpenIAPError.FeatureNotSupported))
         }
     }
 
     override fun requestReceiptRefreshIOS(): Promise<String> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIAPError.FeatureNotSupported))
+            throw OpenIapException(toErrorJson(OpenIAPError.FeatureNotSupported))
         }
     }
 
     override fun isTransactionVerifiedIOS(sku: String): Promise<Boolean> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIAPError.FeatureNotSupported))
+            throw OpenIapException(toErrorJson(OpenIAPError.FeatureNotSupported))
         }
     }
     
     override fun getTransactionJwsIOS(sku: String): Promise<String?> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIAPError.FeatureNotSupported))
+            throw OpenIapException(toErrorJson(OpenIAPError.FeatureNotSupported))
         }
     }
 
@@ -1166,7 +1182,7 @@ class HybridRnIap : HybridRnIapSpec() {
             } catch (err: Throwable) {
                 RnIapLog.failure("checkAlternativeBillingAvailabilityAndroid", err)
                 val errorType = parseOpenIapError(err)
-                throw Exception(toErrorJson(errorType, debugMessage = err.message))
+                throw OpenIapException(toErrorJson(errorType, debugMessage = err.message))
             }
         }
     }
@@ -1176,7 +1192,7 @@ class HybridRnIap : HybridRnIapSpec() {
             RnIapLog.payload("showAlternativeBillingDialogAndroid", null)
             try {
                 val activity = context.currentActivity
-                    ?: throw Exception(toErrorJson(OpenIAPError.DeveloperError, debugMessage = "Activity not available"))
+                    ?: throw OpenIapException(toErrorJson(OpenIAPError.DeveloperError, debugMessage = "Activity not available"))
 
                 val userAccepted = withContext(Dispatchers.Main) {
                     openIap.setActivity(activity)
@@ -1187,7 +1203,7 @@ class HybridRnIap : HybridRnIapSpec() {
             } catch (err: Throwable) {
                 RnIapLog.failure("showAlternativeBillingDialogAndroid", err)
                 val errorType = parseOpenIapError(err)
-                throw Exception(toErrorJson(errorType, debugMessage = err.message))
+                throw OpenIapException(toErrorJson(errorType, debugMessage = err.message))
             }
         }
     }
@@ -1206,7 +1222,7 @@ class HybridRnIap : HybridRnIapSpec() {
             } catch (err: Throwable) {
                 RnIapLog.failure("createAlternativeBillingTokenAndroid", err)
                 val errorType = parseOpenIapError(err)
-                throw Exception(toErrorJson(errorType, debugMessage = err.message))
+                throw OpenIapException(toErrorJson(errorType, debugMessage = err.message))
             }
         }
     }
@@ -1236,19 +1252,19 @@ class HybridRnIap : HybridRnIapSpec() {
 
     override fun canPresentExternalPurchaseNoticeIOS(): Promise<Boolean> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIAPError.FeatureNotSupported))
+            throw OpenIapException(toErrorJson(OpenIAPError.FeatureNotSupported))
         }
     }
 
     override fun presentExternalPurchaseNoticeSheetIOS(): Promise<ExternalPurchaseNoticeResultIOS> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIAPError.FeatureNotSupported))
+            throw OpenIapException(toErrorJson(OpenIAPError.FeatureNotSupported))
         }
     }
 
     override fun presentExternalPurchaseLinkIOS(url: String): Promise<ExternalPurchaseLinkResultIOS> {
         return Promise.async {
-            throw Exception(toErrorJson(OpenIAPError.FeatureNotSupported))
+            throw OpenIapException(toErrorJson(OpenIAPError.FeatureNotSupported))
         }
     }
 

--- a/android/src/test/java/com/margelo/nitro/iap/OpenIapExceptionTest.kt
+++ b/android/src/test/java/com/margelo/nitro/iap/OpenIapExceptionTest.kt
@@ -1,0 +1,93 @@
+package com.margelo.nitro.iap
+
+import org.junit.Test
+import org.junit.Assert.*
+
+/**
+ * Unit tests for OpenIapException to verify that error messages
+ * are returned without Java/Kotlin stack traces.
+ *
+ * This addresses Issue #3075 where error.code was undefined because
+ * stack traces were breaking JSON parsing on the JavaScript side.
+ */
+class OpenIapExceptionTest {
+
+    @Test
+    fun `test OpenIapException message returns clean JSON`() {
+        val errorJson = """{"code":"init-connection","message":"Failed to initialize connection"}"""
+        val exception = OpenIapException(errorJson)
+
+        // Verify message is exactly the JSON string
+        assertEquals(errorJson, exception.message)
+    }
+
+    @Test
+    fun `test OpenIapException toString returns clean JSON without stack trace`() {
+        val errorJson = """{"code":"user-cancelled","message":"User cancelled"}"""
+        val exception = OpenIapException(errorJson)
+
+        // toString() should return only the JSON, not "java.lang.Exception: ..."
+        val result = exception.toString()
+        assertEquals(errorJson, result)
+        assertFalse(result.startsWith("java.lang.Exception:"))
+        assertFalse(result.contains("\tat "))
+    }
+
+    @Test
+    fun `test thrown OpenIapException message is clean`() {
+        val errorJson = """{"code":"network-error","message":"Network error occurred","responseCode":-1}"""
+
+        try {
+            throw OpenIapException(errorJson)
+        } catch (e: Exception) {
+            // Verify the caught exception message is clean
+            assertEquals(errorJson, e.message)
+            assertEquals(errorJson, e.toString())
+        }
+    }
+
+    @Test
+    fun `test OpenIapException with complex JSON structure`() {
+        val errorJson = """{"code":"purchase-error","message":"Purchase failed","responseCode":3,"debugMessage":"Item unavailable","productId":"com.test.product"}"""
+        val exception = OpenIapException(errorJson)
+
+        assertEquals(errorJson, exception.message)
+        assertEquals(errorJson, exception.toString())
+    }
+
+    @Test
+    fun `test multiple OpenIapException instances are independent`() {
+        val error1 = """{"code":"error-1","message":"First error"}"""
+        val error2 = """{"code":"error-2","message":"Second error"}"""
+
+        val exception1 = OpenIapException(error1)
+        val exception2 = OpenIapException(error2)
+
+        assertEquals(error1, exception1.message)
+        assertEquals(error2, exception2.message)
+        assertNotEquals(exception1.message, exception2.message)
+    }
+
+    @Test
+    fun `test OpenIapException with empty JSON`() {
+        val errorJson = """{}"""
+        val exception = OpenIapException(errorJson)
+
+        assertEquals(errorJson, exception.message)
+        assertEquals(errorJson, exception.toString())
+    }
+
+    @Test
+    fun `test OpenIapException message does not contain stack trace keywords`() {
+        val errorJson = """{"code":"test-error","message":"Test message"}"""
+        val exception = OpenIapException(errorJson)
+
+        val result = exception.toString()
+
+        // Verify no stack trace keywords are present
+        assertFalse("Should not contain 'at ' (stack trace)", result.contains("\tat "))
+        assertFalse("Should not contain 'java.lang.Exception:'", result.contains("java.lang.Exception:"))
+        assertFalse("Should not contain '.kt:' (Kotlin file reference)", result.contains(".kt:"))
+        assertFalse("Should not contain '.java:' (Java file reference)", result.contains(".java:"))
+    }
+}


### PR DESCRIPTION
Create OpenIapException that overrides message, toString, and fillInStackTrace to prevent Java stack traces from breaking JSON parsing in Nitro bridge.

Fixes #3075 - error.code was undefined due to stack traces in error strings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized error handling throughout the application to deliver cleaner, more user-friendly error messages without unnecessary technical details.

* **Tests**
  * Added testing framework dependencies to enhance test infrastructure and coverage capabilities.
  * Introduced comprehensive unit test suite to thoroughly validate error handling implementation and ensure application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->