### PR TITLE
fix: add missing 'non-renewing-subscription' in normalization

### DIFF
--- a/src/utils/type-bridge.ts
+++ b/src/utils/type-bridge.ts
@@ -93,6 +93,7 @@ function normalizeProductTypeIOS(value?: Nullable<string>): ProductTypeIOS {
       return 'auto-renewable-subscription';
     case 'nonrenewingsubscription':
     case 'non_renewing_subscription':
+    case 'non-renewing-subscription':
       return 'non-renewing-subscription';
     default:
       if (value) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced handling of iOS product type variants, including support for the hyphenated non-renewing-subscription format alongside existing variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->