### PR TITLE
fix(android): handle JNI exceptions during initConnection setup

### DIFF
--- a/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
+++ b/android/src/main/java/com/margelo/nitro/iap/HybridRnIap.kt
@@ -211,13 +211,21 @@ class HybridRnIap : HybridRnIapSpec() {
                 val error = OpenIAPError.InitConnection
                 val errorMessage = err.message ?: err.javaClass.name
                 RnIapLog.failure("initConnection.listeners", err)
-                throw OpenIapException(
+                val wrapped = OpenIapException(
                     toErrorJson(
                         error = error,
                         debugMessage = errorMessage,
                         messageOverride = "Failed to register billing listeners: $errorMessage"
                     )
                 )
+                synchronized(initLock) {
+                    initDeferred?.let { deferred ->
+                        if (!deferred.isCompleted) deferred.completeExceptionally(wrapped)
+                    }
+                    initDeferred = null
+                }
+                isInitialized = false
+                throw wrapped
             }
 
             // We created it above; reuse the shared instance


### PR DESCRIPTION
## Summary

- Wrap `setActivity` and listener registration in try-catch blocks to convert raw JNI exceptions into structured `OpenIapException`
- Prevents cryptic `Unknown N8facebook3jni12JniExceptionE error` messages on the JS side
- Developers now receive structured errors with code `init-connection` and descriptive messages

## Problem

During `initConnection`, the `openIap` object is lazy-initialized (`OpenIapModule(context)`). The first access happens at either `openIap.setActivity()` or `openIap.addPurchaseUpdateListener()` — both were **outside any try-catch block**.

On devices without Google Play Services or with billing client issues, the constructor throws a JNI exception that propagates unhandled through `Promise.async`. Nitro converts the raw C++ exception class name (`facebook::jni::JniException`) into the unhelpful error message users see.

Meanwhile, the actual `openIap.initConnection()` call (which IS protected by try-catch) is never reached because the exception occurs earlier.

## Changes

### Android (`android/.../HybridRnIap.kt`)
- Wrap `setActivity` call in try-catch → throws `OpenIapException` with message `"Failed to set activity: <original error>"`
- Wrap listener registration block in try-catch → throws `OpenIapException` with message `"Failed to register billing listeners: <original error>"`
- Reset `listenersAttached = false` on listener registration failure for retry on next `initConnection` call
- All converted errors use `init-connection` error code for consistent JS-side handling

## Test plan

- [x] `yarn typecheck` passes
- [x] `yarn lint` passes
- [x] `yarn test` passes (251 tests, 12 suites)
- [x] Pre-commit hooks pass

Closes #3144

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened in-app purchase connection error handling with clearer diagnostics and logging for more reliable failure visibility.
  * Improved billing listener registration resilience: failures now roll back listener state, cancel pending initialization, and propagate errors to concurrent callers to avoid silent failures and improve purchase flow stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->