### PR TITLE
fix(android): add CMake task dependency to prevent race condition

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -209,10 +209,10 @@ configurations.all {
 // to prevent race condition where libNitroModules.so is not yet built.
 // See: https://github.com/hyochan/react-native-iap/issues/3163
 afterEvaluate {
-  tasks.configureEach { task ->
-    if (task.name.startsWith('buildCMake')) {
-      def nitroProject = rootProject.findProject(':react-native-nitro-modules')
-      if (nitroProject) {
+  def nitroProject = rootProject.findProject(':react-native-nitro-modules')
+  if (nitroProject) {
+    tasks.configureEach { task ->
+      if (task.name.startsWith('buildCMake')) {
         def nitroTask = nitroProject.tasks.findByName(task.name)
         if (nitroTask) {
           task.dependsOn(nitroTask)


### PR DESCRIPTION
## Summary

- Add `afterEvaluate` block in `android/build.gradle` to ensure `buildCMake*` tasks depend on `react-native-nitro-modules`' corresponding CMake tasks
- Prevents intermittent linker error where `libNitroModules.so` is not yet built when IAP's CMake runs

## Context

When building with Gradle parallel execution, IAP's `buildCMakeDebug[arm64-v8a]` can run before `react-native-nitro-modules` finishes producing `libNitroModules.so`, causing a linker failure. This was a latent race condition that became more visible after the nitro-modules 0.35.0 upgrade (JNI initialization pattern change).

Investigated upstream nitro 0.35.0 — no CMake/Gradle build order changes were made, confirming this is a pre-existing issue.

Closes #3163

## Test plan

- [x] Android build succeeds with `--parallel` flag
- [x] No regression on iOS build (android-only change, no iOS impact)

🤖 Generated with [Claude Code](https://claude.ai/code)